### PR TITLE
Sync project location field with name and warn about existing folders

### DIFF
--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -10,23 +10,66 @@ typedef struct {
   GtkEntry *name_entry;
   GtkEntry *location_entry;
   GtkLabel *info_label;
+  GtkWidget *create_button;
+  const gchar *base_dir;
+  gboolean location_dirty;
 } ProjectNewWidgets;
 
-static void update_info(GtkEditable */*editable*/, gpointer user_data) {
-  ProjectNewWidgets *w = user_data;
-  const gchar *name = gtk_entry_get_text(w->name_entry);
-  const gchar *loc = gtk_entry_get_text(w->location_entry);
-  gchar *path = g_build_filename(loc, name, NULL);
-  gchar *msg = g_strdup_printf("Project will be created in %s/", path);
-  gtk_label_set_text(w->info_label, msg);
-  g_free(msg);
-  g_free(path);
-}
+static void update_info(ProjectNewWidgets *w);
+static void name_changed(GtkEditable *editable, gpointer user_data);
+static void location_changed(GtkEditable *editable, gpointer user_data);
 
 static gchar *expand_home(const gchar *path) {
   if (path[0] == '~')
     return g_build_filename(g_get_home_dir(), path + 1, NULL);
   return g_strdup(path);
+}
+
+static void update_info(ProjectNewWidgets *w) {
+  const gchar *name = gtk_entry_get_text(w->name_entry);
+  const gchar *loc = gtk_entry_get_text(w->location_entry);
+  gchar *loc_expanded = expand_home(loc);
+  gchar *name_asd = g_strdup_printf("%s.asd", name);
+  gchar *asd = g_build_filename(loc_expanded, name_asd, NULL);
+  if (g_file_test(asd, G_FILE_TEST_EXISTS)) {
+    gchar *msg = g_strdup_printf("Already a project named %s/%s", loc, name_asd);
+    gtk_label_set_text(w->info_label, msg);
+    gtk_widget_set_sensitive(w->create_button, FALSE);
+    g_free(msg);
+  } else {
+    gtk_widget_set_sensitive(w->create_button, TRUE);
+    if (g_file_test(loc_expanded, G_FILE_TEST_IS_DIR)) {
+      gchar *msg = g_strdup_printf("Project will be created in existing folder %s", loc);
+      gtk_label_set_text(w->info_label, msg);
+      g_free(msg);
+    } else {
+      gchar *msg = g_strdup_printf("Project will be created in the new folder %s", loc);
+      gtk_label_set_text(w->info_label, msg);
+      g_free(msg);
+    }
+  }
+  g_free(asd);
+  g_free(name_asd);
+  g_free(loc_expanded);
+}
+
+static void location_changed(GtkEditable */*editable*/, gpointer user_data) {
+  ProjectNewWidgets *w = user_data;
+  w->location_dirty = TRUE;
+  update_info(w);
+}
+
+static void name_changed(GtkEditable */*editable*/, gpointer user_data) {
+  ProjectNewWidgets *w = user_data;
+  if (!w->location_dirty) {
+    const gchar *name = gtk_entry_get_text(w->name_entry);
+    gchar *loc = g_build_filename(w->base_dir, name, NULL);
+    g_signal_handlers_block_by_func(w->location_entry, location_changed, w);
+    gtk_entry_set_text(w->location_entry, loc);
+    g_signal_handlers_unblock_by_func(w->location_entry, location_changed, w);
+    g_free(loc);
+  }
+  update_info(w);
 }
 
 void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
@@ -54,7 +97,9 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
   GtkWidget *loc_entry = gtk_entry_new();
   Preferences *prefs = app_get_preferences(app);
   const gchar *dir = preferences_get_project_dir(prefs);
-  gtk_entry_set_text(GTK_ENTRY(loc_entry), dir);
+  gchar *initial = g_build_filename(dir, "untitled", NULL);
+  gtk_entry_set_text(GTK_ENTRY(loc_entry), initial);
+  g_free(initial);
   gtk_grid_attach(GTK_GRID(grid), loc_label, 0, 1, 1, 1);
   gtk_grid_attach(GTK_GRID(grid), loc_entry, 1, 1, 1, 1);
 
@@ -62,19 +107,21 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
   gtk_widget_set_sensitive(info, FALSE);
   gtk_grid_attach(GTK_GRID(grid), info, 1, 2, 1, 1);
 
-  ProjectNewWidgets w = {GTK_ENTRY(name_entry), GTK_ENTRY(loc_entry), GTK_LABEL(info)};
-  g_signal_connect(name_entry, "changed", G_CALLBACK(update_info), &w);
-  g_signal_connect(loc_entry, "changed", G_CALLBACK(update_info), &w);
-  update_info(NULL, &w);
+  GtkWidget *create_button = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
+  ProjectNewWidgets w = {GTK_ENTRY(name_entry), GTK_ENTRY(loc_entry), GTK_LABEL(info), create_button, dir, FALSE};
+  g_signal_connect(name_entry, "changed", G_CALLBACK(name_changed), &w);
+  g_signal_connect(loc_entry, "changed", G_CALLBACK(location_changed), &w);
+  update_info(&w);
 
   gtk_widget_show_all(dialog);
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     g_debug("project_new_wizard accepted");
     const gchar *name = gtk_entry_get_text(GTK_ENTRY(name_entry));
     const gchar *loc_text = gtk_entry_get_text(GTK_ENTRY(loc_entry));
-    preferences_set_project_dir(prefs, loc_text);
-    gchar *loc = expand_home(loc_text);
-    gchar *dir = g_build_filename(loc, name, NULL);
+    gchar *pref_dir = g_path_get_dirname(loc_text);
+    preferences_set_project_dir(prefs, pref_dir);
+    g_free(pref_dir);
+    gchar *dir = expand_home(loc_text);
     g_debug("creating project in %s", dir);
     g_mkdir_with_parents(dir, 0755);
     gchar *unnamed = g_build_filename(dir, "unnamed.lisp", NULL);
@@ -90,7 +137,6 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
     g_free(name_asd);
     g_free(asd_path);
     g_free(dir);
-    g_free(loc);
   }
   gtk_widget_destroy(dialog);
 }


### PR DESCRIPTION
## Summary
- Keep project wizard location in sync with project name until the user edits it
- Show whether the destination folder already exists and disable creation if a project file is present

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9d48a46888328a5ebc734437ba681