### PR TITLE
Implement default project scratch file and adjust saving logic

### DIFF
--- a/src/file_save.c
+++ b/src/file_save.c
@@ -16,11 +16,12 @@ void file_save(GtkWidget *, gpointer data) {
       lisp_source_view_get_buffer(app_get_source_view(app));
   ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
   const gchar *filename = project_file_get_path(file);
+  gboolean scratch = project_file_get_state(file) == PROJECT_FILE_SCRATCH;
 
   gchar *chosen_filename = NULL;
 
   // Check if we already have a filename
-  if (!filename) {
+  if (!filename || scratch) {
     // We do not have a known filename -> use a "Save As" dialog
     GtkWidget *dialog = gtk_file_chooser_dialog_new(
         "Save File",
@@ -37,6 +38,7 @@ void file_save(GtkWidget *, gpointer data) {
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
       chosen_filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
       project_file_set_path(file, chosen_filename);
+      project_file_set_state(file, PROJECT_FILE_LIVE);
       filename = chosen_filename;
     }
 

--- a/src/lisp_source_view.c
+++ b/src/lisp_source_view.c
@@ -71,9 +71,18 @@ lisp_source_view_new (Project *project)
 
   LispSourceView *self = g_object_new (LISP_TYPE_SOURCE_VIEW, NULL);
   self->project = g_object_ref(project);
+  self->file = project_get_file(project, 0);
+
+  TextProvider *existing = project_file_get_provider(self->file);
+  if (existing) {
+    gsize len = text_provider_get_length(existing);
+    gchar *text = text_provider_get_text(existing, 0, len);
+    gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self->buffer), text, -1);
+    g_free(text);
+  }
+
   TextProvider *provider = gtk_text_provider_new(GTK_TEXT_BUFFER(self->buffer));
-  self->file = project_add_file(project, provider, GTK_TEXT_BUFFER(self->buffer), NULL,
-      PROJECT_FILE_SCRATCH);
+  project_file_set_provider(self->file, provider, GTK_TEXT_BUFFER(self->buffer));
   g_object_unref(provider);
   g_signal_connect(self->buffer, "changed", G_CALLBACK(on_buffer_changed), self);
   return GTK_WIDGET(self);

--- a/src/project.h
+++ b/src/project.h
@@ -19,6 +19,14 @@ typedef enum {
 typedef struct _ProjectFile ProjectFile;
 
 Project *project_new(void);
+ProjectFile *project_create_scratch(Project *self);
+ProjectFile *project_get_file(Project *self, guint index);
+guint project_get_file_count(Project *self);
+ProjectFileState project_file_get_state(ProjectFile *file);
+void project_file_set_state(ProjectFile *file, ProjectFileState state);
+void project_file_set_provider(ProjectFile *file, TextProvider *provider,
+    GtkTextBuffer *buffer);
+TextProvider *project_file_get_provider(ProjectFile *file);
 ProjectFile *project_add_file(Project *self, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
 void project_file_changed(Project *self, ProjectFile *file);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -2,6 +2,16 @@
 #include "string_text_provider.h"
 #include <glib.h>
 
+static void test_default_scratch(void)
+{
+  Project *project = project_new();
+  g_assert_cmpuint(project_get_file_count(project), ==, 1);
+  ProjectFile *file = project_get_file(project, 0);
+  g_assert_cmpint(project_file_get_state(file), ==, PROJECT_FILE_SCRATCH);
+  g_assert_cmpstr(project_file_get_path(file), ==, "scratch00");
+  g_object_unref(project);
+}
+
 static void test_parse_on_change(void)
 {
   Project *project = project_new();
@@ -24,6 +34,7 @@ static void test_parse_on_change(void)
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/project/default_scratch", test_default_scratch);
   g_test_add_func("/project/parse_on_change", test_parse_on_change);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- create default scratch file when creating a Project
- add helper APIs for project files and their providers
- open LispSourceView on the project's first file
- treat scratch files specially when saving
- test project default scratch file behavior

## Testing
- `make` in `tests` and `make run`

------
https://chatgpt.com/codex/tasks/task_e_6878cf0c2b3883288e5c150eb0ef0b51