### PR TITLE
Move filename from App to ProjectFile

### DIFF
--- a/doc/classes.plantuml
+++ b/doc/classes.plantuml
@@ -6,7 +6,7 @@ App *-- SwankSession
 App *-- Window
 App *-- LispSourceView
 App *-- Preferences
-App : filename
+ProjectFile : path
 
 GtkSourceView <|-- LispSourceView
 LispSourceView *-- GtkSourceBuffer

--- a/src/app.c
+++ b/src/app.c
@@ -21,7 +21,6 @@ struct _App
   /* UI pointers we want to reuse */
   GtkWidget      *window;
   LispSourceView *source_view;
-  gchar          *filename;   /* current file path or NULL */
   Preferences    *preferences;
   SwankSession   *swank;
   Project        *project;
@@ -142,7 +141,6 @@ app_dispose (GObject *object)
 
   g_debug("App.dispose");
 
-  g_clear_pointer (&self->filename, g_free);
   g_clear_object (&self->project);
   g_clear_object (&self->preferences);
   g_clear_object (&self->swank);
@@ -166,7 +164,6 @@ app_init (App *self)
 {
   g_debug("App.init");
   /* Everything that needs only the *instance* goes here */
-  self->filename = NULL;
   self->preferences = NULL;
   self->swank = NULL;
   self->project = NULL;
@@ -200,26 +197,6 @@ app_get_source_view(App *self)
   return self->source_view;
 }
 
-STATIC const gchar *
-app_get_filename (App *self)
-{
-  g_debug("App.get_filename");
-  g_return_val_if_fail (GLIDE_IS_APP (self), NULL);
-  return self->filename;
-}
-
-STATIC void
-app_set_filename (App *self, const gchar *new_filename)
-{
-  g_debug("App.set_filename %s", new_filename ? new_filename : "(null)");
-  g_return_if_fail (GLIDE_IS_APP (self));
-  gchar *dup = new_filename ? g_strdup (new_filename) : NULL;
-  g_free (self->filename);
-  self->filename = dup;
-
-  /* If you later register a “filename” property, notify here:
-     g_object_notify_by_pspec (G_OBJECT (self), obj_props[PROP_FILENAME]); */
-}
 
 STATIC Preferences *
 app_get_preferences (App *self)

--- a/src/app.h
+++ b/src/app.h
@@ -19,8 +19,6 @@ G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 
 STATIC App *app_new (Preferences *prefs, SwankSession *swank, Project *project);
 STATIC LispSourceView *app_get_source_view(App *self);
-STATIC const gchar *app_get_filename  (App *self); // Returns the current filename or NULL (borrowed – do not free)
-STATIC void app_set_filename  (App *self, const gchar *new_filename);
 STATIC Preferences *app_get_preferences(App *self);
 STATIC SwankSession *app_get_swank(App *self);
 STATIC void app_on_quit(App *self);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -26,7 +26,8 @@ void file_open(GtkWidget *, gpointer data) {
 
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     gchar* filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-    app_set_filename (app, filename);
+    ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
+    project_file_set_path(file, filename);
 
     // Open the file using syscalls
     int fd = sys_open(filename, O_RDONLY, 0);

--- a/src/file_save.c
+++ b/src/file_save.c
@@ -14,7 +14,8 @@ void file_save(GtkWidget *, gpointer data) {
   App *app = (App *) data;
   GtkSourceBuffer *source_buffer =
       lisp_source_view_get_buffer(app_get_source_view(app));
-  const gchar *filename = app_get_filename (app);
+  ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
+  const gchar *filename = project_file_get_path(file);
 
   gchar *chosen_filename = NULL;
 
@@ -35,7 +36,7 @@ void file_save(GtkWidget *, gpointer data) {
 
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
       chosen_filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-      app_set_filename(app, chosen_filename);
+      project_file_set_path(file, chosen_filename);
       filename = chosen_filename;
     }
 
@@ -89,14 +90,15 @@ void file_save(GtkWidget *, gpointer data) {
 
 void file_saveas(GtkWidget *widget, gpointer data) {
   App *app = (App *) data;
-  gchar *old_filename = g_strdup(app_get_filename (app));
-  app_set_filename (app, NULL);
+  ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
+  gchar *old_filename = g_strdup(project_file_get_path(file));
+  project_file_set_path(file, NULL);
 
   file_save(widget, app);
 
-  const char *new_filename = app_get_filename (app);
+  const char *new_filename = project_file_get_path(file);
   if (!new_filename) {
-    app_set_filename (app, old_filename);
+    project_file_set_path(file, old_filename);
   }
   g_free(old_filename);
 }

--- a/src/project.c
+++ b/src/project.c
@@ -81,3 +81,14 @@ GtkTextBuffer *project_file_get_buffer(ProjectFile *file) {
   return file->buffer;
 }
 
+const gchar *project_file_get_path(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->path;
+}
+
+void project_file_set_path(ProjectFile *file, const gchar *path) {
+  g_return_if_fail(file != NULL);
+  g_free(file->path);
+  file->path = path ? g_strdup(path) : NULL;
+}
+

--- a/src/project.h
+++ b/src/project.h
@@ -24,5 +24,7 @@ ProjectFile *project_add_file(Project *self, TextProvider *provider,
 void project_file_changed(Project *self, ProjectFile *file);
 LispParser *project_file_get_parser(ProjectFile *file);
 GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
+const gchar *project_file_get_path(ProjectFile *file); // borrowed, do not free
+void project_file_set_path(ProjectFile *file, const gchar *path);
 
 G_END_DECLS


### PR DESCRIPTION
## Summary
- store file path in `ProjectFile` rather than in `App`
- update save/open logic to use `ProjectFile` path helpers
- document the change in the class diagram

## Testing
- `make -C tests`
- `cd tests && ./preferences_test && ./process_test && ./swank_process_test && ./swank_session_test && ./lisp_parser_test && ./project_test && cd ..`

------
https://chatgpt.com/codex/tasks/task_e_6878b77db1cc8328a0d45052135f8208