### PR TITLE
Track package context in AST nodes

### DIFF
--- a/src/analyser.c
+++ b/src/analyser.c
@@ -1,7 +1,8 @@
 #include "analyser.h"
 #include "node.h"
+#include <string.h>
 
-static void analyse_node(Node *node) {
+static void analyse_node(Node *node, gchar **context) {
   if (!node)
     return;
 
@@ -9,23 +10,33 @@ static void analyse_node(Node *node) {
     if (node->children->len > 0) {
       Node *first = g_array_index(node->children, Node*, 0);
       if (first->type == LISP_AST_NODE_TYPE_SYMBOL) {
-        if (!first->sd_type)
-          node_set_sd_type(first, SDT_FUNCTION_USE);
-        if (first->start_token && first->start_token->text &&
-            g_ascii_strcasecmp(first->start_token->text, "defun") == 0 &&
-            node->children->len > 1) {
-          Node *name = g_array_index(node->children, Node*, 1);
-          if (name->type == LISP_AST_NODE_TYPE_SYMBOL && !name->sd_type)
-            node_set_sd_type(name, SDT_FUNCTION_DEF);
+        const gchar *name = node_get_name(first);
+        if (name) {
+          if (!first->sd_type)
+            node_set_sd_type(first, SDT_FUNCTION_USE, *context);
+          if (strcmp(name, "DEFUN") == 0 && node->children->len > 1) {
+            Node *fn_name = g_array_index(node->children, Node*, 1);
+            if (fn_name->type == LISP_AST_NODE_TYPE_SYMBOL && !fn_name->sd_type)
+              node_set_sd_type(fn_name, SDT_FUNCTION_DEF, *context);
+          } else if (strcmp(name, "IN-PACKAGE") == 0 && node->children->len > 1) {
+            Node *pkg_node = g_array_index(node->children, Node*, 1);
+            const gchar *pkg_name = node_get_name(pkg_node);
+            if (pkg_name) {
+              g_free(*context);
+              *context = g_strdup(pkg_name);
+            }
+          }
         }
       }
     }
     for (guint i = 0; i < node->children->len; i++)
-      analyse_node(g_array_index(node->children, Node*, i));
+      analyse_node(g_array_index(node->children, Node*, i), context);
   }
 }
 
 void analyse_ast(Node *root) {
-  analyse_node(root);
+  gchar *context = g_strdup("COMMON-LISP-USER");
+  analyse_node(root, &context);
+  g_free(context);
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -45,6 +45,8 @@ struct Node {
   gint ref;
   VariableInfo *var;
   Package *package;
+  gchar *package_context;
+  gchar *name;
   gchar *field_name;
   GPtrArray *methods; /* FunctionInfo* */
 };
@@ -55,12 +57,12 @@ void variable_info_unref(VariableInfo *var);
 FunctionInfo *function_info_ref(FunctionInfo *fn);
 void function_info_unref(FunctionInfo *fn);
 
-void node_set_sd_type(Node *node, StringDesignatorType sd_type);
-void node_set_var_use(Node *node, VariableInfo *var);
-void node_set_var_def(Node *node, VariableInfo *var_new);
-void node_set_struct_field(Node *node, const gchar *field_name);
-void node_set_package_def(Node *node, Package *package);
-void node_set_package_use(Node *node, Package *package);
+void node_set_sd_type(Node *node, StringDesignatorType sd_type, const gchar *package_context);
+void node_set_var_use(Node *node, VariableInfo *var, const gchar *package_context);
+void node_set_var_def(Node *node, VariableInfo *var_new, const gchar *package_context);
+void node_set_struct_field(Node *node, const gchar *field_name, const gchar *package_context);
+void node_set_package_def(Node *node, Package *package, const gchar *package_context);
+void node_set_package_use(Node *node, Package *package, const gchar *package_context);
 
 Node *node_ref(Node *node);
 void node_unref(Node *node);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0`
-TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test asdf_test package_test package_common_lisp_test
+TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test project_test asdf_test analyser_test package_test package_common_lisp_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -28,6 +28,9 @@ project_test: project_test.c project.c analyser.c node.c package.c lisp_lexer.c 
 asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c analyser.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
+analyser_test: analyser_test.c analyser.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
 package_test: package_test.c package.c package_common_lisp_user.c node.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
@@ -42,6 +45,7 @@ run: all
 	./lisp_parser_test
 	./project_test
 	./asdf_test
+	./analyser_test
 	./package_test
 	./package_common_lisp_test
 

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -1,0 +1,35 @@
+#include "analyser.h"
+#include "lisp_lexer.h"
+#include "lisp_parser.h"
+#include "node.h"
+#include "string_text_provider.h"
+#include <glib.h>
+
+int main(void) {
+  const gchar *text =
+    "(defun foo ())\n"
+    "(in-package \"MY-PACK\")\n"
+    "(defun bar ())";
+  TextProvider *provider = string_text_provider_new(text);
+  LispLexer *lexer = lisp_lexer_new(provider);
+  lisp_lexer_lex(lexer);
+  LispParser *parser = lisp_parser_new();
+  GArray *tokens = lisp_lexer_get_tokens(lexer);
+  lisp_parser_parse(parser, tokens);
+  Node *ast = (Node*)lisp_parser_get_ast(parser);
+
+  analyse_ast(ast);
+
+  Node *foo_expr = g_array_index(ast->children, Node*, 0);
+  Node *foo_name = g_array_index(foo_expr->children, Node*, 1);
+  g_assert_cmpstr(foo_name->package_context, ==, "COMMON-LISP-USER");
+
+  Node *bar_expr = g_array_index(ast->children, Node*, 2);
+  Node *bar_name = g_array_index(bar_expr->children, Node*, 1);
+  g_assert_cmpstr(bar_name->package_context, ==, "MY-PACK");
+
+  lisp_parser_free(parser);
+  lisp_lexer_free(lexer);
+  g_object_unref(provider);
+  return 0;
+}

--- a/tests/package_test.c
+++ b/tests/package_test.c
@@ -27,9 +27,10 @@ int main(void) {
 
   Node *node = g_new0(Node, 1);
   g_atomic_int_set(&node->ref, 1);
-  node_set_package_def(node, package);
+  node_set_package_def(node, package, "COMMON-LISP-USER");
   assert(node_is(node, SDT_PACKAGE_DEF));
   assert(node->package == package);
+  assert(g_strcmp0(node->package_context, "COMMON-LISP-USER") == 0);
 
   node_unref(node);
   package_unref(package);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -110,12 +110,12 @@ static void test_index(void)
   Node *callee = g_array_index(call->children, Node*, 0);
   GHashTable *defs = project_get_index(project, SDT_FUNCTION_DEF);
   GHashTable *uses = project_get_index(project, SDT_FUNCTION_USE);
-  GPtrArray *defarr = g_hash_table_lookup(defs, "foo");
+  GPtrArray *defarr = g_hash_table_lookup(defs, "FOO");
   g_assert_nonnull(defarr);
   g_assert_cmpuint(defarr->len, ==, 1);
   g_assert_true(g_ptr_array_index(defarr, 0) == name);
-  GPtrArray *use_defun = g_hash_table_lookup(uses, "defun");
-  GPtrArray *use_bar = g_hash_table_lookup(uses, "bar");
+  GPtrArray *use_defun = g_hash_table_lookup(uses, "DEFUN");
+  GPtrArray *use_bar = g_hash_table_lookup(uses, "BAR");
   g_assert_nonnull(use_defun);
   g_assert_nonnull(use_bar);
   g_assert_cmpuint(use_defun->len, ==, 1);


### PR DESCRIPTION
## Summary
- store package_context on AST nodes
- normalize node names and strip string quotes
- update analyser to track current package using normalized names
- ensure project index tests use uppercase keys
- compute node names solely from tokens and assert string tokens are quoted
- assert node name extraction only occurs with valid tokens and symbol/string nodes

## Testing
- `make -C tests run`
- `make -C src app-full`


------
https://chatgpt.com/codex/tasks/task_e_68a2dca89f708328a0289f03fb2fa926