### PR TITLE
Refactor buffer access through source view

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -20,7 +20,6 @@ struct _App
 
   /* UI pointers we want to reuse */
   GtkWidget      *window;
-  GtkSourceBuffer*buffer;
   LispSourceView *source_view;
   gchar          *filename;   /* current file path or NULL */
   Preferences    *preferences;
@@ -86,7 +85,6 @@ app_activate (GApplication *app)
 
   GtkWidget *view = lisp_source_view_new (self->project);
   self->source_view = LISP_SOURCE_VIEW(view);
-  self->buffer = lisp_source_view_get_buffer (self->source_view);
   gtk_container_add (GTK_CONTAINER (scrolled), view);
 
   /* Catch Alt+Enter in the view */
@@ -193,12 +191,13 @@ app_new (Preferences *prefs, SwankSession *swank, Project *project)
   return self;
 }
 
-STATIC GtkSourceBuffer *
-app_get_source_buffer (App *self)
+
+STATIC LispSourceView *
+app_get_source_view(App *self)
 {
-  g_debug("App.get_source_buffer");
+  g_debug("App.get_source_view");
   g_return_val_if_fail (GLIDE_IS_APP (self), NULL);
-  return self->buffer;
+  return self->source_view;
 }
 
 STATIC const gchar *

--- a/src/app.h
+++ b/src/app.h
@@ -6,6 +6,7 @@
 #include "preferences.h"
 #include "swank_session.h"
 #include "project.h"
+#include "lisp_source_view.h"
 
 #ifndef STATIC
 #define STATIC
@@ -17,7 +18,7 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 
 STATIC App *app_new (Preferences *prefs, SwankSession *swank, Project *project);
-STATIC GtkSourceBuffer *app_get_source_buffer (App *self);
+STATIC LispSourceView *app_get_source_view(App *self);
 STATIC const gchar *app_get_filename  (App *self); // Returns the current filename or NULL (borrowed – do not free)
 STATIC void app_set_filename  (App *self, const gchar *new_filename);
 STATIC Preferences *app_get_preferences(App *self);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -8,6 +8,7 @@
 #include "swank_session.h"
 #include "interaction.h"
 #include "evaluate.h"
+#include "lisp_source_view.h"
 
 #include <gtk/gtk.h>
 #include <gtksourceview/gtksource.h>
@@ -19,7 +20,8 @@ void
 on_evaluate(App *self)
 {
   g_debug("Evaluate.on_evaluate");
-  GtkSourceBuffer *source_buffer = app_get_source_buffer(self);
+  GtkSourceBuffer *source_buffer =
+      lisp_source_view_get_buffer(app_get_source_view(self));
 
   /* 1. Locate the iterator at the caret (insert mark). */
   GtkTextMark *insert_mark = gtk_text_buffer_get_insert(GTK_TEXT_BUFFER(source_buffer));

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -8,10 +8,12 @@
 #include "syscalls.h"
 #include "file_open.h"
 #include "app.h"
+#include "lisp_source_view.h"
 
 void file_open(GtkWidget *, gpointer data) {
   App *app = (App *) data;
-  GtkSourceBuffer *source_buffer = app_get_source_buffer (app);
+  GtkSourceBuffer *source_buffer =
+      lisp_source_view_get_buffer(app_get_source_view(app));
 
   // Create a file chooser dialog
   GtkWidget *dialog = gtk_file_chooser_dialog_new(

--- a/src/file_save.c
+++ b/src/file_save.c
@@ -8,10 +8,12 @@
 #include "syscalls.h"
 #include "file_save.h"
 #include "app.h"
+#include "lisp_source_view.h"
 
 void file_save(GtkWidget *, gpointer data) {
   App *app = (App *) data;
-  GtkSourceBuffer *source_buffer = app_get_source_buffer (app);
+  GtkSourceBuffer *source_buffer =
+      lisp_source_view_get_buffer(app_get_source_view(app));
   const gchar *filename = app_get_filename (app);
 
   gchar *chosen_filename = NULL;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,34 +1,35 @@
-INCLUDES = -I..
+VPATH = ../src
+INCLUDES = -I$(VPATH) -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0`
 TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
-	
-preferences_test: preferences_test.c ../preferences.c
+
+preferences_test: preferences_test.c preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-process_test: process_test.c ../process.c ../real_process.c
+process_test: process_test.c process.c real_process.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_process_test: swank_process_test.c ../swank_process.c ../real_swank_process.c ../process.c ../preferences.c
+swank_process_test: swank_process_test.c swank_process.c real_swank_process.c process.c preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_session_test: swank_session_test.c ../swank_session.c ../swank_process.c ../real_swank_session.c
+swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c ../lisp_parser.c ../string_text_provider.c ../text_provider.c
+lisp_parser_test: lisp_parser_test.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c ../project.c ../lisp_parser.c ../string_text_provider.c ../text_provider.c
+project_test: project_test.c project.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all
-	        ./preferences_test
-	        ./process_test
-	        ./swank_process_test
-	        ./swank_session_test
+	./preferences_test
+	./process_test
+	./swank_process_test
+	./swank_session_test
 	./lisp_parser_test
 	./project_test
 


### PR DESCRIPTION
## Summary
- stop storing GtkSourceBuffer in `App`
- add accessor to retrieve the `LispSourceView` from `App`
- update evaluate, file open/save to query the buffer from the view
- tests/Makefile: use `VPATH` so test rules don't need `../src` prefixes

## Testing
- `make -C src all`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_6878938744508328be9b8834fd5c0f31