### PR TITLE
Use lisp lexer/parser in swank session

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ process_test: process_test.c process.c real_process.c
 swank_process_test: swank_process_test.c swank_process.c real_swank_process.c process.c preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c
+swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c


### PR DESCRIPTION
## Summary
- replace ad hoc message parser in RealSwankSession with lisp_lexer/lisp_parser
- adjust tests Makefile for new parser dependencies

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_6893bbba7b508328b0fc23fbef9da511