### PR TITLE
Add NodeInfo inheritance helpers and safe downcasts

### DIFF
--- a/src/node_info.c
+++ b/src/node_info.c
@@ -1,13 +1,58 @@
 #include "node_info.h"
 
+struct FunctionInfo {
+  NodeInfo base;
+};
+
+VariableInfo *variable_info_new(void) {
+  VariableInfo *var = g_new0(VariableInfo, 1);
+  g_atomic_int_set(&var->ref, 1);
+  var->usages = g_ptr_array_new();
+  return var;
+}
+
+VariableInfo *variable_info_ref(VariableInfo *var) {
+  if (!var) return NULL;
+  g_atomic_int_inc(&var->ref);
+  return var;
+}
+
+void variable_info_unref(VariableInfo *var) {
+  if (!var) return;
+  if (g_atomic_int_dec_and_test(&var->ref)) {
+    if (var->usages)
+      g_ptr_array_free(var->usages, TRUE);
+    g_free(var);
+  }
+}
+
+FunctionInfo *function_info_ref(FunctionInfo *fn) {
+  if (!fn) return NULL;
+  node_info_ref(&fn->base);
+  return fn;
+}
+
+void function_info_unref(FunctionInfo *fn) {
+  if (!fn) return;
+  node_info_unref(&fn->base);
+}
+
 static void var_use_info_finalize(NodeInfo *ni) {
   VarUseInfo *s = VAR_USE_INFO(ni);
-  if (s->var) variable_info_unref(s->var);
+  if (s->var) {
+    if (s->var->usages)
+      g_ptr_array_remove(s->var->usages, s);
+    variable_info_unref(s->var);
+  }
 }
 
 static void var_def_info_finalize(NodeInfo *ni) {
   VarDefInfo *s = VAR_DEF_INFO(ni);
-  if (s->var) variable_info_unref(s->var);
+  if (s->var) {
+    if (s->var->definition == s)
+      s->var->definition = NULL;
+    variable_info_unref(s->var);
+  }
 }
 
 static void struct_field_info_finalize(NodeInfo *ni) {
@@ -26,6 +71,8 @@ VarUseInfo *var_use_info_new(VariableInfo *var) {
   VarUseInfo *s = g_new0(VarUseInfo, 1);
   node_info_init(&s->base, NODE_INFO_VAR_USE, var_use_info_finalize);
   s->var = var ? variable_info_ref(var) : NULL;
+  if (var && var->usages)
+    g_ptr_array_add(var->usages, s);
   return s;
 }
 
@@ -33,6 +80,8 @@ VarDefInfo *var_def_info_new(VariableInfo *var_new) {
   VarDefInfo *s = g_new0(VarDefInfo, 1);
   node_info_init(&s->base, NODE_INFO_VAR_DEF, var_def_info_finalize);
   s->var = var_new ? variable_info_ref(var_new) : NULL;
+  if (var_new)
+    var_new->definition = s;
   return s;
 }
 

--- a/src/node_info.h
+++ b/src/node_info.h
@@ -37,23 +37,31 @@ static inline void node_info_unref(NodeInfo *ni) {
   }
 }
 
-typedef struct VariableInfo VariableInfo;
-typedef struct FunctionInfo  FunctionInfo;
+typedef struct VarUseInfo VarUseInfo;
+typedef struct VarDefInfo VarDefInfo;
+typedef struct VariableInfo {
+  gint ref;
+  VarDefInfo *definition;
+  GPtrArray *usages; /* VarUseInfo* */
+} VariableInfo;
+typedef struct FunctionInfo FunctionInfo;
 typedef struct StructFieldInfo StructFieldInfo;
 
+VariableInfo *variable_info_new(void);
 VariableInfo *variable_info_ref(VariableInfo *var);
 void variable_info_unref(VariableInfo *var);
+FunctionInfo *function_info_ref(FunctionInfo *fn);
 void function_info_unref(FunctionInfo *fn);
 
-typedef struct {
+struct VarUseInfo {
   NodeInfo base;
   VariableInfo *var;
-} VarUseInfo;
+};
 
-typedef struct {
+struct VarDefInfo {
   NodeInfo base;
   VariableInfo *var;
-} VarDefInfo;
+};
 
 struct StructFieldInfo {
   NodeInfo base;
@@ -64,9 +72,12 @@ struct StructFieldInfo {
 static inline gboolean node_info_is(const NodeInfo *ni, NodeInfoKind k) {
   return ni && ni->kind == k;
 }
-#define VAR_USE_INFO(ni)    ((VarUseInfo*)(ni))
-#define VAR_DEF_INFO(ni)    ((VarDefInfo*)(ni))
-#define STRUCT_FIELD_INFO(ni) ((StructFieldInfo*)(ni))
+#define VAR_USE_INFO(ni) \
+  (node_info_is((NodeInfo*)(ni), NODE_INFO_VAR_USE) ? (VarUseInfo*)(ni) : NULL)
+#define VAR_DEF_INFO(ni) \
+  (node_info_is((NodeInfo*)(ni), NODE_INFO_VAR_DEF) ? (VarDefInfo*)(ni) : NULL)
+#define STRUCT_FIELD_INFO(ni) \
+  (node_info_is((NodeInfo*)(ni), NODE_INFO_STRUCT_FIELD) ? (StructFieldInfo*)(ni) : NULL)
 
 VarUseInfo *var_use_info_new(VariableInfo *var);
 VarDefInfo *var_def_info_new(VariableInfo *var_new);


### PR DESCRIPTION
## Summary
- add reference counting helpers for `VariableInfo` and `FunctionInfo`
- check node types in downcast macros
- represent `VariableInfo` independently from `NodeInfo` with definition and usage tracking

## Testing
- `make -C src app-full`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_689fa4f3f254832886a3e51d0dd3aba1