### PR TITLE
Handle Swank messages on main loop

### DIFF
--- a/src/real_swank_process.c
+++ b/src/real_swank_process.c
@@ -34,7 +34,9 @@ static gpointer swank_reader_thread(gpointer data) {
       g_free(dbg);
       g_mutex_lock(&self->swank_mutex);
       g_string_append_len(self->swank_data, buf, n);
-      if (self->msg_cb) {
+      SwankProcessMessageCallback cb = self->msg_cb;
+      gpointer cb_data = self->msg_cb_data;
+      if (cb) {
         while (TRUE) {
           if (self->swank_data->len - self->swank_consumed >= 6) {
             char hdr[7];
@@ -45,7 +47,7 @@ static gpointer swank_reader_thread(gpointer data) {
               char *start = self->swank_data->str + self->swank_consumed + 6;
               GString *msg = g_string_new_len(start, len);
               self->swank_consumed += 6 + len;
-              self->msg_cb(msg, self->msg_cb_data);
+              cb(msg, cb_data);
               g_string_free(msg, TRUE);
               continue;
             }


### PR DESCRIPTION
## Summary
- Dispatch interaction callbacks through the GTK main loop inside `InteractionsView`
- Keep Swank process callbacks thread-agnostic by invoking UI updates from the view layer

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a71e07e400832886a6ddd4ad6f5219