### PR TITLE
refactor: flatten NodeInfo structure

### DIFF
--- a/src/analyser.c
+++ b/src/analyser.c
@@ -9,20 +9,14 @@ static void analyse_node(LispAstNode *node) {
     if (node->children->len > 0) {
       LispAstNode *first = g_array_index(node->children, LispAstNode*, 0);
       if (first->type == LISP_AST_NODE_TYPE_SYMBOL) {
-        if (!first->node_info) {
-          NodeInfo *ni = g_new0(NodeInfo, 1);
-          node_info_init(ni, NODE_INFO_FUNCTION_USE, NULL);
-          first->node_info = ni;
-        }
+        if (!first->node_info)
+          first->node_info = node_info_new(NODE_INFO_FUNCTION_USE);
         if (first->start_token && first->start_token->text &&
             g_ascii_strcasecmp(first->start_token->text, "defun") == 0 &&
             node->children->len > 1) {
           LispAstNode *name = g_array_index(node->children, LispAstNode*, 1);
-          if (name->type == LISP_AST_NODE_TYPE_SYMBOL && !name->node_info) {
-            NodeInfo *ni = g_new0(NodeInfo, 1);
-            node_info_init(ni, NODE_INFO_FUNCTION_DEF, NULL);
-            name->node_info = ni;
-          }
+          if (name->type == LISP_AST_NODE_TYPE_SYMBOL && !name->node_info)
+            name->node_info = node_info_new(NODE_INFO_FUNCTION_DEF);
         }
       }
     }

--- a/src/node_info.c
+++ b/src/node_info.c
@@ -1,9 +1,5 @@
 #include "node_info.h"
 
-struct FunctionInfo {
-  NodeInfo base;
-};
-
 VariableInfo *variable_info_new(void) {
   VariableInfo *var = g_new0(VariableInfo, 1);
   g_atomic_int_set(&var->ref, 1);
@@ -28,69 +24,74 @@ void variable_info_unref(VariableInfo *var) {
 
 FunctionInfo *function_info_ref(FunctionInfo *fn) {
   if (!fn) return NULL;
-  node_info_ref(&fn->base);
+  node_info_ref(fn);
   return fn;
 }
 
 void function_info_unref(FunctionInfo *fn) {
   if (!fn) return;
-  node_info_unref(&fn->base);
+  node_info_unref(fn);
 }
 
-static void var_use_info_finalize(NodeInfo *ni) {
-  VarUseInfo *s = VAR_USE_INFO(ni);
-  if (s->var) {
-    if (s->var->usages)
-      g_ptr_array_remove(s->var->usages, s);
-    variable_info_unref(s->var);
-  }
+NodeInfo *node_info_new(NodeInfoKind kind) {
+  NodeInfo *ni = g_new0(NodeInfo, 1);
+  ni->kind = kind;
+  g_atomic_int_set(&ni->ref, 1);
+  return ni;
 }
 
-static void var_def_info_finalize(NodeInfo *ni) {
-  VarDefInfo *s = VAR_DEF_INFO(ni);
-  if (s->var) {
-    if (s->var->definition == s)
-      s->var->definition = NULL;
-    variable_info_unref(s->var);
-  }
-}
-
-static void struct_field_info_finalize(NodeInfo *ni) {
-  StructFieldInfo *s = STRUCT_FIELD_INFO(ni);
-  g_clear_pointer(&s->field_name, g_free);
-  if (s->methods) {
-    for (guint i = 0; i < s->methods->len; i++) {
-      FunctionInfo *fn = g_ptr_array_index(s->methods, i);
-      function_info_unref(fn);
-    }
-    g_ptr_array_free(s->methods, TRUE);
-  }
-}
-
-VarUseInfo *var_use_info_new(VariableInfo *var) {
-  VarUseInfo *s = g_new0(VarUseInfo, 1);
-  node_info_init(&s->base, NODE_INFO_VAR_USE, var_use_info_finalize);
-  s->var = var ? variable_info_ref(var) : NULL;
+NodeInfo *node_info_new_var_use(VariableInfo *var) {
+  NodeInfo *ni = node_info_new(NODE_INFO_VAR_USE);
+  ni->var = var ? variable_info_ref(var) : NULL;
   if (var && var->usages)
-    g_ptr_array_add(var->usages, s);
-  return s;
+    g_ptr_array_add(var->usages, ni);
+  return ni;
 }
 
-VarDefInfo *var_def_info_new(VariableInfo *var_new) {
-  VarDefInfo *s = g_new0(VarDefInfo, 1);
-  node_info_init(&s->base, NODE_INFO_VAR_DEF, var_def_info_finalize);
-  s->var = var_new ? variable_info_ref(var_new) : NULL;
+NodeInfo *node_info_new_var_def(VariableInfo *var_new) {
+  NodeInfo *ni = node_info_new(NODE_INFO_VAR_DEF);
+  ni->var = var_new ? variable_info_ref(var_new) : NULL;
   if (var_new)
-    var_new->definition = s;
-  return s;
+    var_new->definition = ni;
+  return ni;
 }
 
-StructFieldInfo *struct_field_info_new(const gchar *field_name) {
-  StructFieldInfo *s = g_new0(StructFieldInfo, 1);
-  node_info_init(&s->base, NODE_INFO_STRUCT_FIELD, struct_field_info_finalize);
-  s->field_name = field_name ? g_strdup(field_name) : NULL;
-  s->methods = g_ptr_array_new();
-  return s;
+NodeInfo *node_info_new_struct_field(const gchar *field_name) {
+  NodeInfo *ni = node_info_new(NODE_INFO_STRUCT_FIELD);
+  ni->field_name = field_name ? g_strdup(field_name) : NULL;
+  ni->methods = g_ptr_array_new();
+  return ni;
+}
+
+void node_info_finalize(NodeInfo *ni) {
+  switch (ni->kind) {
+    case NODE_INFO_VAR_USE:
+      if (ni->var) {
+        if (ni->var->usages)
+          g_ptr_array_remove(ni->var->usages, ni);
+        variable_info_unref(ni->var);
+      }
+      break;
+    case NODE_INFO_VAR_DEF:
+      if (ni->var) {
+        if (ni->var->definition == ni)
+          ni->var->definition = NULL;
+        variable_info_unref(ni->var);
+      }
+      break;
+    case NODE_INFO_STRUCT_FIELD:
+      g_clear_pointer(&ni->field_name, g_free);
+      if (ni->methods) {
+        for (guint i = 0; i < ni->methods->len; i++) {
+          FunctionInfo *fn = g_ptr_array_index(ni->methods, i);
+          function_info_unref(fn);
+        }
+        g_ptr_array_free(ni->methods, TRUE);
+      }
+      break;
+    default:
+      break;
+  }
 }
 
 const gchar *node_info_kind_to_string(NodeInfoKind kind) {
@@ -109,13 +110,12 @@ gchar *node_info_to_string(const NodeInfo *ni) {
     return NULL;
   const gchar *type = node_info_kind_to_string(ni->kind);
   switch(ni->kind) {
-    case NODE_INFO_STRUCT_FIELD: {
-      const StructFieldInfo *s = STRUCT_FIELD_INFO(ni);
-      if (s->field_name)
-        return g_strdup_printf("%s %s", type, s->field_name);
+    case NODE_INFO_STRUCT_FIELD:
+      if (ni->field_name)
+        return g_strdup_printf("%s %s", type, ni->field_name);
       return g_strdup(type);
-    }
     default:
       return g_strdup(type);
   }
 }
+

--- a/src/node_info.h
+++ b/src/node_info.h
@@ -12,40 +12,23 @@ typedef enum {
   NODE_INFO_STRUCT_FIELD,
 } NodeInfoKind;
 
-typedef struct NodeInfo {
+typedef struct VariableInfo VariableInfo;
+typedef struct NodeInfo NodeInfo;
+typedef NodeInfo FunctionInfo;
+
+struct NodeInfo {
   NodeInfoKind kind;
-  gint         ref;
-  void       (*finalize)(struct NodeInfo *self);
-} NodeInfo;
-
-static inline void node_info_init(NodeInfo *ni, NodeInfoKind kind,
-                                  void (*finalize)(NodeInfo*)) {
-  ni->kind = kind;
-  g_atomic_int_set(&ni->ref, 1);
-  ni->finalize = finalize;
-}
-
-static inline NodeInfo *node_info_ref(NodeInfo *ni) {
-  g_atomic_int_inc(&ni->ref);
-  return ni;
-}
-
-static inline void node_info_unref(NodeInfo *ni) {
-  if (g_atomic_int_dec_and_test(&ni->ref)) {
-    if (ni->finalize) ni->finalize(ni);
-    g_free(ni);
-  }
-}
-
-typedef struct VarUseInfo VarUseInfo;
-typedef struct VarDefInfo VarDefInfo;
-typedef struct VariableInfo {
   gint ref;
-  VarDefInfo *definition;
-  GPtrArray *usages; /* VarUseInfo* */
-} VariableInfo;
-typedef struct FunctionInfo FunctionInfo;
-typedef struct StructFieldInfo StructFieldInfo;
+  VariableInfo *var;
+  gchar *field_name;
+  GPtrArray *methods; /* FunctionInfo* */
+};
+
+struct VariableInfo {
+  gint ref;
+  NodeInfo *definition; /* NODE_INFO_VAR_DEF */
+  GPtrArray *usages;    /* NodeInfo* (NODE_INFO_VAR_USE) */
+};
 
 VariableInfo *variable_info_new(void);
 VariableInfo *variable_info_ref(VariableInfo *var);
@@ -53,37 +36,31 @@ void variable_info_unref(VariableInfo *var);
 FunctionInfo *function_info_ref(FunctionInfo *fn);
 void function_info_unref(FunctionInfo *fn);
 
-struct VarUseInfo {
-  NodeInfo base;
-  VariableInfo *var;
-};
+NodeInfo *node_info_new(NodeInfoKind kind);
+NodeInfo *node_info_new_var_use(VariableInfo *var);
+NodeInfo *node_info_new_var_def(VariableInfo *var_new);
+NodeInfo *node_info_new_struct_field(const gchar *field_name);
 
-struct VarDefInfo {
-  NodeInfo base;
-  VariableInfo *var;
-};
+static inline NodeInfo *node_info_ref(NodeInfo *ni) {
+  g_atomic_int_inc(&ni->ref);
+  return ni;
+}
 
-struct StructFieldInfo {
-  NodeInfo base;
-  gchar *field_name;
-  GPtrArray *methods;
-};
+void node_info_finalize(NodeInfo *ni);
+
+static inline void node_info_unref(NodeInfo *ni) {
+  if (g_atomic_int_dec_and_test(&ni->ref)) {
+    node_info_finalize(ni);
+    g_free(ni);
+  }
+}
 
 static inline gboolean node_info_is(const NodeInfo *ni, NodeInfoKind k) {
   return ni && ni->kind == k;
 }
-#define VAR_USE_INFO(ni) \
-  (node_info_is((NodeInfo*)(ni), NODE_INFO_VAR_USE) ? (VarUseInfo*)(ni) : NULL)
-#define VAR_DEF_INFO(ni) \
-  (node_info_is((NodeInfo*)(ni), NODE_INFO_VAR_DEF) ? (VarDefInfo*)(ni) : NULL)
-#define STRUCT_FIELD_INFO(ni) \
-  (node_info_is((NodeInfo*)(ni), NODE_INFO_STRUCT_FIELD) ? (StructFieldInfo*)(ni) : NULL)
-
-VarUseInfo *var_use_info_new(VariableInfo *var);
-VarDefInfo *var_def_info_new(VariableInfo *var_new);
-StructFieldInfo *struct_field_info_new(const gchar *field_name);
 
 const gchar *node_info_kind_to_string(NodeInfoKind kind);
 gchar *node_info_to_string(const NodeInfo *ni);
 
 #endif // NODE_INFO_H
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,16 +16,16 @@ process_test: process_test.c process.c real_process.c
 swank_process_test: swank_process_test.c swank_process.c real_swank_process.c process.c preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c lisp_lexer.c lisp_parser.c node_info.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node_info.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project.c analyser.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+project_test: project_test.c project.c analyser.c node_info.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c project.c analyser.c
+asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node_info.c project.c analyser.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all


### PR DESCRIPTION
## Summary
- simplify NodeInfo into a single struct with optional fields
- adjust analyzer to use new node_info_new constructor
- update tests to build with node_info.c

## Testing
- `make app-full`
- `make clean && make run` in tests


------
https://chatgpt.com/codex/tasks/task_e_68a1c5ca38608328b62e5b4a36f5ca93