### PR TITLE
Simplify ASDF view layout

### DIFF
--- a/src/asdf_view.c
+++ b/src/asdf_view.c
@@ -8,7 +8,7 @@ struct _AsdfView {
 
 G_DEFINE_TYPE(AsdfView, asdf_view, GTK_TYPE_TREE_VIEW)
 
-enum { COL_KEY, COL_VALUE, N_COLS };
+enum { COL_TEXT, N_COLS };
 
 static void populate_store(AsdfView *self);
 
@@ -18,16 +18,13 @@ asdf_view_init(AsdfView *self)
   GtkCellRenderer *renderer;
 
   self->asdf = NULL;
-  self->store = gtk_tree_store_new(N_COLS, G_TYPE_STRING, G_TYPE_STRING);
+  self->store = gtk_tree_store_new(N_COLS, G_TYPE_STRING);
   gtk_tree_view_set_model(GTK_TREE_VIEW(self), GTK_TREE_MODEL(self->store));
 
   renderer = gtk_cell_renderer_text_new();
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(self), -1, "Key",
-      renderer, "text", COL_KEY, NULL);
-
-  renderer = gtk_cell_renderer_text_new();
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(self), -1, "Value",
-      renderer, "text", COL_VALUE, NULL);
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(self), -1, NULL,
+      renderer, "text", COL_TEXT, NULL);
+  gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(self), FALSE);
 }
 
 static void
@@ -49,49 +46,42 @@ asdf_view_class_init(AsdfViewClass *klass)
 static void
 populate_store(AsdfView *self)
 {
+  GtkTreeIter root;
   GtkTreeIter iter;
   GtkTreeIter child;
   const gchar *pathname = asdf_get_pathname(self->asdf);
+  const gchar *filename = asdf_get_filename(self->asdf);
+  gchar *basename = filename ? g_path_get_basename(filename) : g_strdup("");
   gtk_tree_store_clear(self->store);
 
-  gtk_tree_store_append(self->store, &iter, NULL);
-  gtk_tree_store_set(self->store, &iter,
-      COL_KEY, "pathname",
-      COL_VALUE, pathname ? pathname : "",
-      -1);
+  gtk_tree_store_append(self->store, &root, NULL);
+  gtk_tree_store_set(self->store, &root, COL_TEXT, basename, -1);
+  g_free(basename);
 
-  gtk_tree_store_append(self->store, &iter, NULL);
-  gtk_tree_store_set(self->store, &iter,
-      COL_KEY, "serial",
-      COL_VALUE, asdf_get_serial(self->asdf) ? "t" : "nil",
-      -1);
+  gtk_tree_store_append(self->store, &iter, &root);
+  gchar *text = g_strdup_printf("pathname %s", pathname ? pathname : "");
+  gtk_tree_store_set(self->store, &iter, COL_TEXT, text, -1);
+  g_free(text);
 
-  gtk_tree_store_append(self->store, &iter, NULL);
-  gtk_tree_store_set(self->store, &iter,
-      COL_KEY, "depends-on",
-      COL_VALUE, "",
-      -1);
+  gtk_tree_store_append(self->store, &iter, &root);
+  text = g_strdup_printf("serial %s", asdf_get_serial(self->asdf) ? "t" : "nil");
+  gtk_tree_store_set(self->store, &iter, COL_TEXT, text, -1);
+  g_free(text);
+
+  gtk_tree_store_append(self->store, &iter, &root);
+  gtk_tree_store_set(self->store, &iter, COL_TEXT, "depends-on", -1);
   for (guint i = 0; i < asdf_get_dependency_count(self->asdf); i++) {
     const gchar *dep = asdf_get_dependency(self->asdf, i);
     gtk_tree_store_append(self->store, &child, &iter);
-    gtk_tree_store_set(self->store, &child,
-        COL_KEY, dep,
-        COL_VALUE, "",
-        -1);
+    gtk_tree_store_set(self->store, &child, COL_TEXT, dep, -1);
   }
 
-  gtk_tree_store_append(self->store, &iter, NULL);
-  gtk_tree_store_set(self->store, &iter,
-      COL_KEY, "components",
-      COL_VALUE, "",
-      -1);
+  gtk_tree_store_append(self->store, &iter, &root);
+  gtk_tree_store_set(self->store, &iter, COL_TEXT, "components", -1);
   for (guint i = 0; i < asdf_get_component_count(self->asdf); i++) {
     const gchar *comp = asdf_get_component(self->asdf, i);
     gtk_tree_store_append(self->store, &child, &iter);
-    gtk_tree_store_set(self->store, &child,
-        COL_KEY, comp,
-        COL_VALUE, "",
-        -1);
+    gtk_tree_store_set(self->store, &child, COL_TEXT, comp, -1);
   }
 
   gtk_tree_view_expand_all(GTK_TREE_VIEW(self));


### PR DESCRIPTION
## Summary
- remove key/value columns in ASDF tree view and hide headers
- display ASDF file name as the root item and nest metadata beneath it
- render values inline with keys in the tree view

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68a9c2570464832890226173ed3992f6