### PR TITLE
Add startup status bar

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -119,6 +119,10 @@ app_activate (GApplication *app)
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox), menu_bar, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(vbox), paned, TRUE, TRUE, 0);
+  GtkWidget *statusbar = gtk_statusbar_new();
+  guint context_id = gtk_statusbar_get_context_id(GTK_STATUSBAR(statusbar), "default");
+  gtk_statusbar_push(GTK_STATUSBAR(statusbar), context_id, "Ready.");
+  gtk_box_pack_start(GTK_BOX(vbox), statusbar, FALSE, FALSE, 0);
   gtk_container_add(GTK_CONTAINER(self->window), vbox);
 
   gtk_widget_show_all (self->window);


### PR DESCRIPTION
## Summary
- Add a GtkStatusbar to the main window and display "Ready." when the app starts.

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a87d0537bc83289055e198a64860fb