### PR TITLE
Remember last project location

### DIFF
--- a/src/preferences.h
+++ b/src/preferences.h
@@ -13,4 +13,6 @@ guint16      preferences_get_swank_port(Preferences *self);
 void         preferences_set_swank_port(Preferences *self, guint16 new_port);
 const gchar *preferences_get_project_file(Preferences *self);
 void         preferences_set_project_file(Preferences *self, const gchar *file);
+const gchar *preferences_get_project_dir(Preferences *self);
+void         preferences_set_project_dir(Preferences *self, const gchar *dir);
 

--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -50,7 +50,9 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
 
   GtkWidget *loc_label = gtk_label_new("Location:");
   GtkWidget *loc_entry = gtk_entry_new();
-  gtk_entry_set_text(GTK_ENTRY(loc_entry), "~");
+  Preferences *prefs = app_get_preferences(app);
+  const gchar *dir = preferences_get_project_dir(prefs);
+  gtk_entry_set_text(GTK_ENTRY(loc_entry), dir);
   gtk_grid_attach(GTK_GRID(grid), loc_label, 0, 1, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), loc_entry, 1, 1, 1, 1);
 
@@ -67,6 +69,7 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     const gchar *name = gtk_entry_get_text(GTK_ENTRY(name_entry));
     const gchar *loc_text = gtk_entry_get_text(GTK_ENTRY(loc_entry));
+    preferences_set_project_dir(prefs, loc_text);
     gchar *loc = expand_home(loc_text);
     gchar *dir = g_build_filename(loc, name, NULL);
     g_mkdir_with_parents(dir, 0755);

--- a/tests/preferences_test.c
+++ b/tests/preferences_test.c
@@ -13,6 +13,7 @@ test_defaults(void)
 
     g_assert_null(preferences_get_sdk(prefs));
     g_assert_cmpuint(preferences_get_swank_port(prefs), ==, 4005);
+    g_assert_cmpstr(preferences_get_project_dir(prefs), ==, "~/lisp");
 
     preferences_unref(prefs);
 
@@ -52,6 +53,33 @@ test_set_sdk(void)
     g_free(tmpdir);
 }
 
+static void
+test_set_project_dir(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("prefs-test-XXXXXX", NULL);
+  Preferences *prefs = preferences_new(tmpdir);
+  gchar *file = g_build_filename(tmpdir, "glide", "preferences.ini", NULL);
+
+  preferences_set_project_dir(prefs, "/tmp/foo");
+  g_assert_cmpstr(preferences_get_project_dir(prefs), ==, "/tmp/foo");
+
+  gchar *contents = NULL;
+  g_file_get_contents(file, &contents, NULL, NULL);
+  g_assert_nonnull(contents);
+  g_assert_nonnull(strstr(contents, "/tmp/foo"));
+  g_free(contents);
+
+  preferences_unref(prefs);
+
+  g_remove(file);
+  gchar *prefs_dir = g_path_get_dirname(file);
+  g_rmdir(prefs_dir);
+  g_rmdir(tmpdir);
+  g_free(prefs_dir);
+  g_free(file);
+  g_free(tmpdir);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -59,6 +87,7 @@ main(int argc, char *argv[])
 
     g_test_add_func("/preferences/defaults", test_defaults);
     g_test_add_func("/preferences/set_sdk", test_set_sdk);
+    g_test_add_func("/preferences/set_project_dir", test_set_project_dir);
 
     return g_test_run();
 }


### PR DESCRIPTION
## Summary
- Track a default project directory in preferences, defaulting to `~/lisp`
- Load and save the location in the New Project wizard so the last-used path is prefilled
- Test preferences for default and custom project directories

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9b359b74c83289e109da722724b32