### PR TITLE
Reject directories in preferences dialog

### DIFF
--- a/src/preferences_dialog.c
+++ b/src/preferences_dialog.c
@@ -22,6 +22,8 @@ update_status(PreferencesDialog *self) {
   }
   if (!g_file_test(filename, G_FILE_TEST_EXISTS)) {
     gtk_label_set_markup(GTK_LABEL(self->status_label), "<span foreground=\"red\">file not found</span>");
+  } else if (g_file_test(filename, G_FILE_TEST_IS_DIR)) {
+    gtk_label_set_markup(GTK_LABEL(self->status_label), "<span foreground=\"red\">is a directory</span>");
   } else if (!g_file_test(filename, G_FILE_TEST_IS_EXECUTABLE)) {
     gtk_label_set_markup(GTK_LABEL(self->status_label), "<span foreground=\"red\">not executable</span>");
   } else {


### PR DESCRIPTION
## Summary
- ensure preference dialog reports an error when a directory is selected instead of an executable

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68a9aa27274483288b1a66651495612f