### PR TITLE
Fix notebook save-all crash due to invalid cast

### DIFF
--- a/src/file_save.c
+++ b/src/file_save.c
@@ -113,8 +113,9 @@ void file_save_all(GtkWidget * /*widget*/, gpointer data) {
   gint current = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
   gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
   for (gint i = 0; i < pages; i++) {
-    GtkWidget *child = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
-    GtkTextBuffer *buffer = GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(child)));
+    GtkWidget *scrolled = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
+    GtkWidget *view = gtk_bin_get_child(GTK_BIN(scrolled));
+    GtkTextBuffer *buffer = GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(view)));
     if (buffer && gtk_text_buffer_get_modified(buffer)) {
       gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), i);
       file_save(NULL, app);


### PR DESCRIPTION
## Summary
- fix `file_save_all` to handle GtkScrolledWindow pages and access the underlying `LispSourceView`

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9f00bf7708328b14f480834bc2edf