### PR TITLE
feat: remember recent projects

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -24,6 +24,7 @@ STATIC LispSourceNotebook *app_get_notebook(App *self);
 STATIC Project *app_get_project(App *self);
 STATIC void app_connect_view(App *self, LispSourceView *view);
 STATIC void app_update_asdf_view(App *self);
+STATIC void app_update_recent_menu(App *self);
 STATIC Preferences *app_get_preferences(App *self);
 STATIC SwankSession *app_get_swank(App *self);
 STATIC void app_on_quit(App *self);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -91,6 +91,8 @@ gboolean file_open_path(App *app, const gchar *filename) {
 
   Preferences *prefs = app_get_preferences(app);
   preferences_set_project_file(prefs, filename);
+  preferences_add_recent_project(prefs, filename);
+  app_update_recent_menu(app);
 
   LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
   if (view)

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -17,4 +17,6 @@ const gchar *preferences_get_project_dir(Preferences *self);
 void         preferences_set_project_dir(Preferences *self, const gchar *dir);
 gint         preferences_get_asdf_view_width(Preferences *self);
 void         preferences_set_asdf_view_width(Preferences *self, gint width);
+const GList *preferences_get_recent_projects(Preferences *self);
+void         preferences_add_recent_project(Preferences *self, const gchar *path);
 

--- a/tests/preferences_test.c
+++ b/tests/preferences_test.c
@@ -108,6 +108,45 @@ test_set_asdf_view_width(void)
   g_free(tmpdir);
 }
 
+static void
+test_recent_projects(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("prefs-test-XXXXXX", NULL);
+  Preferences *prefs = preferences_new(tmpdir);
+
+  preferences_add_recent_project(prefs, "/tmp/a");
+  preferences_add_recent_project(prefs, "/tmp/b");
+  preferences_add_recent_project(prefs, "/tmp/c");
+  preferences_add_recent_project(prefs, "/tmp/d");
+  preferences_add_recent_project(prefs, "/tmp/e");
+  preferences_add_recent_project(prefs, "/tmp/f");
+
+  const GList *list = preferences_get_recent_projects(prefs);
+  g_assert_cmpuint(g_list_length((GList *)list), ==, 5);
+  g_assert_cmpstr(list->data, ==, "/tmp/f");
+  g_assert_cmpstr(g_list_nth_data((GList *)list, 4), ==, "/tmp/b");
+
+  preferences_add_recent_project(prefs, "/tmp/d");
+  list = preferences_get_recent_projects(prefs);
+  g_assert_cmpstr(list->data, ==, "/tmp/d");
+  g_assert_cmpstr(g_list_nth_data((GList *)list, 1), ==, "/tmp/f");
+
+  preferences_unref(prefs);
+  prefs = preferences_new(tmpdir);
+  list = preferences_get_recent_projects(prefs);
+  g_assert_cmpstr(list->data, ==, "/tmp/d");
+  preferences_unref(prefs);
+
+  gchar *file = g_build_filename(tmpdir, "glide", "preferences.ini", NULL);
+  g_remove(file);
+  gchar *prefs_dir = g_path_get_dirname(file);
+  g_rmdir(prefs_dir);
+  g_rmdir(tmpdir);
+  g_free(prefs_dir);
+  g_free(file);
+  g_free(tmpdir);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -117,6 +156,7 @@ main(int argc, char *argv[])
     g_test_add_func("/preferences/set_sdk", test_set_sdk);
     g_test_add_func("/preferences/set_project_dir", test_set_project_dir);
     g_test_add_func("/preferences/set_asdf_view_width", test_set_asdf_view_width);
+    g_test_add_func("/preferences/recent_projects", test_recent_projects);
 
     return g_test_run();
 }


### PR DESCRIPTION
## Summary
- track last 5 opened projects in preferences
- populate Project > Recent menu and update on open
- test recent project persistence

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9e73a85088328a2aae30dada420f7