### PR TITLE
Expose token arrays via GArray

### DIFF
--- a/src/asdf.c
+++ b/src/asdf.c
@@ -130,9 +130,8 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
   LispLexer *lexer = lisp_lexer_new(provider);
   lisp_lexer_lex(lexer);
   LispParser *parser = lisp_parser_new();
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(lexer, &n_tokens);
-  lisp_parser_parse(parser, tokens, n_tokens);
+  GArray *tokens = lisp_lexer_get_tokens(lexer);
+  lisp_parser_parse(parser, tokens);
 
   const LispAstNode *ast = lisp_parser_get_ast(parser);
   if (!ast)

--- a/src/lisp_lexer.c
+++ b/src/lisp_lexer.c
@@ -118,9 +118,7 @@ void lisp_lexer_lex(LispLexer *lexer) {
   }
 }
 
-const LispToken *lisp_lexer_get_tokens(LispLexer *lexer, guint *n_tokens) {
+GArray *lisp_lexer_get_tokens(LispLexer *lexer) {
   g_return_val_if_fail(lexer != NULL, NULL);
-  if (n_tokens)
-    *n_tokens = lexer->tokens ? lexer->tokens->len : 0;
-  return lexer->tokens ? (const LispToken*)lexer->tokens->data : NULL;
+  return lexer->tokens;
 }

--- a/src/lisp_lexer.h
+++ b/src/lisp_lexer.h
@@ -28,6 +28,6 @@ typedef struct {
 LispLexer *lisp_lexer_new(TextProvider *provider);
 void lisp_lexer_free(LispLexer *lexer);
 void lisp_lexer_lex(LispLexer *lexer);
-const LispToken *lisp_lexer_get_tokens(LispLexer *lexer, guint *n_tokens);
+GArray *lisp_lexer_get_tokens(LispLexer *lexer);
 
 G_END_DECLS

--- a/src/lisp_parser.h
+++ b/src/lisp_parser.h
@@ -48,12 +48,11 @@ void lisp_parser_free(LispParser *parser);
 /**
  * lisp_parser_parse:
  * @parser: The LispParser instance.
- * @tokens: (array length=n_tokens): The tokens to parse.
- * @n_tokens: The number of tokens.
+ * @tokens: (nullable): The tokens to parse.
  *
  * Parses the provided tokens and builds a new AST. Any existing AST is destroyed.
  */
-void lisp_parser_parse(LispParser *parser, const LispToken *tokens, guint n_tokens);
+void lisp_parser_parse(LispParser *parser, GArray *tokens);
 
 /**
  * lisp_parser_get_ast:

--- a/src/project.c
+++ b/src/project.c
@@ -159,9 +159,8 @@ void project_file_changed(Project * /*self*/, ProjectFile *file) {
   if (!file->lexer || !file->parser)
     return;
   lisp_lexer_lex(file->lexer);
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(file->lexer, &n_tokens);
-  lisp_parser_parse(file->parser, tokens, n_tokens);
+  GArray *tokens = lisp_lexer_get_tokens(file->lexer);
+  lisp_parser_parse(file->parser, tokens);
 }
 
 LispParser *project_file_get_parser(ProjectFile *file) {

--- a/src/real_swank_session.c
+++ b/src/real_swank_session.c
@@ -281,10 +281,9 @@ real_swank_session_handle_message(gpointer data)
   TextProvider *provider = string_text_provider_new(msg->str);
   LispLexer *lexer = lisp_lexer_new(provider);
   lisp_lexer_lex(lexer);
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(lexer, &n_tokens);
+  GArray *tokens = lisp_lexer_get_tokens(lexer);
   LispParser *parser = lisp_parser_new();
-  lisp_parser_parse(parser, tokens, n_tokens);
+  lisp_parser_parse(parser, tokens);
   const LispAstNode *ast = lisp_parser_get_ast(parser);
 
   if (ast && ast->children && ast->children->len > 0) {

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -14,9 +14,8 @@ static ParserFixture parser_fixture_from_text(const gchar *text) {
   fixture.lexer = lisp_lexer_new(provider);
   lisp_lexer_lex(fixture.lexer);
   fixture.parser = lisp_parser_new();
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  lisp_parser_parse(fixture.parser, tokens, n_tokens);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  lisp_parser_parse(fixture.parser, tokens);
   g_object_unref(provider);
   return fixture;
 }
@@ -29,9 +28,8 @@ static void parser_fixture_free(ParserFixture *fixture) {
 static void test_empty_file(void) {
   ParserFixture fixture = parser_fixture_from_text("");
 
-  guint n_tokens = 0;
-  lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 0);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  g_assert_cmpint(tokens->len, ==, 0);
 
   const LispAstNode *ast = lisp_parser_get_ast(fixture.parser);
   g_assert_cmpint(ast->children->len, ==, 0);
@@ -42,10 +40,10 @@ static void test_empty_file(void) {
 static void test_symbol(void) {
   ParserFixture fixture = parser_fixture_from_text("foo");
 
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 1);
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_SYMBOL);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  g_assert_cmpint(tokens->len, ==, 1);
+  const LispToken *token = &g_array_index(tokens, LispToken, 0);
+  g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_SYMBOL);
 
   const LispAstNode *ast = lisp_parser_get_ast(fixture.parser);
   g_assert_cmpint(ast->children->len, ==, 1);
@@ -59,10 +57,10 @@ static void test_symbol(void) {
 static void test_number(void) {
   ParserFixture fixture = parser_fixture_from_text("42");
 
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 1);
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_NUMBER);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  g_assert_cmpint(tokens->len, ==, 1);
+  const LispToken *token = &g_array_index(tokens, LispToken, 0);
+  g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_NUMBER);
 
   const LispAstNode *ast = lisp_parser_get_ast(fixture.parser);
   g_assert_cmpint(ast->children->len, ==, 1);
@@ -76,10 +74,10 @@ static void test_number(void) {
 static void test_atom_string(void) {
   ParserFixture fixture = parser_fixture_from_text("\"bar\"");
 
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 1);
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_STRING);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  g_assert_cmpint(tokens->len, ==, 1);
+  const LispToken *token = &g_array_index(tokens, LispToken, 0);
+  g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_STRING);
 
   const LispAstNode *ast = lisp_parser_get_ast(fixture.parser);
   g_assert_cmpint(ast->children->len, ==, 1);
@@ -146,10 +144,10 @@ static void test_missing_closing_paren(void) {
 static void test_extra_closing_paren(void) {
   ParserFixture fixture = parser_fixture_from_text(")");
 
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 1);
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_LIST_END);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  g_assert_cmpint(tokens->len, ==, 1);
+  const LispToken *token = &g_array_index(tokens, LispToken, 0);
+  g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_LIST_END);
 
   const LispAstNode *ast = lisp_parser_get_ast(fixture.parser);
   g_assert_cmpint(ast->children->len, ==, 0);
@@ -160,10 +158,10 @@ static void test_extra_closing_paren(void) {
 static void test_comment(void) {
   ParserFixture fixture = parser_fixture_from_text("; a comment\n");
 
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(fixture.lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 2);
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_COMMENT);
+  GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
+  g_assert_cmpint(tokens->len, ==, 2);
+  const LispToken *token = &g_array_index(tokens, LispToken, 0);
+  g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_COMMENT);
 
   const LispAstNode *ast = lisp_parser_get_ast(fixture.parser);
   g_assert_cmpint(ast->children->len, ==, 0);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -23,10 +23,10 @@ static void test_parse_on_change(void)
   /* file already parsed by project_add_file */
   LispParser *parser = project_file_get_parser(file);
   LispLexer *lexer = project_file_get_lexer(file);
-  guint n_tokens = 0;
-  const LispToken *tokens = lisp_lexer_get_tokens(lexer, &n_tokens);
-  g_assert_cmpint(n_tokens, ==, 3); /* (, a, ) */
-  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_LIST_START);
+  GArray *tokens = lisp_lexer_get_tokens(lexer);
+  g_assert_cmpint(tokens->len, ==, 3); /* (, a, ) */
+  const LispToken *token = &g_array_index(tokens, LispToken, 0);
+  g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_LIST_START);
   project_file_changed(project, file); /* should still parse without error */
   const LispAstNode *ast = lisp_parser_get_ast(parser);
   g_assert_cmpint(ast->children->len, ==, 1);


### PR DESCRIPTION
## Summary
- Return a `GArray` of `LispToken` from the lexer instead of a pointer/length pair
- Parse tokens from a `GArray` in the Lisp parser and update all call sites
- Adjust tests and project code to use `GArray->len` for token counts

## Testing
- `make -C tests`
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_6893d08460ec8328b76470bbc7b50d28