### PR TITLE
Add project creation wizard

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@ LIBS += gtksourceview-4
 SOURCES += \
   file_open.c \
   file_new.c \
+  project_new_wizard.c \
   file_save.c \
   preferences.c \
   preferences_dialog.c \

--- a/src/app.c
+++ b/src/app.c
@@ -2,6 +2,7 @@
 #include "app.h"
 #include "file_open.h"
 #include "file_new.h"
+#include "project_new_wizard.h"
 #include "preferences_dialog.h"
 #include "evaluate.h"
 #include "interactions_view.h"
@@ -120,6 +121,7 @@ app_activate (GApplication *app)
   gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), exit_item);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), file_item);
 
+  g_signal_connect(proj_new_item, "activate", G_CALLBACK(project_new_wizard), self);
   g_signal_connect(proj_open_item, "activate", G_CALLBACK(file_open), self);
   g_signal_connect(newfile_item, "activate", G_CALLBACK(file_new), self);
   g_signal_connect(settings_item, "activate", G_CALLBACK(on_preferences), self);

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "evaluate.c"
 #include "file_open.c"
 #include "file_new.c"
+#include "project_new_wizard.c"
 #include "file_save.c"
 #include "gtk_text_provider.c"
 #include "interactions_view.c"

--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -1,0 +1,86 @@
+#include <gtk/gtk.h>
+#include "project_new_wizard.h"
+#include "app.h"
+#include "project.h"
+#include "asdf.h"
+#include <glib/gstdio.h>
+
+typedef struct {
+  GtkEntry *name_entry;
+  GtkEntry *location_entry;
+  GtkLabel *info_label;
+} ProjectNewWidgets;
+
+static void update_info(GtkEditable */*editable*/, gpointer user_data) {
+  ProjectNewWidgets *w = user_data;
+  const gchar *name = gtk_entry_get_text(w->name_entry);
+  const gchar *loc = gtk_entry_get_text(w->location_entry);
+  gchar *path = g_build_filename(loc, name, NULL);
+  gchar *msg = g_strdup_printf("Project will be created in %s/", path);
+  gtk_label_set_text(w->info_label, msg);
+  g_free(msg);
+  g_free(path);
+}
+
+static gchar *expand_home(const gchar *path) {
+  if (path[0] == '~')
+    return g_build_filename(g_get_home_dir(), path + 1, NULL);
+  return g_strdup(path);
+}
+
+void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
+  App *app = data;
+  GtkWidget *dialog = gtk_dialog_new_with_buttons("New Project", NULL,
+      GTK_DIALOG_MODAL,
+      "_Cancel", GTK_RESPONSE_CANCEL,
+      "_Create", GTK_RESPONSE_ACCEPT,
+      NULL);
+  GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+  GtkWidget *grid = gtk_grid_new();
+  gtk_container_set_border_width(GTK_CONTAINER(grid), 6);
+  gtk_grid_set_row_spacing(GTK_GRID(grid), 6);
+  gtk_grid_set_column_spacing(GTK_GRID(grid), 6);
+  gtk_container_add(GTK_CONTAINER(content), grid);
+
+  GtkWidget *name_label = gtk_label_new("Name:");
+  GtkWidget *name_entry = gtk_entry_new();
+  gtk_entry_set_text(GTK_ENTRY(name_entry), "untitled");
+  gtk_grid_attach(GTK_GRID(grid), name_label, 0, 0, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), name_entry, 1, 0, 1, 1);
+
+  GtkWidget *loc_label = gtk_label_new("Location:");
+  GtkWidget *loc_entry = gtk_entry_new();
+  gtk_entry_set_text(GTK_ENTRY(loc_entry), "~");
+  gtk_grid_attach(GTK_GRID(grid), loc_label, 0, 1, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), loc_entry, 1, 1, 1, 1);
+
+  GtkWidget *info = gtk_label_new(NULL);
+  gtk_widget_set_sensitive(info, FALSE);
+  gtk_grid_attach(GTK_GRID(grid), info, 1, 2, 1, 1);
+
+  ProjectNewWidgets w = {GTK_ENTRY(name_entry), GTK_ENTRY(loc_entry), GTK_LABEL(info)};
+  g_signal_connect(name_entry, "changed", G_CALLBACK(update_info), &w);
+  g_signal_connect(loc_entry, "changed", G_CALLBACK(update_info), &w);
+  update_info(NULL, &w);
+
+  gtk_widget_show_all(dialog);
+  if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+    const gchar *name = gtk_entry_get_text(GTK_ENTRY(name_entry));
+    const gchar *loc_text = gtk_entry_get_text(GTK_ENTRY(loc_entry));
+    gchar *loc = expand_home(loc_text);
+    gchar *dir = g_build_filename(loc, name, NULL);
+    g_mkdir_with_parents(dir, 0755);
+    gchar *name_asd = g_strdup_printf("%s.asd", name);
+    gchar *asd_path = g_build_filename(dir, name_asd, NULL);
+    Asdf *asdf = asdf_new_from_file(asd_path);
+    asdf_save(asdf, asd_path);
+    project_set_asdf(app_get_project(app), asdf);
+    g_object_unref(asdf);
+    g_free(name_asd);
+    g_free(asd_path);
+    g_free(dir);
+    g_free(loc);
+  }
+  gtk_widget_destroy(dialog);
+}
+

--- a/src/project_new_wizard.h
+++ b/src/project_new_wizard.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <gtk/gtk.h>
+
+void project_new_wizard(GtkWidget *widget, gpointer data);
+


### PR DESCRIPTION
## Summary
- Add project creation wizard prompting for name and location, updating output path live
- Save minimal ASDF file and set project when wizard completes
- Hook Project > New menu item to new wizard

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9ae5157588328b60ac782efa64eac