### PR TITLE
Remove pathname handling from Asdf

### DIFF
--- a/src/asdf.h
+++ b/src/asdf.h
@@ -10,8 +10,6 @@ G_DECLARE_FINAL_TYPE(Asdf, asdf, GLIDE, ASDF, GObject)
 Asdf *asdf_new(void);
 Asdf *asdf_new_from_file(const gchar *filename);
 const gchar *asdf_get_filename(Asdf *self);
-const gchar *asdf_get_pathname(Asdf *self);
-void asdf_set_pathname(Asdf *self, const gchar *pathname);
 void asdf_set_serial(Asdf *self, gboolean serial);
 gboolean asdf_get_serial(Asdf *self);
 void asdf_add_component(Asdf *self, const gchar *file);

--- a/src/asdf_view.c
+++ b/src/asdf_view.c
@@ -49,7 +49,6 @@ asdf_view_populate_store(AsdfView *self)
   GtkTreeIter root;
   GtkTreeIter iter;
   GtkTreeIter child;
-  const gchar *pathname = asdf_get_pathname(self->asdf);
   const gchar *filename = asdf_get_filename(self->asdf);
   gchar *basename = filename ? g_path_get_basename(filename) : g_strdup("");
   gtk_tree_store_clear(self->store);
@@ -59,12 +58,7 @@ asdf_view_populate_store(AsdfView *self)
   g_free(basename);
 
   gtk_tree_store_append(self->store, &iter, &root);
-  gchar *text = g_strdup_printf("pathname %s", pathname ? pathname : "");
-  gtk_tree_store_set(self->store, &iter, COL_TEXT, text, -1);
-  g_free(text);
-
-  gtk_tree_store_append(self->store, &iter, &root);
-  text = g_strdup_printf("serial %s", asdf_get_serial(self->asdf) ? "t" : "nil");
+  gchar *text = g_strdup_printf("serial %s", asdf_get_serial(self->asdf) ? "t" : "nil");
   gtk_tree_store_set(self->store, &iter, COL_TEXT, text, -1);
   g_free(text);
 

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -61,8 +61,7 @@ gboolean file_open_path(App *app, const gchar *filename) {
     project_set_asdf(project, asdf);
     g_object_unref(asdf);
     gchar *base = g_path_get_dirname(filename);
-    const gchar *pathname = asdf_get_pathname(project_get_asdf(project));
-    gchar *dir = pathname ? g_build_filename(base, pathname, NULL) : g_strdup(base);
+    gchar *dir = g_strdup(base);
     for (guint i = 0; i < asdf_get_component_count(project_get_asdf(project)); i++) {
       const gchar *comp = asdf_get_component(project_get_asdf(project), i);
       gchar *path = g_build_filename(dir, comp, NULL);

--- a/tests/asdf_test.c
+++ b/tests/asdf_test.c
@@ -6,11 +6,10 @@ static void test_parse(void)
 {
   gchar *tmpdir = g_dir_make_tmp("asdf-test-XXXXXX", NULL);
   gchar *file = g_build_filename(tmpdir, "foo.asd", NULL);
-  const gchar *contents = "(defsystem \"foo\"\n  :serial t\n  :pathname \"bar/\"\n  :components ((file \"a\") (file \"b\"))\n  :depends-on (\"dep1\" \"dep2\"))";
+  const gchar *contents = "(defsystem \"foo\"\n  :serial t\n  :components ((file \"a\") (file \"b\"))\n  :depends-on (\"dep1\" \"dep2\"))";
   g_file_set_contents(file, contents, -1, NULL);
 
   Asdf *asdf = asdf_new_from_file(file);
-  g_assert_cmpstr(asdf_get_pathname(asdf), ==, "bar/");
   g_assert_true(asdf_get_serial(asdf));
   g_assert_cmpuint(asdf_get_component_count(asdf), ==, 2);
   g_assert_cmpstr(asdf_get_component(asdf, 0), ==, "a");
@@ -20,7 +19,7 @@ static void test_parse(void)
   g_assert_cmpstr(asdf_get_dependency(asdf, 1), ==, "dep2");
 
   gchar *str = asdf_to_string(asdf);
-  g_assert_nonnull(strstr(str, "pathname \"bar/\""));
+  g_assert_null(strstr(str, "pathname"));
   g_free(str);
 
   g_object_unref(asdf);
@@ -36,7 +35,6 @@ static void test_save(void)
   gchar *out = g_build_filename(tmpdir, "out.asd", NULL);
 
   Asdf *asdf = asdf_new();
-  asdf_set_pathname(asdf, "bar/");
   asdf_set_serial(asdf, TRUE);
   asdf_add_component(asdf, "a");
   asdf_add_component(asdf, "b");


### PR DESCRIPTION
## Summary
- drop pathname field and related parsing/serialization from Asdf
- adjust file open and view logic to operate without pathnames
- update Asdf tests to reflect removal of pathname support

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9df42b62483288c49ba2ea4a23e57