### PR TITLE
Add Project class and integrate parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 LIBS += gtksourceview-4
-SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c lisp_parser.c lisp_parser_view.c gtk_text_provider.c string_text_provider.c text_provider.c
+SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c lisp_parser.c lisp_parser_view.c project.c gtk_text_provider.c string_text_provider.c text_provider.c
 
 include Makefile_common
 

--- a/app.h
+++ b/app.h
@@ -5,6 +5,7 @@
 #include <gtksourceview/gtksource.h>
 #include "preferences.h"
 #include "swank_session.h"
+#include "project.h"
 
 #ifndef STATIC
 #define STATIC
@@ -15,7 +16,7 @@ G_BEGIN_DECLS
 #define GLIDE_TYPE (app_get_type())
 G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 
-STATIC App *app_new (Preferences *prefs, SwankSession *swank);
+STATIC App *app_new (Preferences *prefs, SwankSession *swank, Project *project);
 STATIC GtkSourceBuffer *app_get_source_buffer (App *self);
 STATIC const gchar *app_get_filename  (App *self); // Returns the current filename or NULL (borrowed – do not free)
 STATIC void app_set_filename  (App *self, const gchar *new_filename);

--- a/lisp_parser_view.h
+++ b/lisp_parser_view.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "lisp_parser.h"
+#include "project.h"
 #include <gtk/gtk.h>
 #include <gtksourceview/gtksource.h>
 
@@ -9,6 +10,6 @@ G_BEGIN_DECLS
 #define LISP_TYPE_PARSER_VIEW (lisp_parser_view_get_type())
 G_DECLARE_FINAL_TYPE(LispParserView, lisp_parser_view, LISP, PARSER_VIEW, GtkTreeView)
 
-GtkWidget *lisp_parser_view_new(GtkSourceBuffer *buffer);
+GtkWidget *lisp_parser_view_new(ProjectFile *file);
 
 G_END_DECLS

--- a/lisp_source_view.h
+++ b/lisp_source_view.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "lisp_parser.h"
+#include "project.h"
 #include <gtk/gtk.h>
 #include <gtksourceview/gtksource.h>
 
@@ -9,7 +10,8 @@ G_BEGIN_DECLS
 #define LISP_TYPE_SOURCE_VIEW (lisp_source_view_get_type ())
 G_DECLARE_FINAL_TYPE (LispSourceView, lisp_source_view, LISP, SOURCE_VIEW, GtkSourceView)
 
-GtkWidget      *lisp_source_view_new (void);
+GtkWidget      *lisp_source_view_new (Project *project);
 GtkSourceBuffer *lisp_source_view_get_buffer (LispSourceView *self);
+ProjectFile    *lisp_source_view_get_file (LispSourceView *self);
 
 G_END_DECLS

--- a/main.c
+++ b/main.c
@@ -35,6 +35,7 @@
 #include "real_swank_session.h"
 #include "swank_process.h"
 #include "swank_session.h"
+#include "project.h"
 
 int
 main (int argc, char *argv[])
@@ -48,11 +49,13 @@ main (int argc, char *argv[])
   Process *proc = real_process_new (sdk_path);
   SwankProcess *swank_proc = real_swank_process_new (proc, prefs);
   SwankSession *swank = real_swank_session_new (swank_proc);
-  App *app     = app_new (prefs, swank);
+  Project *project = project_new();
+  App *app     = app_new (prefs, swank, project);
 
   int status = g_application_run (G_APPLICATION (app), argc, argv);
   g_object_unref (app);
   g_object_unref (swank);
+  g_object_unref (project);
   g_object_unref (prefs);
   exit(status);
 }

--- a/project.c
+++ b/project.c
@@ -1,0 +1,83 @@
+#include "project.h"
+
+struct _ProjectFile {
+  ProjectFileState state;
+  gchar *path;
+  GtkTextBuffer *buffer; /* nullable */
+  TextProvider *provider; /* owned */
+  LispParser *parser; /* owned */
+};
+
+struct _Project {
+  GObject parent_instance;
+  GPtrArray *files; /* ProjectFile* */
+};
+
+static void project_finalize(GObject *obj);
+
+G_DEFINE_TYPE(Project, project, G_TYPE_OBJECT)
+
+static void project_class_init(ProjectClass *klass) {
+  GObjectClass *obj = G_OBJECT_CLASS(klass);
+  obj->finalize = project_finalize;
+}
+
+static void project_file_free(ProjectFile *file) {
+  if (!file) return;
+  if (file->parser) lisp_parser_free(file->parser);
+  if (file->provider) g_object_unref(file->provider);
+  if (file->buffer) g_object_unref(file->buffer);
+  g_free(file->path);
+  g_free(file);
+}
+
+static void project_init(Project *self) {
+  self->files = g_ptr_array_new_with_free_func((GDestroyNotify)project_file_free);
+}
+
+static void project_finalize(GObject *obj) {
+  Project *self = GLIDE_PROJECT(obj);
+  if (self->files)
+    g_ptr_array_free(self->files, TRUE);
+  G_OBJECT_CLASS(project_parent_class)->finalize(obj);
+}
+
+Project *project_new(void) {
+  return g_object_new(PROJECT_TYPE, NULL);
+}
+
+ProjectFile *project_add_file(Project *self, TextProvider *provider,
+    GtkTextBuffer *buffer, const gchar *path, ProjectFileState state) {
+  g_return_val_if_fail(GLIDE_IS_PROJECT(self), NULL);
+  g_return_val_if_fail(GLIDE_IS_TEXT_PROVIDER(provider), NULL);
+
+  ProjectFile *file = g_new0(ProjectFile, 1);
+  file->state = state;
+  file->provider = g_object_ref(provider);
+  file->buffer = buffer ? g_object_ref(buffer) : NULL;
+  file->parser = lisp_parser_new(file->provider);
+  file->path = path ? g_strdup(path) : NULL;
+
+  g_ptr_array_add(self->files, file);
+
+  project_file_changed(self, file);
+
+  return file;
+}
+
+void project_file_changed(Project *self /*unused*/, ProjectFile *file) {
+  g_return_if_fail(file != NULL);
+  if (file->parser)
+    lisp_parser_parse(file->parser);
+}
+
+LispParser *project_file_get_parser(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->parser;
+}
+
+GtkTextBuffer *project_file_get_buffer(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->buffer;
+}
+

--- a/project.h
+++ b/project.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <glib-object.h>
+typedef struct _GtkTextBuffer GtkTextBuffer;
+#include "text_provider.h"
+#include "lisp_parser.h"
+
+G_BEGIN_DECLS
+
+#define PROJECT_TYPE (project_get_type())
+G_DECLARE_FINAL_TYPE(Project, project, GLIDE, PROJECT, GObject)
+
+typedef enum {
+  PROJECT_FILE_DORMANT,
+  PROJECT_FILE_LIVE,
+  PROJECT_FILE_SCRATCH
+} ProjectFileState;
+
+typedef struct _ProjectFile ProjectFile;
+
+Project *project_new(void);
+ProjectFile *project_add_file(Project *self, TextProvider *provider,
+    GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
+void project_file_changed(Project *self, ProjectFile *file);
+LispParser *project_file_get_parser(ProjectFile *file);
+GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
+
+G_END_DECLS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,33 +1,37 @@
 VPATH = ../common
-INCLUDES = -I../common -I../64k
+INCLUDES = -I../common -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0`
-TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test
+TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
 	
-preferences_test: preferences_test.c preferences.c
+preferences_test: preferences_test.c ../preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-process_test: process_test.c process.c real_process.c
+process_test: process_test.c ../process.c ../real_process.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_process_test: swank_process_test.c swank_process.c real_swank_process.c process.c preferences.c
+swank_process_test: swank_process_test.c ../swank_process.c ../real_swank_process.c ../process.c ../preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c
+swank_session_test: swank_session_test.c ../swank_session.c ../swank_process.c ../real_swank_session.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c ../64k/lisp_parser.c ../64k/string_text_provider.c ../64k/text_provider.c
+lisp_parser_test: lisp_parser_test.c ../lisp_parser.c ../string_text_provider.c ../text_provider.c
+	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
+project_test: project_test.c ../project.c ../lisp_parser.c ../string_text_provider.c ../text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all
-	./preferences_test
-	./process_test
-	./swank_process_test
-	./swank_session_test
+	        ./preferences_test
+	        ./process_test
+	        ./swank_process_test
+	        ./swank_session_test
 	./lisp_parser_test
+	./project_test
 
 clean:
 	rm -f $(CLEANABLES)

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -1,0 +1,29 @@
+#include "project.h"
+#include "string_text_provider.h"
+#include <glib.h>
+
+static void test_parse_on_change(void)
+{
+  Project *project = project_new();
+  TextProvider *provider = string_text_provider_new("(a)");
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_SCRATCH);
+  g_object_unref(provider);
+  /* file already parsed by project_add_file */
+  LispParser *parser = project_file_get_parser(file);
+  guint n_tokens = 0;
+  const LispToken *tokens = lisp_parser_get_tokens(parser, &n_tokens);
+  g_assert_cmpint(n_tokens, ==, 3); /* (, a, ) */
+  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_LIST_START);
+  project_file_changed(project, file); /* should still parse without error */
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  project_file_changed(project, file);
+  g_object_unref(project);
+}
+
+int main(int argc, char *argv[])
+{
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/project/parse_on_change", test_parse_on_change);
+  return g_test_run();
+}


### PR DESCRIPTION
## Summary
- create `Project` class to manage source files and run parser
- update source and parser views to use the project
- wire project into `App` and `main`
- add unit test for `Project`
- update build rules

## Testing
- `make -C tests run`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6878099d67cc8328a4b881d0b0fe471b