### PR TITLE
Add Package class and package node info

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,7 @@ SOURCES += \
   lisp_lexer.c \
   lisp_parser.c \
   analyser.c \
+  package.c \
   node_info.c \
   lisp_parser_view.c \
   project.c \

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "gtk_text_provider.c"
 #include "interactions_view.c"
 #include "lisp_lexer.c"
+#include "package.c"
 #include "node_info.c"
 #include "lisp_parser.c"
 #include "analyser.c"

--- a/src/node_info.c
+++ b/src/node_info.c
@@ -1,4 +1,5 @@
 #include "node_info.h"
+#include "package.h"
 
 VariableInfo *variable_info_new(void) {
   VariableInfo *var = g_new0(VariableInfo, 1);
@@ -63,6 +64,12 @@ NodeInfo *node_info_new_struct_field(const gchar *field_name) {
   return ni;
 }
 
+NodeInfo *node_info_new_package_def(Package *package) {
+  NodeInfo *ni = node_info_new(NODE_INFO_PACKAGE_DEF);
+  ni->package = package ? package_ref(package) : NULL;
+  return ni;
+}
+
 void node_info_finalize(NodeInfo *ni) {
   switch (ni->kind) {
     case NODE_INFO_VAR_USE:
@@ -78,6 +85,10 @@ void node_info_finalize(NodeInfo *ni) {
           ni->var->definition = NULL;
         variable_info_unref(ni->var);
       }
+      break;
+    case NODE_INFO_PACKAGE_DEF:
+      if (ni->package)
+        package_unref(ni->package);
       break;
     case NODE_INFO_STRUCT_FIELD:
       g_clear_pointer(&ni->field_name, g_free);
@@ -100,6 +111,7 @@ const gchar *node_info_kind_to_string(NodeInfoKind kind) {
     case NODE_INFO_VAR_USE: return "VarUse";
     case NODE_INFO_FUNCTION_DEF: return "FunctionDef";
     case NODE_INFO_FUNCTION_USE: return "FunctionUse";
+    case NODE_INFO_PACKAGE_DEF: return "PackageDef";
     case NODE_INFO_STRUCT_FIELD: return "StructField";
     default: return "None";
   }

--- a/src/node_info.h
+++ b/src/node_info.h
@@ -9,17 +9,20 @@ typedef enum {
   NODE_INFO_VAR_USE,
   NODE_INFO_FUNCTION_DEF,
   NODE_INFO_FUNCTION_USE,
+  NODE_INFO_PACKAGE_DEF,
   NODE_INFO_STRUCT_FIELD,
 } NodeInfoKind;
 
 typedef struct VariableInfo VariableInfo;
 typedef struct NodeInfo NodeInfo;
 typedef NodeInfo FunctionInfo;
+typedef struct Package Package;
 
 struct NodeInfo {
   NodeInfoKind kind;
   gint ref;
   VariableInfo *var;
+  Package *package;
   gchar *field_name;
   GPtrArray *methods; /* FunctionInfo* */
 };
@@ -40,6 +43,7 @@ NodeInfo *node_info_new(NodeInfoKind kind);
 NodeInfo *node_info_new_var_use(VariableInfo *var);
 NodeInfo *node_info_new_var_def(VariableInfo *var_new);
 NodeInfo *node_info_new_struct_field(const gchar *field_name);
+NodeInfo *node_info_new_package_def(Package *package);
 
 static inline NodeInfo *node_info_ref(NodeInfo *ni) {
   g_atomic_int_inc(&ni->ref);

--- a/src/package.c
+++ b/src/package.c
@@ -1,0 +1,73 @@
+#include "package.h"
+
+Package *package_new(const gchar *name) {
+  Package *package = g_new0(Package, 1);
+  g_atomic_int_set(&package->ref, 1);
+  package->name = g_strdup(name);
+  package->nicknames = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+  package->uses = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+  package->exports = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+  package->shadows = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+  package->import_from = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+  return package;
+}
+
+Package *package_ref(Package *package) {
+  if (!package) return NULL;
+  g_atomic_int_inc(&package->ref);
+  return package;
+}
+
+static void package_finalize(Package *package) {
+  g_clear_pointer(&package->name, g_free);
+  g_clear_pointer(&package->description, g_free);
+  g_clear_pointer(&package->nicknames, g_hash_table_unref);
+  g_clear_pointer(&package->uses, g_hash_table_unref);
+  g_clear_pointer(&package->exports, g_hash_table_unref);
+  g_clear_pointer(&package->shadows, g_hash_table_unref);
+  g_clear_pointer(&package->import_from, g_hash_table_unref);
+}
+
+void package_unref(Package *package) {
+  if (!package) return;
+  if (g_atomic_int_dec_and_test(&package->ref)) {
+    package_finalize(package);
+    g_free(package);
+  }
+}
+
+void package_set_description(Package *package, const gchar *description) {
+  if (!package) return;
+  g_free(package->description);
+  package->description = description ? g_strdup(description) : NULL;
+}
+
+static void package_add_to_set(GHashTable *set, const gchar *value) {
+  if (set && value)
+    g_hash_table_add(set, g_strdup(value));
+}
+
+void package_add_nickname(Package *package, const gchar *nickname) {
+  if (!package) return;
+  package_add_to_set(package->nicknames, nickname);
+}
+
+void package_add_use(Package *package, const gchar *use) {
+  if (!package) return;
+  package_add_to_set(package->uses, use);
+}
+
+void package_add_export(Package *package, const gchar *symbol) {
+  if (!package) return;
+  package_add_to_set(package->exports, symbol);
+}
+
+void package_add_shadow(Package *package, const gchar *symbol) {
+  if (!package) return;
+  package_add_to_set(package->shadows, symbol);
+}
+
+void package_add_import_from(Package *package, const gchar *symbol, const gchar *from) {
+  if (!package || !symbol || !from) return;
+  g_hash_table_insert(package->import_from, g_strdup(symbol), g_strdup(from));
+}

--- a/src/package.h
+++ b/src/package.h
@@ -1,0 +1,29 @@
+#ifndef PACKAGE_H
+#define PACKAGE_H
+
+#include <glib.h>
+
+typedef struct Package Package;
+
+struct Package {
+  gint ref;
+  gchar *name;
+  gchar *description;
+  GHashTable *nicknames;
+  GHashTable *uses;
+  GHashTable *exports;
+  GHashTable *shadows;
+  GHashTable *import_from; /* symbol -> package */
+};
+
+Package *package_new(const gchar *name);
+Package *package_ref(Package *package);
+void package_unref(Package *package);
+void package_set_description(Package *package, const gchar *description);
+void package_add_nickname(Package *package, const gchar *nickname);
+void package_add_use(Package *package, const gchar *use);
+void package_add_export(Package *package, const gchar *symbol);
+void package_add_shadow(Package *package, const gchar *symbol);
+void package_add_import_from(Package *package, const gchar *symbol, const gchar *from);
+
+#endif // PACKAGE_H

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0`
-TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test asdf_test
+TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test asdf_test package_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -16,16 +16,19 @@ process_test: process_test.c process.c real_process.c
 swank_process_test: swank_process_test.c swank_process.c real_swank_process.c process.c preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c lisp_lexer.c lisp_parser.c node_info.c string_text_provider.c text_provider.c
+swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c lisp_lexer.c lisp_parser.c node_info.c package.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node_info.c string_text_provider.c text_provider.c
+lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node_info.c package.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project.c analyser.c node_info.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+project_test: project_test.c project.c analyser.c node_info.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node_info.c project.c analyser.c
+asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node_info.c package.c project.c analyser.c
+	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
+package_test: package_test.c package.c node_info.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all
@@ -36,6 +39,7 @@ run: all
 	./lisp_parser_test
 	./project_test
 	./asdf_test
+	./package_test
 
 clean:
 	rm -f $(CLEANABLES)

--- a/tests/package_test.c
+++ b/tests/package_test.c
@@ -1,0 +1,29 @@
+#include "package.h"
+#include "node_info.h"
+#include <assert.h>
+
+int main(void) {
+  Package *package = package_new("CL-USER");
+  package_set_description(package, "desc");
+  package_add_nickname(package, "USER");
+  package_add_use(package, "COMMON-LISP");
+  package_add_export(package, "FOO");
+  package_add_shadow(package, "BAR");
+  package_add_import_from(package, "BAZ", "OTHER");
+
+  assert(g_strcmp0(package->name, "CL-USER") == 0);
+  assert(g_strcmp0(package->description, "desc") == 0);
+  assert(g_hash_table_contains(package->nicknames, "USER"));
+  assert(g_hash_table_contains(package->uses, "COMMON-LISP"));
+  assert(g_hash_table_contains(package->exports, "FOO"));
+  assert(g_hash_table_contains(package->shadows, "BAR"));
+  assert(g_strcmp0(g_hash_table_lookup(package->import_from, "BAZ"), "OTHER") == 0);
+
+  NodeInfo *node_info = node_info_new_package_def(package);
+  assert(node_info_is(node_info, NODE_INFO_PACKAGE_DEF));
+  assert(node_info->package == package);
+
+  node_info_unref(node_info);
+  package_unref(package);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement Package struct with metadata, sets, and import map
- allow NodeInfo to represent package definitions and reference a Package
- add unit test for Package and NodeInfo integration

## Testing
- `make -C src app-full`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_68a1f9abcc248328b962f3dfad07c88a