### PR TITLE
Use pragma once for headers

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -1,5 +1,4 @@
-#ifndef GLIDE_H
-#define GLIDE_H
+#pragma once
 
 #include <gtk/gtk.h>
 #include <gtksourceview/gtksource.h>
@@ -32,4 +31,3 @@ STATIC StatusService *app_get_status_service(App *self);
 
 G_END_DECLS
 
-#endif /* GLIDE_H */

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -1,10 +1,7 @@
-
-#ifndef EVALUATE_H
-#define EVALUATE_H
+#pragma once
 
 #include "app.h"
 
 void
 on_evaluate(App *self);
 
-#endif // EVALUATE_H

--- a/src/file_new.h
+++ b/src/file_new.h
@@ -1,5 +1,4 @@
-#ifndef FILE_NEW_H
-#define FILE_NEW_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -7,4 +6,3 @@ typedef struct _App App;
 
 void file_new(GtkWidget *widget, gpointer data);
 
-#endif

--- a/src/file_open.h
+++ b/src/file_open.h
@@ -1,5 +1,4 @@
-#ifndef OPEN_FILE
-#define OPEN_FILE
+#pragma once
 
 #include <glib.h>
 typedef struct _App App;
@@ -7,4 +6,3 @@ typedef struct _App App;
 void file_open(GtkWidget *, gpointer data);
 gboolean file_open_path(App *app, const gchar *filename);
 
-#endif // OPEN_FILE

--- a/src/file_save.h
+++ b/src/file_save.h
@@ -1,7 +1,5 @@
-#ifndef SAVE_FILE
-#define SAVE_FILE
+#pragma once
 
 void file_save(GtkWidget *, gpointer data);
 void file_saveas(GtkWidget *, gpointer data);
 
-#endif

--- a/src/interaction.h
+++ b/src/interaction.h
@@ -1,5 +1,4 @@
-#ifndef INTERACTION_H
-#define INTERACTION_H
+#pragma once
 
 #include <glib.h>
 
@@ -52,4 +51,3 @@ static inline void interaction_clear(Interaction *self) {
   self->done_cb_data = NULL;
 }
 
-#endif /* INTERACTION_H */

--- a/src/interactions_view.h
+++ b/src/interactions_view.h
@@ -1,5 +1,4 @@
-#ifndef INTERACTIONS_VIEW_H
-#define INTERACTIONS_VIEW_H
+#pragma once
 
 #include <gtk/gtk.h>
 #include "swank_session.h"
@@ -9,4 +8,3 @@ G_DECLARE_FINAL_TYPE(InteractionsView, interactions_view, GLIDE, INTERACTIONS_VI
 
 InteractionsView *interactions_view_new(SwankSession *session);
 
-#endif /* INTERACTIONS_VIEW_H */

--- a/src/package.h
+++ b/src/package.h
@@ -1,5 +1,4 @@
-#ifndef PACKAGE_H
-#define PACKAGE_H
+#pragma once
 
 #include <glib.h>
 
@@ -26,4 +25,3 @@ void package_add_export(Package *package, const gchar *symbol);
 void package_add_shadow(Package *package, const gchar *symbol);
 void package_add_import_from(Package *package, const gchar *symbol, const gchar *from);
 
-#endif // PACKAGE_H

--- a/src/package_common_lisp.h
+++ b/src/package_common_lisp.h
@@ -1,5 +1,4 @@
-#ifndef PACKAGE_COMMON_LISP_H
-#define PACKAGE_COMMON_LISP_H
+#pragma once
 
 #include "package.h"
 
@@ -9,4 +8,3 @@ void package_common_lisp_set_swank_session(SwankSession *swank);
 
 Package *package_common_lisp_get_instance(void);
 
-#endif // PACKAGE_COMMON_LISP_H

--- a/src/package_common_lisp_user.h
+++ b/src/package_common_lisp_user.h
@@ -1,8 +1,6 @@
-#ifndef PACKAGE_COMMON_LISP_USER_H
-#define PACKAGE_COMMON_LISP_USER_H
+#pragma once
 
 #include "package.h"
 
 Package *package_common_lisp_user_get_instance(void);
 
-#endif // PACKAGE_COMMON_LISP_USER_H

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -1,6 +1,4 @@
-
-#ifndef PREFERENCES_H
-#define PREFERENCES_H
+#pragma once
 
 #include <glib.h>
 
@@ -16,4 +14,3 @@ void         preferences_set_swank_port(Preferences *self, guint16 new_port);
 const gchar *preferences_get_project_file(Preferences *self);
 void         preferences_set_project_file(Preferences *self, const gchar *file);
 
-#endif // PREFERENCES_H

--- a/src/preferences_dialog.h
+++ b/src/preferences_dialog.h
@@ -1,7 +1,4 @@
-
-#ifndef PREFERENCES_DIALOG_H
-#define PREFERENCES_DIALOG_H
+#pragma once
 
 void on_preferences(GtkWidget *, gpointer data);
 
-#endif // PREFERENCES_DIALOG_H

--- a/src/process.h
+++ b/src/process.h
@@ -1,5 +1,4 @@
-#ifndef PROCESS_H
-#define PROCESS_H
+#pragma once
 
 #include <glib.h>
 
@@ -43,4 +42,3 @@ static inline void process_start(Process *self) {
 Process *process_ref(Process *self);
 void     process_unref(Process *self);
 
-#endif /* PROCESS_H */

--- a/src/real_process.h
+++ b/src/real_process.h
@@ -1,5 +1,4 @@
-#ifndef REAL_PROCESS_H
-#define REAL_PROCESS_H
+#pragma once
 
 #include "process.h"
 
@@ -22,4 +21,3 @@ typedef struct {
 Process *real_process_new(const gchar *cmd);
 Process *real_process_new_from_argv(const gchar *const *argv);
 
-#endif /* REAL_PROCESS_H */

--- a/src/real_swank_process.h
+++ b/src/real_swank_process.h
@@ -1,5 +1,4 @@
-#ifndef REAL_SWANK_PROCESS_H
-#define REAL_SWANK_PROCESS_H
+#pragma once
 
 #include "swank_process.h"
 #include <gio/gio.h>
@@ -29,4 +28,3 @@ typedef struct {
 SwankProcess *real_swank_process_new(Process *proc, Preferences *prefs);
 void real_swank_process_set_socket(RealSwankProcess *self, int fd);
 
-#endif /* REAL_SWANK_PROCESS_H */

--- a/src/real_swank_session.h
+++ b/src/real_swank_session.h
@@ -1,5 +1,4 @@
-#ifndef REAL_SWANK_SESSION_H
-#define REAL_SWANK_SESSION_H
+#pragma once
 
 #include "swank_session.h"
 #include "swank_process.h"
@@ -24,4 +23,3 @@ typedef struct {
 SwankSession *real_swank_session_new(SwankProcess *proc, StatusService *status_service);
 void real_swank_session_on_message(GString *msg, gpointer user_data);
 
-#endif /* REAL_SWANK_SESSION_H */

--- a/src/reloc.h
+++ b/src/reloc.h
@@ -1,5 +1,4 @@
-#ifndef __RELOC_H__
-#define __RELOC_H__
+#pragma once
 
 // In addition to the symbol name, each symbol from the ELF relocation table has a 48 byte overhead:
 // - 24 bytes in the rela section
@@ -57,4 +56,3 @@ static inline void relocate() {
 #endif
 }
 
-#endif

--- a/src/status_bar.h
+++ b/src/status_bar.h
@@ -1,5 +1,4 @@
-#ifndef STATUS_BAR_H
-#define STATUS_BAR_H
+#pragma once
 
 #include <gtk/gtk.h>
 #include "status_service.h"
@@ -13,4 +12,3 @@ StatusBar *status_bar_new(StatusService *service);
 
 G_END_DECLS
 
-#endif /* STATUS_BAR_H */

--- a/src/status_service.h
+++ b/src/status_service.h
@@ -1,5 +1,4 @@
-#ifndef STATUS_SERVICE_H
-#define STATUS_SERVICE_H
+#pragma once
 
 #include <glib.h>
 
@@ -16,4 +15,3 @@ void status_service_unpublish(StatusService *self, guint id);
 const gchar *status_service_get(StatusService *self);
 void status_service_set_callback(StatusService *self, StatusServiceCallback cb, gpointer user_data);
 
-#endif /* STATUS_SERVICE_H */

--- a/src/swank_process.h
+++ b/src/swank_process.h
@@ -1,5 +1,4 @@
-#ifndef SWANK_PROCESS_H
-#define SWANK_PROCESS_H
+#pragma once
 
 #include "preferences.h"
 #include "process.h"
@@ -42,4 +41,3 @@ static inline void swank_process_set_message_cb(SwankProcess *self,
 SwankProcess *swank_process_ref(SwankProcess *self);
 void          swank_process_unref(SwankProcess *self);
 
-#endif /* SWANK_PROCESS_H */

--- a/src/swank_session.h
+++ b/src/swank_session.h
@@ -1,5 +1,4 @@
-#ifndef SWANK_SESSION_H
-#define SWANK_SESSION_H
+#pragma once
 
 #include "swank_process.h"
 #include "interaction.h"
@@ -39,4 +38,3 @@ static inline void swank_session_set_interaction_updated_cb(SwankSession *self, 
 SwankSession *swank_session_ref(SwankSession *self);
 void swank_session_unref(SwankSession *self);
 
-#endif /* SWANK_SESSION_H */

--- a/src/syscalls.h
+++ b/src/syscalls.h
@@ -1,5 +1,4 @@
-#ifndef SYSCALLS_H
-#define SYSCALLS_H
+#pragma once
 
 #include <sys/stat.h> // For struct stat used by fstat
 #include <stddef.h>
@@ -173,4 +172,3 @@ static inline long sys_fstat(int fd, struct stat *buf)
 
 #endif // SYSCALLS
 
-#endif

--- a/src/text_provider.h
+++ b/src/text_provider.h
@@ -1,5 +1,4 @@
-#ifndef TEXT_PROVIDER_H
-#define TEXT_PROVIDER_H
+#pragma once
 
 #include <glib.h>
 
@@ -41,4 +40,3 @@ static inline gchar *text_provider_get_text(TextProvider *self, gsize start, gsi
 TextProvider *text_provider_ref(TextProvider *self);
 void          text_provider_unref(TextProvider *self);
 
-#endif /* TEXT_PROVIDER_H */

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,4 @@
-#ifndef GLIDE_UTIL_H
-#define GLIDE_UTIL_H
+#pragma once
 
 #include <glib.h>
 
@@ -11,4 +10,3 @@ static inline void g_debug_40(const char *string, const char *msg)
     g_debug("%s%s", string, msg);
 }
 
-#endif /* GLIDE_UTIL_H */


### PR DESCRIPTION
## Summary
- Replace #ifndef/#define include guards with `#pragma once` across the codebase for simpler, consistent header protection.

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9b0d36d30832886f6923b928fc3b5