### PR TITLE
Show SBCL startup message via status service

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -59,10 +59,10 @@ main (int argc, char *argv[])
   const gchar *sdk_path = preferences_get_sdk (prefs);
   Process *proc = real_process_new (sdk_path);
   SwankProcess *swank_proc = real_swank_process_new (proc, prefs);
-  SwankSession *swank = real_swank_session_new (swank_proc);
+  StatusService *status_service = status_service_new();
+  SwankSession *swank = real_swank_session_new (swank_proc, status_service);
   package_common_lisp_set_swank_session(swank);
   Project *project = project_new();
-  StatusService *status_service = status_service_new();
   App *app     = app_new (prefs, swank, project, status_service);
 
   int status = g_application_run (G_APPLICATION (app), argc, argv);

--- a/src/real_swank_session.h
+++ b/src/real_swank_session.h
@@ -3,10 +3,12 @@
 
 #include "swank_session.h"
 #include "swank_process.h"
+#include "status_service.h"
 
 typedef struct {
   SwankSession base;
   SwankProcess *proc;
+  StatusService *status_service;
   gboolean started;
   guint32 next_tag;
   GHashTable *interactions;
@@ -16,7 +18,7 @@ typedef struct {
   gpointer updated_cb_data;
 } RealSwankSession;
 
-SwankSession *real_swank_session_new(SwankProcess *proc);
+SwankSession *real_swank_session_new(SwankProcess *proc, StatusService *status_service);
 void real_swank_session_on_message(GString *msg, gpointer user_data);
 
 #endif /* REAL_SWANK_SESSION_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ process_test: process_test.c process.c real_process.c
 swank_process_test: swank_process_test.c swank_process.c real_swank_process.c process.c preferences.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
+swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c

--- a/tests/swank_session_test.c
+++ b/tests/swank_session_test.c
@@ -2,6 +2,7 @@
 #include "real_swank_session.h"
 #include "swank_process.h"
 #include "interaction.h"
+#include "status_service.h"
 #include <glib.h>
 #include <string.h>
 
@@ -67,7 +68,8 @@ static void on_interaction_done(Interaction * /*interaction*/, gpointer user_dat
 static void test_eval(void)
 {
   MockSwankProcess *mock_swank_process = mock_swank_process_new();
-  SwankSession *sess = real_swank_session_new((SwankProcess*)mock_swank_process);
+  StatusService *status_service = status_service_new();
+  SwankSession *sess = real_swank_session_new((SwankProcess*)mock_swank_process, status_service);
   Interaction interaction;
   interaction_init(&interaction, "(+ 1 2)");
   swank_session_eval(sess, &interaction);
@@ -77,6 +79,7 @@ static void test_eval(void)
       "(:emacs-rex (swank:eval-and-grab-output \"(+ 1 2)\") \"COMMON-LISP-USER\" t 1)");
   g_assert_cmpint(mock_swank_process->start_count, ==, 1);
   swank_session_unref(sess);
+  status_service_free(status_service);
   swank_process_unref((SwankProcess*)mock_swank_process);
 }
 
@@ -93,7 +96,8 @@ static void test_on_message_return_ok(void)
 static void test_on_message_return_abort(void)
 {
   MockSwankProcess *mock_swank_process = mock_swank_process_new();
-  SwankSession *sess = real_swank_session_new((SwankProcess*)mock_swank_process);
+  StatusService *status_service = status_service_new();
+  SwankSession *sess = real_swank_session_new((SwankProcess*)mock_swank_process, status_service);
   Interaction interaction;
   interaction_init(&interaction, "(+ 1 2)");
   swank_session_eval(sess, &interaction);
@@ -107,13 +111,15 @@ static void test_on_message_return_abort(void)
   interaction_clear(&interaction);
   g_string_free(msg, TRUE);
   swank_session_unref(sess);
+  status_service_free(status_service);
   swank_process_unref((SwankProcess*)mock_swank_process);
 }
 
 static void test_interaction_updated_signal(void)
 {
   MockSwankProcess *proc = mock_swank_process_new();
-  SwankSession *sess = real_swank_session_new((SwankProcess*)proc);
+  StatusService *status_service = status_service_new();
+  SwankSession *sess = real_swank_session_new((SwankProcess*)proc, status_service);
   Interaction interaction;
   interaction_init(&interaction, "(+ 1 2)");
   swank_session_eval(sess, &interaction);
@@ -126,13 +132,15 @@ static void test_interaction_updated_signal(void)
   interaction_clear(&interaction);
   g_string_free(msg, TRUE);
   swank_session_unref(sess);
+  status_service_free(status_service);
   swank_process_unref((SwankProcess*)proc);
 }
 
 static void test_interaction_done_callback(void)
 {
   MockSwankProcess *proc = mock_swank_process_new();
-  SwankSession *sess = real_swank_session_new((SwankProcess*)proc);
+  StatusService *status_service = status_service_new();
+  SwankSession *sess = real_swank_session_new((SwankProcess*)proc, status_service);
   Interaction interaction;
   interaction_init(&interaction, "(+ 1 2)");
   int count = 0;
@@ -145,6 +153,7 @@ static void test_interaction_done_callback(void)
   interaction_clear(&interaction);
   g_string_free(msg, TRUE);
   swank_session_unref(sess);
+  status_service_free(status_service);
   swank_process_unref((SwankProcess*)proc);
 }
 


### PR DESCRIPTION
## Summary
- display "SBCL is starting..." using the status service during the first evaluation
- inject `StatusService` into `RealSwankSession` and wire up in `main.c`
- update swank session tests for the new dependency

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a8994bc94c83289f142de81a3be1ad