### PR TITLE
Detect variable uses in analyser

### DIFF
--- a/src/analyser.c
+++ b/src/analyser.c
@@ -29,8 +29,12 @@ static void analyse_node(Node *node, gchar **context) {
         }
       }
     }
-    for (guint i = 0; i < node->children->len; i++)
-      analyse_node(g_array_index(node->children, Node*, i), context);
+    for (guint i = 0; i < node->children->len; i++) {
+      Node *child = g_array_index(node->children, Node*, i);
+      if (i > 0 && child->type == LISP_AST_NODE_TYPE_SYMBOL && !child->sd_type)
+        node_set_sd_type(child, SDT_VAR_USE, *context);
+      analyse_node(child, context);
+    }
   }
 }
 

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -9,7 +9,8 @@ int main(void) {
   const gchar *text =
     "(defun foo ())\n"
     "(in-package \"MY-PACK\")\n"
-    "(defun bar ())";
+    "(defun bar ())\n"
+    "(foo baz)";
   TextProvider *provider = string_text_provider_new(text);
   LispLexer *lexer = lisp_lexer_new(provider);
   lisp_lexer_lex(lexer);
@@ -27,6 +28,11 @@ int main(void) {
   Node *bar_expr = g_array_index(ast->children, Node*, 2);
   Node *bar_name = g_array_index(bar_expr->children, Node*, 1);
   g_assert_cmpstr(bar_name->package_context, ==, "MY-PACK");
+
+  Node *call_expr = g_array_index(ast->children, Node*, 3);
+  Node *var_use = g_array_index(call_expr->children, Node*, 1);
+  g_assert(node_is(var_use, SDT_VAR_USE));
+  g_assert_cmpstr(var_use->package_context, ==, "MY-PACK");
 
   lisp_parser_free(parser);
   lisp_lexer_free(lexer);


### PR DESCRIPTION
## Summary
- mark symbols in non-head list positions as variable uses in analyser
- extend analyser test to cover variable usage detection

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68a36b11353c8328af5270472a789243