### PR TITLE
Implement minimal ASDF parser/writer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,8 @@ SOURCES += \
   project.c \
   gtk_text_provider.c \
   string_text_provider.c \
-  text_provider.c
+  text_provider.c \
+  asdf.c
 
 include Makefile_common
 

--- a/src/asdf.c
+++ b/src/asdf.c
@@ -1,0 +1,250 @@
+#include "asdf.h"
+#include "lisp_parser.h"
+#include "string_text_provider.h"
+#include <glib/gstdio.h>
+
+struct _Asdf {
+  GObject parent_instance;
+  gchar *filename;
+  gchar *pathname;
+  gboolean serial;
+  GPtrArray *components; /* gchar* */
+  GPtrArray *depends_on; /* gchar* */
+};
+
+static void asdf_finalize(GObject *object);
+
+G_DEFINE_TYPE(Asdf, asdf, G_TYPE_OBJECT)
+
+static void asdf_class_init(AsdfClass *klass) {
+  GObjectClass *obj = G_OBJECT_CLASS(klass);
+  obj->finalize = asdf_finalize;
+}
+
+static void asdf_init(Asdf *self) {
+  self->filename = NULL;
+  self->pathname = NULL;
+  self->serial = FALSE;
+  self->components = g_ptr_array_new_with_free_func(g_free);
+  self->depends_on = g_ptr_array_new_with_free_func(g_free);
+}
+
+static void asdf_finalize(GObject *object) {
+  Asdf *self = GLIDE_ASDF(object);
+  g_free(self->filename);
+  g_free(self->pathname);
+  if (self->components)
+    g_ptr_array_free(self->components, TRUE);
+  if (self->depends_on)
+    g_ptr_array_free(self->depends_on, TRUE);
+  G_OBJECT_CLASS(asdf_parent_class)->finalize(object);
+}
+
+Asdf *asdf_new(void) {
+  return g_object_new(ASDF_TYPE, NULL);
+}
+
+static void parse_file_contents(Asdf *self, const gchar *contents);
+
+Asdf *asdf_new_from_file(const gchar *filename) {
+  Asdf *self = asdf_new();
+  self->filename = g_strdup(filename);
+  gchar *contents = NULL;
+  if (g_file_get_contents(filename, &contents, NULL, NULL)) {
+    parse_file_contents(self, contents);
+    g_free(contents);
+  }
+  return self;
+}
+
+const gchar *asdf_get_filename(Asdf *self) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
+  return self->filename;
+}
+
+const gchar *asdf_get_pathname(Asdf *self) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
+  return self->pathname;
+}
+
+void asdf_set_pathname(Asdf *self, const gchar *pathname) {
+  g_return_if_fail(GLIDE_IS_ASDF(self));
+  g_free(self->pathname);
+  self->pathname = g_strdup(pathname);
+}
+
+void asdf_set_serial(Asdf *self, gboolean serial) {
+  g_return_if_fail(GLIDE_IS_ASDF(self));
+  self->serial = serial;
+}
+
+gboolean asdf_get_serial(Asdf *self) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), FALSE);
+  return self->serial;
+}
+
+void asdf_add_component(Asdf *self, const gchar *file) {
+  g_return_if_fail(GLIDE_IS_ASDF(self));
+  g_ptr_array_add(self->components, g_strdup(file));
+}
+
+const gchar *asdf_get_component(Asdf *self, guint index) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
+  if (index >= self->components->len)
+    return NULL;
+  return g_ptr_array_index(self->components, index);
+}
+
+uint asdf_get_component_count(Asdf *self) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), 0);
+  return self->components->len;
+}
+
+void asdf_add_dependency(Asdf *self, const gchar *dep) {
+  g_return_if_fail(GLIDE_IS_ASDF(self));
+  g_ptr_array_add(self->depends_on, g_strdup(dep));
+}
+
+const gchar *asdf_get_dependency(Asdf *self, guint index) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
+  if (index >= self->depends_on->len)
+    return NULL;
+  return g_ptr_array_index(self->depends_on, index);
+}
+
+uint asdf_get_dependency_count(Asdf *self) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), 0);
+  return self->depends_on->len;
+}
+
+static gchar *unquote(const gchar *text) {
+  gsize len = strlen(text);
+  if (len >= 2 && text[0] == '"' && text[len - 1] == '"')
+    return g_strndup(text + 1, len - 2);
+  return g_strdup(text);
+}
+
+static void parse_file_contents(Asdf *self, const gchar *contents) {
+  TextProvider *provider = string_text_provider_new(contents);
+  LispParser *parser = lisp_parser_new(provider);
+  lisp_parser_parse(parser);
+
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  if (!ast)
+    goto cleanup;
+
+  const LispAstNode *defsystem = NULL;
+  for (guint i = 0; i < ast->children->len; i++) {
+    const LispAstNode *child = g_array_index(ast->children, LispAstNode*, i);
+    if (child->type != LISP_AST_NODE_TYPE_LIST || child->children->len < 2)
+      continue;
+    const LispAstNode *head = g_array_index(child->children, LispAstNode*, 0);
+    if (head->type == LISP_AST_NODE_TYPE_ATOM &&
+        g_strcmp0(head->start_token->text, "defsystem") == 0) {
+      defsystem = child;
+      break;
+    }
+  }
+
+  if (!defsystem)
+    goto cleanup;
+
+  for (guint i = 2; i + 1 < defsystem->children->len; i += 2) {
+    const LispAstNode *key = g_array_index(defsystem->children, LispAstNode*, i);
+    const LispAstNode *val = g_array_index(defsystem->children, LispAstNode*, i + 1);
+    if (key->type != LISP_AST_NODE_TYPE_ATOM)
+      continue;
+    const gchar *kw = key->start_token->text;
+
+    if (g_strcmp0(kw, ":pathname") == 0) {
+      gchar *p = unquote(val->start_token->text);
+      asdf_set_pathname(self, p);
+      g_free(p);
+    } else if (g_strcmp0(kw, ":serial") == 0) {
+      if (val->type == LISP_AST_NODE_TYPE_ATOM)
+        self->serial = g_strcmp0(val->start_token->text, "t") == 0 ||
+          g_strcmp0(val->start_token->text, "1") == 0;
+    } else if (g_strcmp0(kw, ":components") == 0) {
+      if (val->type == LISP_AST_NODE_TYPE_LIST) {
+        for (guint j = 0; j < val->children->len; j++) {
+          const LispAstNode *comp = g_array_index(val->children, LispAstNode*, j);
+          if (comp->type != LISP_AST_NODE_TYPE_LIST || comp->children->len < 2)
+            continue;
+          const LispAstNode *sym = g_array_index(comp->children, LispAstNode*, 0);
+          const LispAstNode *fname = g_array_index(comp->children, LispAstNode*, 1);
+          if (sym->type == LISP_AST_NODE_TYPE_ATOM &&
+              g_strcmp0(sym->start_token->text, "file") == 0) {
+            gchar *f = unquote(fname->start_token->text);
+            asdf_add_component(self, f);
+            g_free(f);
+          }
+        }
+      }
+    } else if (g_strcmp0(kw, ":depends-on") == 0) {
+      if (val->type == LISP_AST_NODE_TYPE_LIST) {
+        for (guint j = 0; j < val->children->len; j++) {
+          const LispAstNode *dep = g_array_index(val->children, LispAstNode*, j);
+          gchar *d = unquote(dep->start_token->text);
+          asdf_add_dependency(self, d);
+          g_free(d);
+        }
+      }
+    }
+  }
+
+cleanup:
+  lisp_parser_free(parser);
+  g_object_unref(provider);
+}
+
+static char *get_system_name(Asdf *self) {
+  if (!self->filename)
+    return g_strdup("system");
+  gchar *base = g_path_get_basename(self->filename);
+  gchar *dot = g_strrstr(base, ".");
+  if (dot)
+    *dot = '\0';
+  return base;
+}
+
+char *asdf_to_string(Asdf *self) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
+  GString *out = g_string_new(NULL);
+  gchar *name = get_system_name(self);
+  g_string_append_printf(out, "(defsystem \"%s\"\n", name);
+  g_free(name);
+  if (self->pathname)
+    g_string_append_printf(out, "  :pathname \"%s\"\n", self->pathname);
+  g_string_append_printf(out, "  :serial %s\n", self->serial ? "t" : "nil");
+  if (self->components->len > 0) {
+    g_string_append(out, "  :components (");
+    for (guint i = 0; i < self->components->len; i++) {
+      const gchar *comp = g_ptr_array_index(self->components, i);
+      g_string_append_printf(out, "(file \"%s\")", comp);
+      if (i + 1 < self->components->len)
+        g_string_append(out, " ");
+    }
+    g_string_append(out, ")\n");
+  }
+  if (self->depends_on->len > 0) {
+    g_string_append(out, "  :depends-on (");
+    for (guint i = 0; i < self->depends_on->len; i++) {
+      const gchar *dep = g_ptr_array_index(self->depends_on, i);
+      g_string_append_printf(out, "\"%s\"", dep);
+      if (i + 1 < self->depends_on->len)
+        g_string_append(out, " ");
+    }
+    g_string_append(out, ")\n");
+  }
+  g_string_append(out, ")\n");
+  return g_string_free(out, FALSE);
+}
+
+gboolean asdf_save(Asdf *self, const gchar *filename) {
+  g_return_val_if_fail(GLIDE_IS_ASDF(self), FALSE);
+  gchar *text = asdf_to_string(self);
+  gboolean ok = g_file_set_contents(filename, text, -1, NULL);
+  g_free(text);
+  return ok;
+}
+

--- a/src/asdf.h
+++ b/src/asdf.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define ASDF_TYPE (asdf_get_type())
+G_DECLARE_FINAL_TYPE(Asdf, asdf, GLIDE, ASDF, GObject)
+
+Asdf *asdf_new(void);
+Asdf *asdf_new_from_file(const gchar *filename);
+const gchar *asdf_get_filename(Asdf *self);
+const gchar *asdf_get_pathname(Asdf *self);
+void asdf_set_pathname(Asdf *self, const gchar *pathname);
+void asdf_set_serial(Asdf *self, gboolean serial);
+gboolean asdf_get_serial(Asdf *self);
+void asdf_add_component(Asdf *self, const gchar *file);
+const gchar *asdf_get_component(Asdf *self, guint index);
+guint asdf_get_component_count(Asdf *self);
+void asdf_add_dependency(Asdf *self, const gchar *dep);
+const gchar *asdf_get_dependency(Asdf *self, guint index);
+guint asdf_get_dependency_count(Asdf *self);
+char *asdf_to_string(Asdf *self);
+gboolean asdf_save(Asdf *self, const gchar *filename);
+
+G_END_DECLS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0`
-TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test
+TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test asdf_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -25,6 +25,9 @@ lisp_parser_test: lisp_parser_test.c lisp_parser.c string_text_provider.c text_p
 project_test: project_test.c project.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
+asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_parser.c project.c
+	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
 run: all
 	./preferences_test
 	./process_test
@@ -32,6 +35,7 @@ run: all
 	./swank_session_test
 	./lisp_parser_test
 	./project_test
+	./asdf_test
 
 clean:
 	rm -f $(CLEANABLES)

--- a/tests/asdf_test.c
+++ b/tests/asdf_test.c
@@ -1,0 +1,68 @@
+#include "asdf.h"
+#include <glib.h>
+#include <glib/gstdio.h>
+
+static void test_parse(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("asdf-test-XXXXXX", NULL);
+  gchar *file = g_build_filename(tmpdir, "foo.asd", NULL);
+  const gchar *contents = "(defsystem \"foo\"\n  :serial t\n  :pathname \"bar/\"\n  :components ((file \"a\") (file \"b\"))\n  :depends-on (\"dep1\" \"dep2\"))";
+  g_file_set_contents(file, contents, -1, NULL);
+
+  Asdf *asdf = asdf_new_from_file(file);
+  g_assert_cmpstr(asdf_get_pathname(asdf), ==, "bar/");
+  g_assert_true(asdf_get_serial(asdf));
+  g_assert_cmpuint(asdf_get_component_count(asdf), ==, 2);
+  g_assert_cmpstr(asdf_get_component(asdf, 0), ==, "a");
+  g_assert_cmpstr(asdf_get_component(asdf, 1), ==, "b");
+  g_assert_cmpuint(asdf_get_dependency_count(asdf), ==, 2);
+  g_assert_cmpstr(asdf_get_dependency(asdf, 0), ==, "dep1");
+  g_assert_cmpstr(asdf_get_dependency(asdf, 1), ==, "dep2");
+
+  gchar *str = asdf_to_string(asdf);
+  g_assert_nonnull(strstr(str, "pathname \"bar/\""));
+  g_free(str);
+
+  g_object_unref(asdf);
+  g_remove(file);
+  g_rmdir(tmpdir);
+  g_free(file);
+  g_free(tmpdir);
+}
+
+static void test_save(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("asdf-test-XXXXXX", NULL);
+  gchar *out = g_build_filename(tmpdir, "out.asd", NULL);
+
+  Asdf *asdf = asdf_new();
+  asdf_set_pathname(asdf, "bar/");
+  asdf_set_serial(asdf, TRUE);
+  asdf_add_component(asdf, "a");
+  asdf_add_component(asdf, "b");
+  asdf_add_dependency(asdf, "dep1");
+  asdf_add_dependency(asdf, "dep2");
+
+  g_assert_true(asdf_save(asdf, out));
+  g_assert_true(g_file_test(out, G_FILE_TEST_EXISTS));
+
+  gchar *contents = NULL;
+  g_file_get_contents(out, &contents, NULL, NULL);
+  g_assert_nonnull(contents);
+  g_assert_nonnull(strstr(contents, "(defsystem \"system\""));
+  g_free(contents);
+
+  g_object_unref(asdf);
+  g_remove(out);
+  g_rmdir(tmpdir);
+  g_free(out);
+  g_free(tmpdir);
+}
+
+int main(int argc, char *argv[])
+{
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/asdf/parse", test_parse);
+  g_test_add_func("/asdf/save", test_save);
+  return g_test_run();
+}


### PR DESCRIPTION
## Summary
- implement Asdf parser using existing LispParser
- add `unquote` helper and rewrite parser to avoid regexes
- split `asdf_test` into parse and save tests
- switch Asdf parser to consume the LispParser AST

## Testing
- `make -C tests asdf_test`
- `./tests/asdf_test`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_687bc4cdabcc832895b777ac0153d279