### PR TITLE
Track interaction origin and inject swank session

### DIFF
--- a/src/interaction.h
+++ b/src/interaction.h
@@ -10,10 +10,16 @@ typedef enum {
   INTERACTION_ERROR
 } InteractionStatus;
 
+typedef enum {
+  INTERACTION_USER,
+  INTERACTION_INTERNAL
+} InteractionType;
+
 typedef struct {
   gchar *expression;
   guint32 tag;
   InteractionStatus status;
+  InteractionType type;
   gchar *result;
   gchar *output;
   gchar *error;
@@ -23,6 +29,7 @@ static inline void interaction_init(Interaction *self, const gchar *expr) {
   self->expression = g_strdup(expr);
   self->tag = 0;
   self->status = INTERACTION_CREATED;
+  self->type = INTERACTION_USER;
   self->result = NULL;
   self->output = NULL;
   self->error = NULL;

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -146,6 +146,8 @@ on_interaction_added(SwankSession * /*session*/, Interaction *interaction, gpoin
 {
   InteractionsView *self = GLIDE_INTERACTIONS_VIEW(user_data);
   g_debug("InteractionsView.on_interaction_added %s", interaction->expression);
+  if (interaction->type != INTERACTION_USER)
+    return;
   InteractionRow *row = g_new0(InteractionRow, 1);
   row->frame = gtk_frame_new(NULL);
   gtk_widget_set_margin_start(row->frame, 5);
@@ -165,6 +167,8 @@ on_interaction_updated(SwankSession * /*session*/, Interaction *interaction, gpo
 {
   InteractionsView *self = GLIDE_INTERACTIONS_VIEW(user_data);
   g_debug("InteractionsView.on_interaction_updated %s", interaction->expression);
+  if (interaction->type != INTERACTION_USER)
+    return;
   InteractionRow *row = g_hash_table_lookup(self->rows, interaction);
   if (!row) {
     g_debug("InteractionsView.on_interaction_updated row not found for %s", interaction->expression);

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@
 #include "swank_process.h"
 #include "swank_session.h"
 #include "project.h"
+#include "package_common_lisp.h"
 
 int
 main (int argc, char *argv[])
@@ -57,6 +58,7 @@ main (int argc, char *argv[])
   Process *proc = real_process_new (sdk_path);
   SwankProcess *swank_proc = real_swank_process_new (proc, prefs);
   SwankSession *swank = real_swank_session_new (swank_proc);
+  package_common_lisp_set_swank_session(swank);
   Project *project = project_new();
   App *app     = app_new (prefs, swank, project);
 

--- a/src/package_common_lisp.c
+++ b/src/package_common_lisp.c
@@ -1,4 +1,13 @@
 #include "package_common_lisp.h"
+#include "swank_session.h"
+
+static SwankSession *swank_session = NULL;
+
+void package_common_lisp_set_swank_session(SwankSession *swank) {
+  if (swank_session)
+    swank_session_unref(swank_session);
+  swank_session = swank ? swank_session_ref(swank) : NULL;
+}
 
 static const gchar *const functions[] = {
   "*",

--- a/src/package_common_lisp.h
+++ b/src/package_common_lisp.h
@@ -3,6 +3,10 @@
 
 #include "package.h"
 
+typedef struct _SwankSession SwankSession;
+
+void package_common_lisp_set_swank_session(SwankSession *swank);
+
 Package *package_common_lisp_get_instance(void);
 
 #endif // PACKAGE_COMMON_LISP_H

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -34,7 +34,7 @@ analyser_test: analyser_test.c analyser.c node.c package.c lisp_lexer.c lisp_par
 package_test: package_test.c package.c package_common_lisp_user.c node.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-package_common_lisp_test: package_common_lisp_test.c package_common_lisp.c package.c
+package_common_lisp_test: package_common_lisp_test.c package_common_lisp.c package.c swank_session.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all


### PR DESCRIPTION
## Summary
- Distinguish user and internal interactions with a new `InteractionType`
- Filter out internal interactions from `InteractionsView`
- Inject `SwankSession` into Common Lisp package for future dynamic symbols

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68a5e99dac1083289d666192833c5236