### PR TITLE
Move install button beneath instructions in preferences dialog

### DIFF
--- a/src/preferences_dialog.c
+++ b/src/preferences_dialog.c
@@ -79,19 +79,19 @@ preferences_dialog_new(GtkWindow *parent, Preferences *preferences) {
   gtk_grid_attach(GTK_GRID(grid), self->binary_entry, 1, 0, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), choose_button, 2, 0, 1, 1);
 
-  GtkWidget *install_button = gtk_button_new_with_label("Run installer for SBCL");
-  g_signal_connect(install_button, "clicked", G_CALLBACK(on_install_sbcl), NULL);
-  gtk_grid_attach(GTK_GRID(grid), install_button, 1, 1, 2, 1);
-
   GtkWidget *install_label = gtk_label_new("To install SBCL, run:");
   GtkWidget *install_entry = gtk_entry_new();
   gtk_entry_set_text(GTK_ENTRY(install_entry), "sudo apt install sbcl");
   gtk_editable_set_editable(GTK_EDITABLE(install_entry), FALSE);
   GtkWidget *copy_button = gtk_button_new_from_icon_name("edit-copy", GTK_ICON_SIZE_BUTTON);
   g_signal_connect(copy_button, "clicked", G_CALLBACK(on_copy_install), install_entry);
-  gtk_grid_attach(GTK_GRID(grid), install_label, 0, 2, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), install_entry, 1, 2, 1, 1);
-  gtk_grid_attach(GTK_GRID(grid), copy_button, 2, 2, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), install_label, 0, 1, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), install_entry, 1, 1, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), copy_button, 2, 1, 1, 1);
+
+  GtkWidget *install_button = gtk_button_new_with_label("Run installer for SBCL");
+  g_signal_connect(install_button, "clicked", G_CALLBACK(on_install_sbcl), NULL);
+  gtk_grid_attach(GTK_GRID(grid), install_button, 1, 2, 2, 1);
 
   gtk_widget_show_all(self->dialog);
 


### PR DESCRIPTION
## Summary
- reorder preferences dialog elements so SBCL install button appears below its instructions

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9974584508328b24453c1d28f0b2f