### PR TITLE
Fix scrolled window cast in save check

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -405,7 +405,8 @@ app_maybe_save_all(App *self)
   gboolean modified = FALSE;
   for (gint i = 0; i < pages; i++) {
     GtkWidget *child = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
-    GtkTextBuffer *buffer = GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(child)));
+    GtkWidget *view = child ? gtk_bin_get_child(GTK_BIN(child)) : NULL;
+    GtkTextBuffer *buffer = view ? GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(view))) : NULL;
     if (buffer && gtk_text_buffer_get_modified(buffer)) {
       modified = TRUE;
       break;


### PR DESCRIPTION
## Summary
- correctly retrieve source view from notebook pages in `app_maybe_save_all`

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68a9f1d955388328924d9f789223a1cd