### PR TITLE
Fix tree store initialization in AsdfView

### DIFF
--- a/src/asdf_view.c
+++ b/src/asdf_view.c
@@ -8,7 +8,7 @@ struct _AsdfView {
 
 G_DEFINE_TYPE(AsdfView, asdf_view, GTK_TYPE_TREE_VIEW)
 
-enum { COL_TEXT, COL_VALUE, ASDF_VIEW_N_COLS };
+enum { COL_TEXT, ASDF_VIEW_N_COLS };
 
 static void asdf_view_populate_store(AsdfView *self);
 


### PR DESCRIPTION
## Summary
- remove unused second column and fix GtkTreeStore initialization

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68a9d0f3a240832889319101514390f9