### PR TITLE
Avoid redundant project parsing and reset buffer state

### DIFF
--- a/src/lisp_source_view.c
+++ b/src/lisp_source_view.c
@@ -88,6 +88,8 @@ lisp_source_view_new_for_file (Project *project, ProjectFile *file)
   TextProvider *provider = gtk_text_provider_new(GTK_TEXT_BUFFER(self->buffer));
   project_file_set_provider(self->file, provider, GTK_TEXT_BUFFER(self->buffer));
   text_provider_unref(provider);
+  project_file_changed(self->project, self->file);
+  gtk_text_buffer_set_modified(GTK_TEXT_BUFFER(self->buffer), FALSE);
   g_signal_connect(self->buffer, "changed", G_CALLBACK(on_buffer_changed), self);
   return GTK_WIDGET(self);
 }

--- a/src/project.c
+++ b/src/project.c
@@ -74,8 +74,6 @@ ProjectFile *project_add_file(Project *self, TextProvider *provider,
 
   g_ptr_array_add(self->files, file);
 
-  project_file_changed(self, file);
-
   return file;
 }
 

--- a/src/project_file.c
+++ b/src/project_file.c
@@ -70,8 +70,6 @@ void project_file_set_provider(ProjectFile *file, TextProvider *provider,
   file->buffer = buffer ? g_object_ref(buffer) : NULL;
   file->lexer = lisp_lexer_new(file->provider);
   file->parser = lisp_parser_new();
-  if (file->project)
-    project_file_changed(file->project, file);
 }
 
 TextProvider *project_file_get_provider(ProjectFile *file) {

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -21,7 +21,7 @@ static void test_parse_on_change(void)
   TextProvider *provider = string_text_provider_new("(a)");
   ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_SCRATCH);
   text_provider_unref(provider);
-  /* file already parsed by project_add_file */
+  project_file_changed(project, file);
   LispParser *parser = project_file_get_parser(file);
   LispLexer *lexer = project_file_get_lexer(file);
   GArray *tokens = lisp_lexer_get_tokens(lexer);
@@ -81,6 +81,7 @@ static void test_function_analysis(void)
   TextProvider *provider = string_text_provider_new("(defun foo () (bar))");
   ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_SCRATCH);
   text_provider_unref(provider);
+  project_file_changed(project, file);
   LispParser *parser = project_file_get_parser(file);
   const Node *ast = lisp_parser_get_ast(parser);
   const Node *form = g_array_index(ast->children, Node*, 0);
@@ -101,6 +102,7 @@ static void test_index(void)
   ProjectFile *file = project_add_file(project, provider, NULL, NULL,
       PROJECT_FILE_SCRATCH);
   text_provider_unref(provider);
+  project_file_changed(project, file);
   LispParser *parser = project_file_get_parser(file);
   const Node *ast = lisp_parser_get_ast(parser);
   const Node *form = g_array_index(ast->children, Node*, 0);


### PR DESCRIPTION
## Summary
- Stop Project from auto-re-parsing files on add or provider change
- Rebuild project state once after view setup and clear buffer modified flag
- Update tests to parse explicitly after adding files

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68aa260c765883289fef006c6615aa06