### PR TITLE
Add ASDF project loading and startup persistence

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -125,7 +125,9 @@ app_activate (GApplication *app)
   self->statusbar = status_bar_new(self->status_service);
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(self->statusbar), FALSE, FALSE, 0);
   gtk_container_add(GTK_CONTAINER(self->window), vbox);
-
+  const gchar *proj = preferences_get_project_file(self->preferences);
+  if (proj)
+    file_open_path(self, proj);
   gtk_widget_show_all (self->window);
 }
 

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -12,37 +12,104 @@
 #include "lisp_source_notebook.h"
 #include "project.h"
 #include "string_text_provider.h"
+#include "file_save.h"
+#include "preferences.h"
+#include "asdf.h"
 
-void file_open(GtkWidget *, gpointer data) {
-  App *app = (App *) data;
+static gboolean save_if_modified(App *app) {
+  Project *project = app_get_project(app);
+  if (project_get_file_count(project) == 0)
+    return TRUE;
+  ProjectFile *file = project_get_file(project, 0);
+  GtkTextBuffer *buffer = project_file_get_buffer(file);
+  if (buffer && gtk_text_buffer_get_modified(buffer)) {
+    GtkWidget *dialog = gtk_message_dialog_new(NULL, GTK_DIALOG_MODAL,
+        GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+        "Save changes to %s?", project_file_get_path(file));
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_Cancel", GTK_RESPONSE_CANCEL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_Discard", GTK_RESPONSE_REJECT);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_Save", GTK_RESPONSE_ACCEPT);
+    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    if (res == GTK_RESPONSE_CANCEL)
+      return FALSE;
+    if (res == GTK_RESPONSE_ACCEPT)
+      file_save(NULL, app);
+  }
+  return TRUE;
+}
+
+static gchar *ensure_lisp_extension(const gchar *path) {
+  if (g_str_has_suffix(path, ".lisp"))
+    return g_strdup(path);
+  return g_strconcat(path, ".lisp", NULL);
+}
+
+gboolean file_open_path(App *app, const gchar *filename) {
+  g_return_val_if_fail(app != NULL, FALSE);
+  if (!save_if_modified(app))
+    return FALSE;
+
   Project *project = app_get_project(app);
   LispSourceNotebook *notebook = app_get_notebook(app);
+  project_clear(project);
+  lisp_source_notebook_clear(notebook);
 
-  // Create a file chooser dialog
+  gboolean is_asdf = g_str_has_suffix(filename, ".asd");
+  if (is_asdf) {
+    Asdf *asdf = asdf_new_from_file(filename);
+    project_set_asdf(project, asdf);
+    g_object_unref(asdf);
+    gchar *base = g_path_get_dirname(filename);
+    const gchar *pathname = asdf_get_pathname(project_get_asdf(project));
+    gchar *dir = pathname ? g_build_filename(base, pathname, NULL) : g_strdup(base);
+    for (guint i = 0; i < asdf_get_component_count(project_get_asdf(project)); i++) {
+      const gchar *comp = asdf_get_component(project_get_asdf(project), i);
+      gchar *path = g_build_filename(dir, comp, NULL);
+      gchar *full = ensure_lisp_extension(path);
+      g_free(path);
+      TextProvider *provider = string_text_provider_new("");
+      ProjectFile *pf = project_add_file(project, provider, NULL, full, PROJECT_FILE_LIVE);
+      text_provider_unref(provider);
+      if (pf)
+        project_file_load(project, pf);
+      g_free(full);
+    }
+    g_free(dir);
+    g_free(base);
+  } else {
+    project_set_asdf(project, NULL);
+    TextProvider *provider = string_text_provider_new("");
+    ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
+    text_provider_unref(provider);
+    if (file)
+      project_file_load(project, file);
+  }
+
+  Preferences *prefs = app_get_preferences(app);
+  preferences_set_project_file(prefs, filename);
+
+  LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+  if (view)
+    app_connect_view(app, view);
+  return TRUE;
+}
+
+void file_open(GtkWidget *widget, gpointer data) {
+  App *app = (App *)data;
+
   GtkWidget *dialog = gtk_file_chooser_dialog_new(
       "Open File",
       NULL,
       GTK_FILE_CHOOSER_ACTION_OPEN,
       "_Cancel", GTK_RESPONSE_CANCEL,
-      "_Open",   GTK_RESPONSE_ACCEPT,
+      "_Open", GTK_RESPONSE_ACCEPT,
       NULL);
 
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-    gchar* filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-
-    TextProvider *provider = string_text_provider_new("");
-    ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
-    text_provider_unref(provider);
-
-    if (file) {
-      project_file_load(project, file);
-      LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
-      app_connect_view(app, view);
-    }
-
+    gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+    file_open_path(app, filename);
     g_free(filename);
   }
-
-  // Destroy the dialog
   gtk_widget_destroy(dialog);
 }

--- a/src/file_open.h
+++ b/src/file_open.h
@@ -1,6 +1,10 @@
 #ifndef OPEN_FILE
 #define OPEN_FILE
 
+#include <glib.h>
+typedef struct _App App;
+
 void file_open(GtkWidget *, gpointer data);
+gboolean file_open_path(App *app, const gchar *filename);
 
 #endif // OPEN_FILE

--- a/src/lisp_source_notebook.c
+++ b/src/lisp_source_notebook.c
@@ -88,6 +88,15 @@ lisp_source_notebook_add_file(LispSourceNotebook *self, ProjectFile *file)
   return page;
 }
 
+void
+lisp_source_notebook_clear(LispSourceNotebook *self)
+{
+  g_return_if_fail(LISP_IS_SOURCE_NOTEBOOK(self));
+  gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(self));
+  while (pages-- > 0)
+    gtk_notebook_remove_page(GTK_NOTEBOOK(self), 0);
+}
+
 LispSourceView *
 lisp_source_notebook_get_current_view(LispSourceNotebook *self)
 {

--- a/src/lisp_source_notebook.h
+++ b/src/lisp_source_notebook.h
@@ -12,5 +12,6 @@ G_DECLARE_FINAL_TYPE(LispSourceNotebook, lisp_source_notebook, LISP, SOURCE_NOTE
 GtkWidget *lisp_source_notebook_new(Project *project);
 LispSourceView *lisp_source_notebook_get_current_view(LispSourceNotebook *self);
 gint lisp_source_notebook_add_file(LispSourceNotebook *self, ProjectFile *file);
+void lisp_source_notebook_clear(LispSourceNotebook *self);
 
 G_END_DECLS

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -13,5 +13,7 @@ const gchar *preferences_get_sdk(Preferences *self);
 void         preferences_set_sdk(Preferences *self, const gchar *new_sdk);
 guint16      preferences_get_swank_port(Preferences *self);
 void         preferences_set_swank_port(Preferences *self, guint16 new_port);
+const gchar *preferences_get_project_file(Preferences *self);
+void         preferences_set_project_file(Preferences *self, const gchar *file);
 
 #endif // PREFERENCES_H

--- a/src/project.h
+++ b/src/project.h
@@ -6,6 +6,7 @@ typedef struct _GtkTextBuffer GtkTextBuffer;
 #include "lisp_lexer.h"
 #include "lisp_parser.h"
 #include "node.h"
+#include "asdf.h"
 
 typedef struct _Project Project;
 typedef struct _ProjectFile ProjectFile;
@@ -41,3 +42,6 @@ void           project_file_set_path(ProjectFile *file, const gchar *path);
 gboolean       project_file_load(Project *self, ProjectFile *file);
 void           project_index_add(Project *self, Node *node);
 GHashTable    *project_get_index(Project *self, StringDesignatorType sd_type);
+void           project_set_asdf(Project *self, Asdf *asdf);
+Asdf          *project_get_asdf(Project *self);
+void           project_clear(Project *self);


### PR DESCRIPTION
## Summary
- Track an ASDF system in `Project` and allow clearing project files
- Support opening Lisp or ASDF projects, prompting to save and loading all components
- Persist last project file in preferences and reopen it on startup

## Testing
- `make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a8b88490d88328a3d594968a30c25f