### PR TITLE
Add AST NodeInfo index to Project

### DIFF
--- a/src/lisp_source_view.c
+++ b/src/lisp_source_view.c
@@ -83,7 +83,8 @@ lisp_source_view_new_for_file (Project *project, ProjectFile *file)
   }
 
   TextProvider *provider = gtk_text_provider_new(GTK_TEXT_BUFFER(self->buffer));
-  project_file_set_provider(self->file, provider, GTK_TEXT_BUFFER(self->buffer));
+  project_file_set_provider(self->project, self->file, provider,
+      GTK_TEXT_BUFFER(self->buffer));
   g_object_unref(provider);
   g_signal_connect(self->buffer, "changed", G_CALLBACK(on_buffer_changed), self);
   return GTK_WIDGET(self);

--- a/src/node_info.h
+++ b/src/node_info.h
@@ -10,6 +10,7 @@ typedef enum {
   NODE_INFO_FUNCTION_DEF,
   NODE_INFO_FUNCTION_USE,
   NODE_INFO_PACKAGE_DEF,
+  NODE_INFO_PACKAGE_USE,
   NODE_INFO_STRUCT_FIELD,
 } NodeInfoKind;
 
@@ -17,6 +18,7 @@ typedef struct VariableInfo VariableInfo;
 typedef struct NodeInfo NodeInfo;
 typedef NodeInfo FunctionInfo;
 typedef struct Package Package;
+typedef struct _LispAstNode LispAstNode;
 
 struct NodeInfo {
   NodeInfoKind kind;
@@ -44,6 +46,7 @@ NodeInfo *node_info_new_var_use(VariableInfo *var);
 NodeInfo *node_info_new_var_def(VariableInfo *var_new);
 NodeInfo *node_info_new_struct_field(const gchar *field_name);
 NodeInfo *node_info_new_package_def(Package *package);
+NodeInfo *node_info_new_package_use(Package *package);
 
 static inline NodeInfo *node_info_ref(NodeInfo *ni) {
   g_atomic_int_inc(&ni->ref);
@@ -65,6 +68,7 @@ static inline gboolean node_info_is(const NodeInfo *ni, NodeInfoKind k) {
 
 const gchar *node_info_kind_to_string(NodeInfoKind kind);
 gchar *node_info_to_string(const NodeInfo *ni);
+const gchar *node_info_get_name(const NodeInfo *ni, const LispAstNode *node);
 
 #endif // NODE_INFO_H
 

--- a/src/project.h
+++ b/src/project.h
@@ -5,6 +5,7 @@ typedef struct _GtkTextBuffer GtkTextBuffer;
 #include "text_provider.h"
 #include "lisp_lexer.h"
 #include "lisp_parser.h"
+#include "node_info.h"
 
 G_BEGIN_DECLS
 
@@ -25,8 +26,8 @@ ProjectFile *project_get_file(Project *self, guint index);
 guint project_get_file_count(Project *self);
 ProjectFileState project_file_get_state(ProjectFile *file);
 void project_file_set_state(ProjectFile *file, ProjectFileState state);
-void project_file_set_provider(ProjectFile *file, TextProvider *provider,
-    GtkTextBuffer *buffer);
+void project_file_set_provider(Project *self, ProjectFile *file,
+    TextProvider *provider, GtkTextBuffer *buffer);
 TextProvider *project_file_get_provider(ProjectFile *file);
 ProjectFile *project_add_file(Project *self, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
@@ -37,5 +38,7 @@ GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
 const gchar *project_file_get_path(ProjectFile *file); // borrowed, do not free
 void project_file_set_path(ProjectFile *file, const gchar *path);
 gboolean project_file_load(Project *self, ProjectFile *file);
+void project_index_add(Project *self, NodeInfo *ni, const LispAstNode *node);
+GHashTable *project_get_index(Project *self, NodeInfoKind kind);
 
 G_END_DECLS


### PR DESCRIPTION
## Summary
- expose node_info_get_name for deriving index keys from AST nodes
- index function, variable, and package nodes by name using hash tables
- update project tests for name-based indexing
- refine indexing API to compute keys from NodeInfo and walk AST safely

## Testing
- `make -C tests run`
- `make -C src app-full`


------
https://chatgpt.com/codex/tasks/task_e_68a22af8cf3483288ca546cab90b90eb