### PR TITLE
Introduce current file tracking

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -214,6 +214,14 @@ app_get_swank (App *self)
   return self->swank;
 }
 
+STATIC Project *
+app_get_project(App *self)
+{
+  g_debug("App.get_project");
+  g_return_val_if_fail(GLIDE_IS_APP(self), NULL);
+  return self->project;
+}
+
 STATIC void
 app_quit (App *self)
 {

--- a/src/app.h
+++ b/src/app.h
@@ -21,6 +21,7 @@ STATIC App *app_new (Preferences *prefs, SwankSession *swank, Project *project);
 STATIC LispSourceView *app_get_source_view(App *self);
 STATIC Preferences *app_get_preferences(App *self);
 STATIC SwankSession *app_get_swank(App *self);
+STATIC Project *app_get_project(App *self);
 STATIC void app_on_quit(App *self);
 STATIC void app_quit(App *self);
 

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -26,7 +26,7 @@ void file_open(GtkWidget *, gpointer data) {
 
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     gchar* filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-    ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
+    ProjectFile *file = project_get_current_file(app_get_project(app));
     project_file_set_path(file, filename);
 
     // Open the file using syscalls

--- a/src/file_save.c
+++ b/src/file_save.c
@@ -14,7 +14,7 @@ void file_save(GtkWidget *, gpointer data) {
   App *app = (App *) data;
   GtkSourceBuffer *source_buffer =
       lisp_source_view_get_buffer(app_get_source_view(app));
-  ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
+  ProjectFile *file = project_get_current_file(app_get_project(app));
   const gchar *filename = project_file_get_path(file);
   gboolean scratch = project_file_get_state(file) == PROJECT_FILE_SCRATCH;
 
@@ -38,7 +38,7 @@ void file_save(GtkWidget *, gpointer data) {
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
       chosen_filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
       project_file_set_path(file, chosen_filename);
-      project_file_set_state(file, PROJECT_FILE_LIVE);
+      project_file_set_state(file, PROJECT_FILE_LOADED);
       filename = chosen_filename;
     }
 

--- a/src/lisp_source_view.c
+++ b/src/lisp_source_view.c
@@ -71,7 +71,7 @@ lisp_source_view_new (Project *project)
 
   LispSourceView *self = g_object_new (LISP_TYPE_SOURCE_VIEW, NULL);
   self->project = g_object_ref(project);
-  self->file = project_get_file(project, 0);
+  self->file = project_get_current_file(project);
 
   TextProvider *existing = project_file_get_provider(self->file);
   if (existing) {

--- a/src/project.h
+++ b/src/project.h
@@ -12,7 +12,7 @@ G_DECLARE_FINAL_TYPE(Project, project, GLIDE, PROJECT, GObject)
 
 typedef enum {
   PROJECT_FILE_DORMANT,
-  PROJECT_FILE_LIVE,
+  PROJECT_FILE_LOADED,
   PROJECT_FILE_SCRATCH
 } ProjectFileState;
 
@@ -22,6 +22,8 @@ Project *project_new(void);
 ProjectFile *project_create_scratch(Project *self);
 ProjectFile *project_get_file(Project *self, guint index);
 guint project_get_file_count(Project *self);
+ProjectFile *project_get_current_file(Project *self);
+void project_set_current_file(Project *self, ProjectFile *file);
 ProjectFileState project_file_get_state(ProjectFile *file);
 void project_file_set_state(ProjectFile *file, ProjectFileState state);
 void project_file_set_provider(ProjectFile *file, TextProvider *provider,

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -9,6 +9,7 @@ static void test_default_scratch(void)
   ProjectFile *file = project_get_file(project, 0);
   g_assert_cmpint(project_file_get_state(file), ==, PROJECT_FILE_SCRATCH);
   g_assert_cmpstr(project_file_get_path(file), ==, "scratch00");
+  g_assert_true(project_get_current_file(project) == file);
   g_object_unref(project);
 }
 
@@ -31,10 +32,23 @@ static void test_parse_on_change(void)
   g_object_unref(project);
 }
 
+static void test_set_current(void)
+{
+  Project *project = project_new();
+  TextProvider *provider = string_text_provider_new("(b)");
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL,
+      PROJECT_FILE_SCRATCH);
+  g_object_unref(provider);
+  project_set_current_file(project, file);
+  g_assert_true(project_get_current_file(project) == file);
+  g_object_unref(project);
+}
+
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/project/default_scratch", test_default_scratch);
   g_test_add_func("/project/parse_on_change", test_parse_on_change);
+  g_test_add_func("/project/set_current", test_set_current);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- rename project file state from `LIVE` to `LOADED`
- keep track of the current file in `Project`
- expose `app_get_project()` accessor
- use the current file for open/save actions
- update `LispSourceView` to use the current file
- test current file behaviour

## Testing
- `make -C tests run`
- `make -C src`

------
https://chatgpt.com/codex/tasks/task_e_6878da6f0220832881c0811c0b24cb20