### PR TITLE
Inline ensure_lisp_extension helper

### DIFF
--- a/src/file_new.c
+++ b/src/file_new.c
@@ -8,12 +8,7 @@
 #include "lisp_source_view.h"
 #include "project_file.h"
 #include "asdf.h"
-
-static gchar *ensure_lisp_extension(const gchar *name) {
-  if (g_str_has_suffix(name, ".lisp"))
-    return g_strdup(name);
-  return g_strconcat(name, ".lisp", NULL);
-}
+#include "file_utilities.h"
 
 void file_new(GtkWidget */*widget*/, gpointer data) {
   App *app = data;

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -15,6 +15,7 @@
 #include "file_save.h"
 #include "preferences.h"
 #include "asdf.h"
+#include "file_utilities.h"
 
 static gboolean save_if_modified(App *app) {
   Project *project = app_get_project(app);
@@ -37,12 +38,6 @@ static gboolean save_if_modified(App *app) {
       file_save(NULL, app);
   }
   return TRUE;
-}
-
-static gchar *ensure_lisp_extension(const gchar *path) {
-  if (g_str_has_suffix(path, ".lisp"))
-    return g_strdup(path);
-  return g_strconcat(path, ".lisp", NULL);
 }
 
 gboolean file_open_path(App *app, const gchar *filename) {

--- a/src/file_utilities.h
+++ b/src/file_utilities.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <glib.h>
+
+static inline gchar *ensure_lisp_extension(const gchar *path) {
+  if (g_str_has_suffix(path, ".lisp"))
+    return g_strdup(path);
+  return g_strconcat(path, ".lisp", NULL);
+}
+


### PR DESCRIPTION
## Summary
- Move duplicated ensure_lisp_extension logic into new inline utility header
- Use shared ensure_lisp_extension in file_open.c and file_new.c

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9eee5b36c8328a95ef9800e039816