### PR TITLE
Use light OO refcounting for Swank components

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -143,12 +143,12 @@ app_dispose (GObject *object)
     project_unref(self->project);
     self->project = NULL;
   }
-  g_clear_object (&self->notebook);
+  g_clear_object(&self->notebook);
   if (self->preferences) {
     preferences_unref(self->preferences);
     self->preferences = NULL;
   }
-  g_clear_object (&self->swank);
+  g_clear_pointer(&self->swank, swank_session_unref);
   G_OBJECT_CLASS (app_parent_class)->dispose (object);
 }
 
@@ -187,9 +187,9 @@ app_new (Preferences *prefs, SwankSession *swank, Project *project)
       "flags",             G_APPLICATION_HANDLES_OPEN,
       NULL);
 
-  self->preferences = preferences_ref (prefs);
-  self->swank       = g_object_ref (swank);
-  self->project     = project_ref (project);
+  self->preferences = preferences_ref(prefs);
+  self->swank       = swank_session_ref(swank);
+  self->project     = project_ref(project);
   return self;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -63,12 +63,12 @@ main (int argc, char *argv[])
   App *app     = app_new (prefs, swank, project);
 
   int status = g_application_run (G_APPLICATION (app), argc, argv);
-  g_object_unref (app);
-  g_object_unref (swank);
-  g_object_unref (swank_proc);
-  g_object_unref (proc);
-  project_unref (project);
-  preferences_unref (prefs);
+  g_object_unref(app);
+  swank_session_unref(swank);
+  swank_process_unref(swank_proc);
+  process_unref(proc);
+  project_unref(project);
+  preferences_unref(prefs);
   exit(status);
 }
 


### PR DESCRIPTION
## Summary
- replace g_object ref/unref with swank_session/process helpers
- clean up SwankSession with g_clear_pointer

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4af93a08328b953610f5a66ba58