### PR TITLE
Add project debug logging and activate new project

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -78,6 +78,7 @@ static void project_free(Project *self) {
 }
 
 Project *project_new(void) {
+  g_debug("project_new");
   Project *self = project_init();
   project_create_scratch(self);
   return self;
@@ -87,6 +88,8 @@ ProjectFile *project_add_file(Project *self, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state) {
   g_return_val_if_fail(self != NULL, NULL);
   g_return_val_if_fail(provider, NULL);
+
+  g_debug("project_add_file path=%s state=%d", path ? path : "(null)", state);
 
   ProjectFile *file = g_new0(ProjectFile, 1);
   file->state = state;
@@ -105,6 +108,7 @@ ProjectFile *project_add_file(Project *self, TextProvider *provider,
 
 ProjectFile *project_create_scratch(Project *self) {
   g_return_val_if_fail(self != NULL, NULL);
+  g_debug("project_create_scratch");
   gchar name[12];
   g_snprintf(name, sizeof(name), "scratch%02u", self->next_scratch_id++);
   TextProvider *provider = string_text_provider_new("");
@@ -204,6 +208,7 @@ GHashTable *project_get_index(Project *self, StringDesignatorType sd_type) {
 
 void project_set_asdf(Project *self, Asdf *asdf) {
   g_return_if_fail(self != NULL);
+  g_debug("project_set_asdf %p", asdf);
   if (self->asdf)
     g_object_unref(self->asdf);
   self->asdf = asdf ? g_object_ref(asdf) : NULL;
@@ -216,6 +221,7 @@ Asdf *project_get_asdf(Project *self) {
 
 void project_clear(Project *self) {
   g_return_if_fail(self != NULL);
+  g_debug("project_clear");
   project_index_clear(self);
   if (self->files)
     g_ptr_array_set_size(self->files, 0);
@@ -239,6 +245,7 @@ static void project_index_walk(Project *self, const Node *node) {
 void project_file_changed(Project *self, ProjectFile *file) {
   g_return_if_fail(self != NULL);
   g_return_if_fail(file != NULL);
+  g_debug("project_file_changed path=%s", file->path);
   if (!file->lexer || !file->parser)
     return;
   project_index_clear(self);
@@ -287,6 +294,7 @@ gboolean project_file_load(Project *self, ProjectFile *file) {
   g_return_val_if_fail(file != NULL, FALSE);
 
   const gchar *path = project_file_get_path(file);
+  g_debug("project_file_load path=%s", path ? path : "(null)");
   if (!path)
     return FALSE;
 

--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -3,6 +3,7 @@
 #include "app.h"
 #include "project.h"
 #include "asdf.h"
+#include "file_open.h"
 #include <glib/gstdio.h>
 
 typedef struct {
@@ -29,6 +30,7 @@ static gchar *expand_home(const gchar *path) {
 }
 
 void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
+  g_debug("project_new_wizard");
   App *app = data;
   GtkWidget *dialog = gtk_dialog_new_with_buttons("New Project", NULL,
       GTK_DIALOG_MODAL,
@@ -67,11 +69,13 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
 
   gtk_widget_show_all(dialog);
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+    g_debug("project_new_wizard accepted");
     const gchar *name = gtk_entry_get_text(GTK_ENTRY(name_entry));
     const gchar *loc_text = gtk_entry_get_text(GTK_ENTRY(loc_entry));
     preferences_set_project_dir(prefs, loc_text);
     gchar *loc = expand_home(loc_text);
     gchar *dir = g_build_filename(loc, name, NULL);
+    g_debug("creating project in %s", dir);
     g_mkdir_with_parents(dir, 0755);
     gchar *unnamed = g_build_filename(dir, "unnamed.lisp", NULL);
     g_file_set_contents(unnamed, "", -1, NULL);
@@ -80,8 +84,8 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
     Asdf *asdf = asdf_new_from_file(asd_path);
     asdf_add_component(asdf, "unnamed");
     asdf_save(asdf, asd_path);
-    project_set_asdf(app_get_project(app), asdf);
     g_object_unref(asdf);
+    file_open_path(app, asd_path);
     g_free(unnamed);
     g_free(name_asd);
     g_free(asd_path);


### PR DESCRIPTION
## Summary
- add debug logging to project lifecycle functions
- ensure `Project > New` opens the created project and logs steps

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9bef5c7bc8328ac95c383e88a3490