### PR TITLE
Refactor project file handling and add relative path helper

### DIFF
--- a/doc/classes.plantuml
+++ b/doc/classes.plantuml
@@ -22,6 +22,8 @@ Project "1" o-- "*" ProjectFile
 ProjectFile *-- LispParser
 ProjectFile *-- TextProvider
 ProjectFile : path
+ProjectFile : project
+ProjectFile --> Project
 
 GtkBox <|-- InteractionsView
 GtkBox <|-- StatusBar

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,7 @@ SOURCES += \
   node.c \
   lisp_parser_view.c \
   project.c \
+  project_file.c \
   gtk_text_provider.c \
   string_text_provider.c \
   text_provider.c \

--- a/src/file_new.c
+++ b/src/file_new.c
@@ -21,7 +21,7 @@ void file_new(GtkWidget */*widget*/, gpointer data) {
     ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
     text_provider_unref(provider);
     if (file) {
-      project_file_load(project, file);
+      project_file_load(file);
       LispSourceView *view = lisp_source_notebook_get_current_view(app_get_notebook(app));
       if (view)
         app_connect_view(app, view);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -72,7 +72,7 @@ gboolean file_open_path(App *app, const gchar *filename) {
       ProjectFile *pf = project_add_file(project, provider, NULL, full, PROJECT_FILE_LIVE);
       text_provider_unref(provider);
       if (pf)
-        project_file_load(project, pf);
+        project_file_load(pf);
       g_free(full);
     }
     g_free(dir);
@@ -83,7 +83,7 @@ gboolean file_open_path(App *app, const gchar *filename) {
     ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
     text_provider_unref(provider);
     if (file)
-      project_file_load(project, file);
+      project_file_load(file);
   }
 
   Preferences *prefs = app_get_preferences(app);

--- a/src/lisp_source_view.c
+++ b/src/lisp_source_view.c
@@ -86,8 +86,7 @@ lisp_source_view_new_for_file (Project *project, ProjectFile *file)
   }
 
   TextProvider *provider = gtk_text_provider_new(GTK_TEXT_BUFFER(self->buffer));
-  project_file_set_provider(self->project, self->file, provider,
-      GTK_TEXT_BUFFER(self->buffer));
+  project_file_set_provider(self->file, provider, GTK_TEXT_BUFFER(self->buffer));
   text_provider_unref(provider);
   g_signal_connect(self->buffer, "changed", G_CALLBACK(on_buffer_changed), self);
   return GTK_WIDGET(self);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 #include "preferences.c"
 #include "preferences_dialog.c"
 #include "process.c"
+#include "project_file.c"
 #include "project.c"
 #include "real_process.c"
 #include "real_swank_process.c"

--- a/src/project.h
+++ b/src/project.h
@@ -3,21 +3,13 @@
 #include <glib.h>
 typedef struct _GtkTextBuffer GtkTextBuffer;
 #include "text_provider.h"
-#include "lisp_lexer.h"
-#include "lisp_parser.h"
+#include "project_file.h"
 #include "node.h"
 #include "asdf.h"
 
 typedef struct _Project Project;
-typedef struct _ProjectFile ProjectFile;
 
 typedef void (*ProjectFileLoadedCb)(Project *self, ProjectFile *file, gpointer user_data);
-
-typedef enum {
-  PROJECT_FILE_DORMANT,
-  PROJECT_FILE_LIVE,
-  PROJECT_FILE_SCRATCH
-} ProjectFileState;
 
 Project       *project_new(void);
 Project       *project_ref(Project *self);
@@ -26,22 +18,14 @@ void           project_set_file_loaded_cb(Project *self, ProjectFileLoadedCb cb,
 ProjectFile   *project_create_scratch(Project *self);
 ProjectFile   *project_get_file(Project *self, guint index);
 guint          project_get_file_count(Project *self);
-ProjectFileState project_file_get_state(ProjectFile *file);
-void           project_file_set_state(ProjectFile *file, ProjectFileState state);
-void           project_file_set_provider(Project *self, ProjectFile *file,
-    TextProvider *provider, GtkTextBuffer *buffer);
-TextProvider  *project_file_get_provider(ProjectFile *file);
 ProjectFile   *project_add_file(Project *self, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
 void           project_file_changed(Project *self, ProjectFile *file);
-LispParser    *project_file_get_parser(ProjectFile *file);
-LispLexer     *project_file_get_lexer(ProjectFile *file);
-GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
-const gchar   *project_file_get_path(ProjectFile *file); // borrowed, do not free
-void           project_file_set_path(ProjectFile *file, const gchar *path);
-gboolean       project_file_load(Project *self, ProjectFile *file);
+void           project_file_loaded(Project *self, ProjectFile *file);
 void           project_index_add(Project *self, Node *node);
 GHashTable    *project_get_index(Project *self, StringDesignatorType sd_type);
 void           project_set_asdf(Project *self, Asdf *asdf);
 Asdf          *project_get_asdf(Project *self);
 void           project_clear(Project *self);
+const gchar   *project_get_path(Project *self);
+void           project_set_path(Project *self, const gchar *path);

--- a/src/project_file.c
+++ b/src/project_file.c
@@ -1,0 +1,180 @@
+#include "project_file.h"
+#include "project.h"
+#include "string_text_provider.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <glib-object.h>
+#include "syscalls.h"
+
+struct _ProjectFile {
+  ProjectFileState state;
+  gchar *path;
+  GtkTextBuffer *buffer; /* nullable */
+  TextProvider *provider; /* owned */
+  LispLexer *lexer; /* owned */
+  LispParser *parser; /* owned */
+  Project *project;
+};
+
+ProjectFile *project_file_new(Project *project, TextProvider *provider,
+    GtkTextBuffer *buffer, const gchar *path, ProjectFileState state) {
+  g_return_val_if_fail(project != NULL, NULL);
+  g_return_val_if_fail(provider, NULL);
+
+  ProjectFile *file = g_new0(ProjectFile, 1);
+  file->project = project;
+  file->state = state;
+  file->provider = text_provider_ref(provider);
+  file->buffer = buffer ? g_object_ref(buffer) : NULL;
+  file->lexer = lisp_lexer_new(file->provider);
+  file->parser = lisp_parser_new();
+  file->path = path ? g_strdup(path) : NULL;
+  return file;
+}
+
+void project_file_free(ProjectFile *file) {
+  if (!file) return;
+  if (file->parser) lisp_parser_free(file->parser);
+  if (file->lexer) lisp_lexer_free(file->lexer);
+  if (file->provider) text_provider_unref(file->provider);
+  if (file->buffer) g_object_unref(file->buffer);
+  g_free(file->path);
+  g_free(file);
+}
+
+ProjectFileState project_file_get_state(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, PROJECT_FILE_DORMANT);
+  return file->state;
+}
+
+void project_file_set_state(ProjectFile *file, ProjectFileState state) {
+  g_return_if_fail(file != NULL);
+  file->state = state;
+}
+
+void project_file_set_provider(ProjectFile *file, TextProvider *provider,
+    GtkTextBuffer *buffer) {
+  g_return_if_fail(file != NULL);
+  g_return_if_fail(provider);
+  if (file->parser)
+    lisp_parser_free(file->parser);
+  if (file->lexer)
+    lisp_lexer_free(file->lexer);
+  if (file->provider)
+    text_provider_unref(file->provider);
+  if (file->buffer)
+    g_object_unref(file->buffer);
+  file->provider = text_provider_ref(provider);
+  file->buffer = buffer ? g_object_ref(buffer) : NULL;
+  file->lexer = lisp_lexer_new(file->provider);
+  file->parser = lisp_parser_new();
+  if (file->project)
+    project_file_changed(file->project, file);
+}
+
+TextProvider *project_file_get_provider(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->provider;
+}
+
+LispParser *project_file_get_parser(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->parser;
+}
+
+LispLexer *project_file_get_lexer(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->lexer;
+}
+
+GtkTextBuffer *project_file_get_buffer(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->buffer;
+}
+
+const gchar *project_file_get_path(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  return file->path;
+}
+
+void project_file_set_path(ProjectFile *file, const gchar *path) {
+  g_return_if_fail(file != NULL);
+  g_free(file->path);
+  file->path = path ? g_strdup(path) : NULL;
+}
+
+gboolean project_file_load(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, FALSE);
+
+  const gchar *path = project_file_get_path(file);
+  g_debug("project_file_load path=%s", path ? path : "(null)");
+  if (!path)
+    return FALSE;
+
+  int fd = sys_open(path, O_RDONLY, 0);
+  if (fd == -1) {
+    g_printerr("Failed to open file using syscalls: %s (errno: %d)\n", path, errno);
+    return FALSE;
+  }
+
+  struct stat sb;
+  if (sys_fstat(fd, &sb) == -1 || !S_ISREG(sb.st_mode)) {
+    g_printerr("Not a regular file: %s\n", path);
+    sys_close(fd);
+    return FALSE;
+  }
+
+  off_t length = sb.st_size;
+  char *content = g_malloc(length + 1);
+  if (!content) {
+    g_printerr("Failed to allocate memory for file content.\n");
+    sys_close(fd);
+    return FALSE;
+  }
+
+  ssize_t total_read = 0;
+  while (total_read < length) {
+    ssize_t r = sys_read(fd, content + total_read, length - total_read);
+    if (r == -1) {
+      g_printerr("Error reading file: %s (errno: %d)\n", path, errno);
+      g_free(content);
+      sys_close(fd);
+      return FALSE;
+    } else if (r == 0) {
+      break;
+    }
+    total_read += r;
+  }
+
+  content[total_read] = '\0';
+  sys_close(fd);
+
+  TextProvider *provider = string_text_provider_new(content);
+  project_file_set_provider(file, provider, NULL);
+  text_provider_unref(provider);
+  project_file_set_state(file, PROJECT_FILE_LIVE);
+
+  Project *self = file->project;
+  if (self)
+    project_file_loaded(self, file);
+
+  g_free(content);
+  return TRUE;
+}
+
+const gchar *project_file_get_relative_path(ProjectFile *file) {
+  g_return_val_if_fail(file != NULL, NULL);
+  const gchar *path = file->path;
+  if (!path)
+    return NULL;
+  Project *project = file->project;
+  const gchar *project_path = project ? project_get_path(project) : NULL;
+  if (project_path && g_str_has_prefix(path, project_path)) {
+    const gchar *rel = path + strlen(project_path);
+    if (g_str_has_prefix(rel, "/")) rel++;
+    return rel;
+  }
+  return path;
+}

--- a/src/project_file.h
+++ b/src/project_file.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <glib.h>
+typedef struct _GtkTextBuffer GtkTextBuffer;
+#include "text_provider.h"
+#include "lisp_lexer.h"
+#include "lisp_parser.h"
+
+typedef struct _Project Project;
+
+typedef enum {
+  PROJECT_FILE_DORMANT,
+  PROJECT_FILE_LIVE,
+  PROJECT_FILE_SCRATCH
+} ProjectFileState;
+
+typedef struct _ProjectFile ProjectFile;
+
+ProjectFile *project_file_new(Project *project, TextProvider *provider,
+    GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
+void        project_file_free(ProjectFile *file);
+ProjectFileState project_file_get_state(ProjectFile *file);
+void        project_file_set_state(ProjectFile *file, ProjectFileState state);
+void        project_file_set_provider(ProjectFile *file, TextProvider *provider,
+    GtkTextBuffer *buffer);
+TextProvider *project_file_get_provider(ProjectFile *file);
+LispParser  *project_file_get_parser(ProjectFile *file);
+LispLexer   *project_file_get_lexer(ProjectFile *file);
+GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
+const gchar *project_file_get_path(ProjectFile *file); /* borrowed */
+void        project_file_set_path(ProjectFile *file, const gchar *path);
+gboolean    project_file_load(ProjectFile *file);
+const gchar *project_file_get_relative_path(ProjectFile *file);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,10 +22,10 @@ swank_session_test: swank_session_test.c swank_session.c swank_process.c real_sw
 lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project.c analyser.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+project_test: project_test.c project.c project_file.c analyser.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c analyser.c
+asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c project_file.c analyser.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 analyser_test: analyser_test.c analyser.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -58,7 +58,7 @@ static void test_file_load(void)
   int count = 0;
   project_set_file_loaded_cb(project, on_file_loaded, &count);
 
-  gboolean ok = project_file_load(project, file);
+  gboolean ok = project_file_load(file);
   g_assert_true(ok);
   g_assert_cmpint(count, ==, 1);
 
@@ -125,6 +125,24 @@ static void test_index(void)
   project_unref(project);
 }
 
+static void test_relative_path(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("project-test-XXXXXX", NULL);
+  Project *project = project_new();
+  project_set_path(project, tmpdir);
+  TextProvider *provider = string_text_provider_new("");
+  gchar *filepath = g_build_filename(tmpdir, "file.lisp", NULL);
+  ProjectFile *file = project_add_file(project, provider, NULL, filepath,
+      PROJECT_FILE_LIVE);
+  text_provider_unref(provider);
+  const gchar *rel = project_file_get_relative_path(file);
+  g_assert_cmpstr(rel, ==, "file.lisp");
+  project_unref(project);
+  g_free(filepath);
+  g_rmdir(tmpdir);
+  g_free(tmpdir);
+}
+
 
 int main(int argc, char *argv[])
 {
@@ -134,5 +152,6 @@ int main(int argc, char *argv[])
   g_test_add_func("/project/file_load", test_file_load);
   g_test_add_func("/project/function_analysis", test_function_analysis);
   g_test_add_func("/project/index", test_index);
+  g_test_add_func("/project/relative_path", test_relative_path);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- split ProjectFile into its own module and link it back to Project
- expose Project path and relative path helper for ProjectFile
- hide ProjectFile internals behind an opaque struct
- update build scripts, sources and tests for new ProjectFile API

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc55eb1883289d9313ef1e7d49ea