### PR TITLE
Add NodeInfo structure for AST nodes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,7 @@ SOURCES += \
   lisp_source_view.c \
   lisp_lexer.c \
   lisp_parser.c \
+  node_info.c \
   lisp_parser_view.c \
   project.c \
   gtk_text_provider.c \

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "gtk_text_provider.c"
 #include "interactions_view.c"
 #include "lisp_lexer.c"
+#include "node_info.c"
 #include "lisp_parser.c"
 #include "lisp_source_notebook.c"
 #include "lisp_source_view.c"

--- a/src/node_info.c
+++ b/src/node_info.c
@@ -1,0 +1,45 @@
+#include "node_info.h"
+
+static void var_use_info_finalize(NodeInfo *ni) {
+  VarUseInfo *s = VAR_USE_INFO(ni);
+  if (s->var) variable_info_unref(s->var);
+}
+
+static void var_def_info_finalize(NodeInfo *ni) {
+  VarDefInfo *s = VAR_DEF_INFO(ni);
+  if (s->var) variable_info_unref(s->var);
+}
+
+static void struct_field_info_finalize(NodeInfo *ni) {
+  StructFieldInfo *s = STRUCT_FIELD_INFO(ni);
+  g_clear_pointer(&s->field_name, g_free);
+  if (s->methods) {
+    for (guint i = 0; i < s->methods->len; i++) {
+      FunctionInfo *fn = g_ptr_array_index(s->methods, i);
+      function_info_unref(fn);
+    }
+    g_ptr_array_free(s->methods, TRUE);
+  }
+}
+
+VarUseInfo *var_use_info_new(VariableInfo *var) {
+  VarUseInfo *s = g_new0(VarUseInfo, 1);
+  node_info_init(&s->base, NODE_INFO_VAR_USE, var_use_info_finalize);
+  s->var = var ? variable_info_ref(var) : NULL;
+  return s;
+}
+
+VarDefInfo *var_def_info_new(VariableInfo *var_new) {
+  VarDefInfo *s = g_new0(VarDefInfo, 1);
+  node_info_init(&s->base, NODE_INFO_VAR_DEF, var_def_info_finalize);
+  s->var = var_new ? variable_info_ref(var_new) : NULL;
+  return s;
+}
+
+StructFieldInfo *struct_field_info_new(const gchar *field_name) {
+  StructFieldInfo *s = g_new0(StructFieldInfo, 1);
+  node_info_init(&s->base, NODE_INFO_STRUCT_FIELD, struct_field_info_finalize);
+  s->field_name = field_name ? g_strdup(field_name) : NULL;
+  s->methods = g_ptr_array_new();
+  return s;
+}

--- a/src/node_info.h
+++ b/src/node_info.h
@@ -1,0 +1,75 @@
+#ifndef NODE_INFO_H
+#define NODE_INFO_H
+
+#include <glib.h>
+
+typedef enum {
+  NODE_INFO_NONE = 0,
+  NODE_INFO_VAR_DEF,
+  NODE_INFO_VAR_USE,
+  NODE_INFO_FUNCTION_DEF,
+  NODE_INFO_FUNCTION_USE,
+  NODE_INFO_STRUCT_FIELD,
+} NodeInfoKind;
+
+typedef struct NodeInfo {
+  NodeInfoKind kind;
+  gint         ref;
+  void       (*finalize)(struct NodeInfo *self);
+} NodeInfo;
+
+static inline void node_info_init(NodeInfo *ni, NodeInfoKind kind,
+                                  void (*finalize)(NodeInfo*)) {
+  ni->kind = kind;
+  g_atomic_int_set(&ni->ref, 1);
+  ni->finalize = finalize;
+}
+
+static inline NodeInfo *node_info_ref(NodeInfo *ni) {
+  g_atomic_int_inc(&ni->ref);
+  return ni;
+}
+
+static inline void node_info_unref(NodeInfo *ni) {
+  if (g_atomic_int_dec_and_test(&ni->ref)) {
+    if (ni->finalize) ni->finalize(ni);
+    g_free(ni);
+  }
+}
+
+typedef struct VariableInfo VariableInfo;
+typedef struct FunctionInfo  FunctionInfo;
+typedef struct StructFieldInfo StructFieldInfo;
+
+VariableInfo *variable_info_ref(VariableInfo *var);
+void variable_info_unref(VariableInfo *var);
+void function_info_unref(FunctionInfo *fn);
+
+typedef struct {
+  NodeInfo base;
+  VariableInfo *var;
+} VarUseInfo;
+
+typedef struct {
+  NodeInfo base;
+  VariableInfo *var;
+} VarDefInfo;
+
+struct StructFieldInfo {
+  NodeInfo base;
+  gchar *field_name;
+  GPtrArray *methods;
+};
+
+static inline gboolean node_info_is(const NodeInfo *ni, NodeInfoKind k) {
+  return ni && ni->kind == k;
+}
+#define VAR_USE_INFO(ni)    ((VarUseInfo*)(ni))
+#define VAR_DEF_INFO(ni)    ((VarDefInfo*)(ni))
+#define STRUCT_FIELD_INFO(ni) ((StructFieldInfo*)(ni))
+
+VarUseInfo *var_use_info_new(VariableInfo *var);
+VarDefInfo *var_def_info_new(VariableInfo *var_new);
+StructFieldInfo *struct_field_info_new(const gchar *field_name);
+
+#endif // NODE_INFO_H


### PR DESCRIPTION
## Summary
- Introduce `NodeInfo` with reference counting and kind enum
- Provide VarUseInfo, VarDefInfo, and StructFieldInfo helpers
- Include node_info module in main inline build and Makefile

## Testing
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_689f50f7ae0c83288b3ed6cf8f40f9b5