### PR TITLE
Refine Lisp parser atom handling

### DIFF
--- a/src/asdf.c
+++ b/src/asdf.c
@@ -139,7 +139,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
     if (child->type != LISP_AST_NODE_TYPE_LIST || child->children->len < 2)
       continue;
     const LispAstNode *head = g_array_index(child->children, LispAstNode*, 0);
-    if (head->type == LISP_AST_NODE_TYPE_ATOM &&
+    if (head->type == LISP_AST_NODE_TYPE_SYMBOL &&
         g_strcmp0(head->start_token->text, "defsystem") == 0) {
       defsystem = child;
       break;
@@ -152,7 +152,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
   for (guint i = 2; i + 1 < defsystem->children->len; i += 2) {
     const LispAstNode *key = g_array_index(defsystem->children, LispAstNode*, i);
     const LispAstNode *val = g_array_index(defsystem->children, LispAstNode*, i + 1);
-    if (key->type != LISP_AST_NODE_TYPE_ATOM)
+    if (key->type != LISP_AST_NODE_TYPE_SYMBOL)
       continue;
     const gchar *kw = key->start_token->text;
 
@@ -161,7 +161,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
       asdf_set_pathname(self, p);
       g_free(p);
     } else if (g_strcmp0(kw, ":serial") == 0) {
-      if (val->type == LISP_AST_NODE_TYPE_ATOM)
+      if (val->type == LISP_AST_NODE_TYPE_SYMBOL || val->type == LISP_AST_NODE_TYPE_NUMBER)
         self->serial = g_strcmp0(val->start_token->text, "t") == 0 ||
           g_strcmp0(val->start_token->text, "1") == 0;
     } else if (g_strcmp0(kw, ":components") == 0) {
@@ -172,7 +172,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
             continue;
           const LispAstNode *sym = g_array_index(comp->children, LispAstNode*, 0);
           const LispAstNode *fname = g_array_index(comp->children, LispAstNode*, 1);
-          if (sym->type == LISP_AST_NODE_TYPE_ATOM &&
+          if (sym->type == LISP_AST_NODE_TYPE_SYMBOL &&
               g_strcmp0(sym->start_token->text, "file") == 0) {
             gchar *f = unquote(fname->start_token->text);
             asdf_add_component(self, f);

--- a/src/lisp_parser.h
+++ b/src/lisp_parser.h
@@ -10,7 +10,8 @@ typedef struct _LispParser LispParser;
 
 // Enum for different types of tokens
 typedef enum {
-    LISP_TOKEN_TYPE_ATOM,
+    LISP_TOKEN_TYPE_NUMBER,
+    LISP_TOKEN_TYPE_SYMBOL,
     LISP_TOKEN_TYPE_LIST_START,     // (
     LISP_TOKEN_TYPE_LIST_END,       // )
     LISP_TOKEN_TYPE_STRING,
@@ -30,7 +31,8 @@ typedef struct {
 
 // Enum for AST node types
 typedef enum {
-    LISP_AST_NODE_TYPE_ATOM,
+    LISP_AST_NODE_TYPE_NUMBER,
+    LISP_AST_NODE_TYPE_SYMBOL,
     LISP_AST_NODE_TYPE_LIST,
     LISP_AST_NODE_TYPE_STRING,
     // Comments and whitespace are not typically included in the AST

--- a/src/lisp_parser_view.c
+++ b/src/lisp_parser_view.c
@@ -63,7 +63,8 @@ node_type_to_string(LispAstNodeType type)
 {
   switch(type)
   {
-    case LISP_AST_NODE_TYPE_ATOM: return "Atom";
+    case LISP_AST_NODE_TYPE_NUMBER: return "Number";
+    case LISP_AST_NODE_TYPE_SYMBOL: return "Symbol";
     case LISP_AST_NODE_TYPE_LIST: return "List";
     case LISP_AST_NODE_TYPE_STRING: return "String";
     default: return "Unknown";

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -25,20 +25,38 @@ static void test_empty_file(void)
   lisp_parser_free(parser);
 }
 
-static void test_atom_symbol(void)
+static void test_symbol(void)
 {
   LispParser *parser = parser_from_text("foo");
 
   guint n_tokens = 0;
   const LispToken *tokens = lisp_parser_get_tokens(parser, &n_tokens);
   g_assert_cmpint(n_tokens, ==, 1);
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_ATOM);
+  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_SYMBOL);
 
   const LispAstNode *ast = lisp_parser_get_ast(parser);
   g_assert_cmpint(ast->children->len, ==, 1);
   const LispAstNode *child = g_array_index(ast->children, LispAstNode*, 0);
-  g_assert_cmpint(child->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpint(child->type, ==, LISP_AST_NODE_TYPE_SYMBOL);
   g_assert_cmpstr(child->start_token->text, ==, "foo");
+
+  lisp_parser_free(parser);
+}
+
+static void test_number(void)
+{
+  LispParser *parser = parser_from_text("42");
+
+  guint n_tokens = 0;
+  const LispToken *tokens = lisp_parser_get_tokens(parser, &n_tokens);
+  g_assert_cmpint(n_tokens, ==, 1);
+  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_NUMBER);
+
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const LispAstNode *child = g_array_index(ast->children, LispAstNode*, 0);
+  g_assert_cmpint(child->type, ==, LISP_AST_NODE_TYPE_NUMBER);
+  g_assert_cmpstr(child->start_token->text, ==, "42");
 
   lisp_parser_free(parser);
 }
@@ -88,9 +106,9 @@ static void test_list_with_elements(void)
 
   const LispAstNode *a = g_array_index(list->children, LispAstNode*, 0);
   const LispAstNode *b = g_array_index(list->children, LispAstNode*, 1);
-  g_assert_cmpint(a->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpint(a->type, ==, LISP_AST_NODE_TYPE_SYMBOL);
   g_assert_cmpstr(a->start_token->text, ==, "a");
-  g_assert_cmpint(b->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpint(b->type, ==, LISP_AST_NODE_TYPE_SYMBOL);
   g_assert_cmpstr(b->start_token->text, ==, "b");
 
   lisp_parser_free(parser);
@@ -109,9 +127,9 @@ static void test_missing_closing_paren(void)
 
   const LispAstNode *a = g_array_index(list->children, LispAstNode*, 0);
   const LispAstNode *b = g_array_index(list->children, LispAstNode*, 1);
-  g_assert_cmpint(a->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpint(a->type, ==, LISP_AST_NODE_TYPE_SYMBOL);
   g_assert_cmpstr(a->start_token->text, ==, "a");
-  g_assert_cmpint(b->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpint(b->type, ==, LISP_AST_NODE_TYPE_SYMBOL);
   g_assert_cmpstr(b->start_token->text, ==, "b");
 
   lisp_parser_free(parser);
@@ -151,7 +169,8 @@ int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/lisp_parser/empty_file", test_empty_file);
-  g_test_add_func("/lisp_parser/atom_symbol", test_atom_symbol);
+  g_test_add_func("/lisp_parser/symbol", test_symbol);
+  g_test_add_func("/lisp_parser/number", test_number);
   g_test_add_func("/lisp_parser/atom_string", test_atom_string);
   g_test_add_func("/lisp_parser/empty_list", test_empty_list);
   g_test_add_func("/lisp_parser/list_with_elements", test_list_with_elements);


### PR DESCRIPTION
## Summary
- Distinguish numbers and symbols in token and AST types
- Update parser logic, view, and ASDF handling for new node types
- Expand parser tests to cover numbers and symbols
- Clarify comment for symbol/number tokenization branch

## Testing
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_688fdab650a48328beb411cc78a7e853