### PR TITLE
Fix File->Open to create new tabs

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -198,6 +198,28 @@ app_get_source_view(App *self)
   return lisp_source_notebook_get_current_view(self->notebook);
 }
 
+STATIC LispSourceNotebook *
+app_get_notebook(App *self)
+{
+  g_return_val_if_fail(GLIDE_IS_APP(self), NULL);
+  return self->notebook;
+}
+
+STATIC Project *
+app_get_project(App *self)
+{
+  g_return_val_if_fail(GLIDE_IS_APP(self), NULL);
+  return self->project;
+}
+
+STATIC void
+app_connect_view(App *self, LispSourceView *view)
+{
+  g_return_if_fail(GLIDE_IS_APP(self));
+  g_return_if_fail(LISP_IS_SOURCE_VIEW(view));
+  g_signal_connect(view, "key-press-event", G_CALLBACK(on_key_press), self);
+}
+
 
 STATIC Preferences *
 app_get_preferences (App *self)

--- a/src/app.h
+++ b/src/app.h
@@ -20,6 +20,9 @@ G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 
 STATIC App *app_new (Preferences *prefs, SwankSession *swank, Project *project);
 STATIC LispSourceView *app_get_source_view(App *self);
+STATIC LispSourceNotebook *app_get_notebook(App *self);
+STATIC Project *app_get_project(App *self);
+STATIC void app_connect_view(App *self, LispSourceView *view);
 STATIC Preferences *app_get_preferences(App *self);
 STATIC SwankSession *app_get_swank(App *self);
 STATIC void app_on_quit(App *self);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -30,50 +30,14 @@ void file_open(GtkWidget *, gpointer data) {
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     gchar* filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
 
-    int fd = sys_open(filename, O_RDONLY, 0);
-    if (fd == -1) {
-      g_printerr("Failed to open file using syscalls: %s (errno: %d)\n", filename, errno);
-    } else {
-      struct stat sb;
-      if (sys_fstat(fd, &sb) == -1) {
-        g_printerr("Failed to stat file: %s (errno: %d)\n", filename, errno);
-        sys_close(fd);
-      } else if (!S_ISREG(sb.st_mode)) {
-        g_printerr("Not a regular file: %s\n", filename);
-        sys_close(fd);
-      } else {
-        off_t length = sb.st_size;
-        char *content = g_malloc(length + 1);
-        if (!content) {
-          g_printerr("Failed to allocate memory for file content.\n");
-          sys_close(fd);
-        } else {
-          ssize_t total_read = 0;
-          while (total_read < length) {
-            ssize_t r = sys_read(fd, content + total_read, length - total_read);
-            if (r == -1) {
-              g_printerr("Error reading file: %s (errno: %d)\n", filename, errno);
-              break;
-            } else if (r == 0) {
-              break;
-            }
-            total_read += r;
-          }
-          content[total_read] = '\0';
-          sys_close(fd);
+    TextProvider *provider = string_text_provider_new("");
+    ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
+    g_object_unref(provider);
 
-          TextProvider *provider = string_text_provider_new(content);
-          ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
-          g_object_unref(provider);
-
-          gint page = lisp_source_notebook_add_file(notebook, file);
-          gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), page);
-          LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
-          app_connect_view(app, view);
-
-          g_free(content);
-        }
-      }
+    if (file) {
+      project_file_load(project, file);
+      LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+      app_connect_view(app, view);
     }
 
     g_free(filename);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -9,11 +9,14 @@
 #include "file_open.h"
 #include "app.h"
 #include "lisp_source_view.h"
+#include "lisp_source_notebook.h"
+#include "project.h"
+#include "string_text_provider.h"
 
 void file_open(GtkWidget *, gpointer data) {
   App *app = (App *) data;
-  GtkSourceBuffer *source_buffer =
-      lisp_source_view_get_buffer(app_get_source_view(app));
+  Project *project = app_get_project(app);
+  LispSourceNotebook *notebook = app_get_notebook(app);
 
   // Create a file chooser dialog
   GtkWidget *dialog = gtk_file_chooser_dialog_new(
@@ -26,13 +29,9 @@ void file_open(GtkWidget *, gpointer data) {
 
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     gchar* filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-    ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
-    project_file_set_path(file, filename);
 
-    // Open the file using syscalls
     int fd = sys_open(filename, O_RDONLY, 0);
     if (fd == -1) {
-      // Handle error opening file
       g_printerr("Failed to open file using syscalls: %s (errno: %d)\n", filename, errno);
     } else {
       struct stat sb;
@@ -43,38 +42,35 @@ void file_open(GtkWidget *, gpointer data) {
         g_printerr("Not a regular file: %s\n", filename);
         sys_close(fd);
       } else {
-        // sb.st_size is the size of the file in bytes
         off_t length = sb.st_size;
-
-        // Allocate buffer for file content + null terminator
         char *content = g_malloc(length + 1);
         if (!content) {
           g_printerr("Failed to allocate memory for file content.\n");
           sys_close(fd);
         } else {
           ssize_t total_read = 0;
-
-          // Read loop to handle partial reads
           while (total_read < length) {
             ssize_t r = sys_read(fd, content + total_read, length - total_read);
             if (r == -1) {
               g_printerr("Error reading file: %s (errno: %d)\n", filename, errno);
               break;
             } else if (r == 0) {
-              // EOF reached unexpectedly
               break;
             }
             total_read += r;
           }
-
-          // Null-terminate properly in case we didn’t read the entire file
           content[total_read] = '\0';
-
-          // Close the file
           sys_close(fd);
 
-          // Set the content to the buffer
-          gtk_text_buffer_set_text(GTK_TEXT_BUFFER(source_buffer), content, -1);
+          TextProvider *provider = string_text_provider_new(content);
+          ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
+          g_object_unref(provider);
+
+          gint page = lisp_source_notebook_add_file(notebook, file);
+          gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), page);
+          LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+          app_connect_view(app, view);
+
           g_free(content);
         }
       }

--- a/src/lisp_source_notebook.c
+++ b/src/lisp_source_notebook.c
@@ -57,17 +57,18 @@ create_scrolled_view(LispSourceNotebook *self, ProjectFile *file)
   return scrolled;
 }
 
-void
+gint
 lisp_source_notebook_add_file(LispSourceNotebook *self, ProjectFile *file)
 {
-  g_return_if_fail(LISP_IS_SOURCE_NOTEBOOK(self));
-  g_return_if_fail(file != NULL);
+  g_return_val_if_fail(LISP_IS_SOURCE_NOTEBOOK(self), -1);
+  g_return_val_if_fail(file != NULL, -1);
 
   GtkWidget *scrolled = create_scrolled_view(self, file);
   const gchar *path = project_file_get_path(file);
   GtkWidget *label = gtk_label_new(path ? path : "untitled");
   gint page = gtk_notebook_append_page(GTK_NOTEBOOK(self), scrolled, label);
   gtk_widget_show_all(gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page));
+  return page;
 }
 
 LispSourceView *

--- a/src/lisp_source_notebook.c
+++ b/src/lisp_source_notebook.c
@@ -8,6 +8,8 @@ struct _LispSourceNotebook
 
 G_DEFINE_TYPE(LispSourceNotebook, lisp_source_notebook, GTK_TYPE_NOTEBOOK)
 
+static void on_file_loaded(Project * /*project*/, ProjectFile *file, gpointer user_data);
+
 static void
 lisp_source_notebook_init(LispSourceNotebook *self)
 {
@@ -37,6 +39,9 @@ lisp_source_notebook_new(Project *project)
   LispSourceNotebook *self = g_object_new(LISP_TYPE_SOURCE_NOTEBOOK, NULL);
   self->project = g_object_ref(project);
 
+  g_signal_connect(project, "file-loaded",
+      G_CALLBACK(on_file_loaded), self);
+
   guint count = project_get_file_count(project);
   for (guint i = 0; i < count; i++) {
     ProjectFile *file = project_get_file(project, i);
@@ -55,6 +60,14 @@ create_scrolled_view(LispSourceNotebook *self, ProjectFile *file)
       GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   gtk_container_add(GTK_CONTAINER(scrolled), view);
   return scrolled;
+}
+
+static void
+on_file_loaded(Project * /*project*/, ProjectFile *file, gpointer user_data)
+{
+  LispSourceNotebook *self = LISP_SOURCE_NOTEBOOK(user_data);
+  gint page = lisp_source_notebook_add_file(self, file);
+  gtk_notebook_set_current_page(GTK_NOTEBOOK(self), page);
 }
 
 gint

--- a/src/lisp_source_notebook.h
+++ b/src/lisp_source_notebook.h
@@ -11,6 +11,6 @@ G_DECLARE_FINAL_TYPE(LispSourceNotebook, lisp_source_notebook, LISP, SOURCE_NOTE
 
 GtkWidget *lisp_source_notebook_new(Project *project);
 LispSourceView *lisp_source_notebook_get_current_view(LispSourceNotebook *self);
-void lisp_source_notebook_add_file(LispSourceNotebook *self, ProjectFile *file);
+gint lisp_source_notebook_add_file(LispSourceNotebook *self, ProjectFile *file);
 
 G_END_DECLS

--- a/src/project.c
+++ b/src/project.c
@@ -1,5 +1,10 @@
 #include "project.h"
 #include "string_text_provider.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include "syscalls.h"
 
 struct _ProjectFile {
   ProjectFileState state;
@@ -15,12 +20,30 @@ struct _Project {
   guint next_scratch_id;
 };
 
+enum {
+  FILE_LOADED,
+  N_SIGNALS
+};
+
+static guint project_signals[N_SIGNALS];
+
 static void project_finalize(GObject *obj);
 ProjectFile *project_create_scratch(Project *self);
 
 G_DEFINE_TYPE(Project, project, G_TYPE_OBJECT)
 
 static void project_class_init(ProjectClass *klass) {
+  project_signals[FILE_LOADED] = g_signal_new(
+      "file-loaded",
+      G_TYPE_FROM_CLASS(klass),
+      G_SIGNAL_RUN_FIRST,
+      0,
+      NULL, NULL,
+      g_cclosure_marshal_VOID__POINTER,
+      G_TYPE_NONE,
+      1,
+      G_TYPE_POINTER);
+
   GObjectClass *obj = G_OBJECT_CLASS(klass);
   obj->finalize = project_finalize;
 }
@@ -150,5 +173,62 @@ void project_file_set_path(ProjectFile *file, const gchar *path) {
   g_return_if_fail(file != NULL);
   g_free(file->path);
   file->path = path ? g_strdup(path) : NULL;
+}
+
+gboolean project_file_load(Project *self, ProjectFile *file) {
+  g_return_val_if_fail(GLIDE_IS_PROJECT(self), FALSE);
+  g_return_val_if_fail(file != NULL, FALSE);
+
+  const gchar *path = project_file_get_path(file);
+  if (!path)
+    return FALSE;
+
+  int fd = sys_open(path, O_RDONLY, 0);
+  if (fd == -1) {
+    g_printerr("Failed to open file using syscalls: %s (errno: %d)\n", path, errno);
+    return FALSE;
+  }
+
+  struct stat sb;
+  if (sys_fstat(fd, &sb) == -1 || !S_ISREG(sb.st_mode)) {
+    g_printerr("Not a regular file: %s\n", path);
+    sys_close(fd);
+    return FALSE;
+  }
+
+  off_t length = sb.st_size;
+  char *content = g_malloc(length + 1);
+  if (!content) {
+    g_printerr("Failed to allocate memory for file content.\n");
+    sys_close(fd);
+    return FALSE;
+  }
+
+  ssize_t total_read = 0;
+  while (total_read < length) {
+    ssize_t r = sys_read(fd, content + total_read, length - total_read);
+    if (r == -1) {
+      g_printerr("Error reading file: %s (errno: %d)\n", path, errno);
+      g_free(content);
+      sys_close(fd);
+      return FALSE;
+    } else if (r == 0) {
+      break;
+    }
+    total_read += r;
+  }
+
+  content[total_read] = '\0';
+  sys_close(fd);
+
+  TextProvider *provider = string_text_provider_new(content);
+  project_file_set_provider(file, provider, NULL);
+  g_object_unref(provider);
+  project_file_set_state(file, PROJECT_FILE_LIVE);
+
+  g_signal_emit(self, project_signals[FILE_LOADED], 0, file);
+
+  g_free(content);
+  return TRUE;
 }
 

--- a/src/project.h
+++ b/src/project.h
@@ -34,5 +34,6 @@ LispParser *project_file_get_parser(ProjectFile *file);
 GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
 const gchar *project_file_get_path(ProjectFile *file); // borrowed, do not free
 void project_file_set_path(ProjectFile *file, const gchar *path);
+gboolean project_file_load(Project *self, ProjectFile *file);
 
 G_END_DECLS

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -1,6 +1,8 @@
 #include "project.h"
 #include "string_text_provider.h"
 #include <glib.h>
+#include <glib/gstdio.h>
+#include <string.h>
 
 static void test_default_scratch(void)
 {
@@ -31,10 +33,51 @@ static void test_parse_on_change(void)
   g_object_unref(project);
 }
 
+static void on_file_loaded(Project * /*project*/, ProjectFile * /*file*/,
+    gpointer user_data)
+{
+  int *count = user_data;
+  (*count)++;
+}
+
+static void test_file_load(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("project-test-XXXXXX", NULL);
+  gchar *filepath = g_build_filename(tmpdir, "file.lisp", NULL);
+  const gchar *contents = "(a b c)";
+  g_file_set_contents(filepath, contents, -1, NULL);
+
+  Project *project = project_new();
+  TextProvider *provider = string_text_provider_new("");
+  ProjectFile *file = project_add_file(project, provider, NULL, filepath,
+      PROJECT_FILE_LIVE);
+  g_object_unref(provider);
+
+  int count = 0;
+  g_signal_connect(project, "file-loaded", G_CALLBACK(on_file_loaded), &count);
+
+  gboolean ok = project_file_load(project, file);
+  g_assert_true(ok);
+  g_assert_cmpint(count, ==, 1);
+
+  TextProvider *tp = project_file_get_provider(file);
+  gsize len = text_provider_get_length(tp);
+  gchar *text = text_provider_get_text(tp, 0, len);
+  g_assert_cmpstr(text, ==, contents);
+  g_free(text);
+
+  g_object_unref(project);
+  g_remove(filepath);
+  g_rmdir(tmpdir);
+  g_free(filepath);
+  g_free(tmpdir);
+}
+
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/project/default_scratch", test_default_scratch);
   g_test_add_func("/project/parse_on_change", test_parse_on_change);
+  g_test_add_func("/project/file_load", test_file_load);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- expose helper functions in `app` to access the notebook/project and to connect views
- return page index from `lisp_source_notebook_add_file`
- update File->Open so it loads the file into a new ProjectFile and notebook tab

## Testing
- `make -C src`
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_6878fcf19474832888693a04df230b5f