### PR TITLE
Preserve project on quit and improve preference logging

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -23,7 +23,7 @@ STATIC void     on_notebook_paned_position(GObject *object, GParamSpec *pspec, g
 STATIC void     app_update_recent_menu(App *self);
 STATIC void     on_recent_project_activate(GtkWidget *item, gpointer data);
 STATIC gboolean app_maybe_save_all(App *self);
-STATIC gboolean app_close_project(App *self);
+STATIC gboolean app_close_project(App *self, gboolean forget_project);
 
 /* === Instance structure ================================================= */
 struct _App
@@ -430,9 +430,9 @@ app_maybe_save_all(App *self)
 }
 
 STATIC gboolean
-app_close_project(App *self)
+app_close_project(App *self, gboolean forget_project)
 {
-  g_debug("App.close_project");
+  g_debug("App.close_project forget=%d", forget_project);
   g_return_val_if_fail(GLIDE_IS_APP(self), FALSE);
   if (!app_maybe_save_all(self))
     return FALSE;
@@ -441,7 +441,7 @@ app_close_project(App *self)
   project_clear(project);
   lisp_source_notebook_clear(notebook);
   Preferences *prefs = app_get_preferences(self);
-  if (prefs)
+  if (prefs && forget_project)
     preferences_set_project_file(prefs, NULL);
   app_update_asdf_view(self);
   return TRUE;
@@ -451,7 +451,7 @@ STATIC void
 close_project_menu_item(GtkWidget * /*item*/, gpointer data)
 {
   g_debug("App.close_project_menu_item");
-  app_close_project(GLIDE_APP(data));
+  app_close_project(GLIDE_APP(data), TRUE);
 }
 
 STATIC void
@@ -467,7 +467,7 @@ app_on_quit (App *self)
 {
   g_debug("App.on_quit");
   g_return_if_fail (GLIDE_IS_APP (self));
-  if (!app_close_project(self))
+  if (!app_close_project(self, FALSE))
     return;
   app_quit (self);
 }

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -41,6 +41,7 @@ static gboolean save_if_modified(App *app) {
 }
 
 gboolean file_open_path(App *app, const gchar *filename) {
+  g_debug("file_open_path %s", filename);
   g_return_val_if_fail(app != NULL, FALSE);
   if (!save_if_modified(app))
     return FALSE;

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -15,6 +15,7 @@ struct _Preferences {
 };
 
 static void preferences_load(Preferences *self) {
+  g_debug("preferences_load %s", self->filename);
   GKeyFile *key_file = g_key_file_new();
   if (g_key_file_load_from_file(key_file, self->filename, G_KEY_FILE_NONE, NULL)) {
     char *sdk = g_key_file_get_string(key_file, "General", "sdk", NULL);
@@ -31,6 +32,7 @@ static void preferences_load(Preferences *self) {
 
     char *proj = g_key_file_get_string(key_file, "General", "project_file", NULL);
     if (proj) {
+      g_debug("preferences_load project_file %s", proj);
       preferences_set_project_file(self, proj);
       g_free(proj);
     }
@@ -56,6 +58,7 @@ static void preferences_load(Preferences *self) {
 }
 
 static void preferences_save(Preferences *self) {
+  g_debug("preferences_save project_file=%s", self->project_file);
   /* Ensure that the configuration directory exists */
   char *dir = g_path_get_dirname(self->filename);
   if (g_mkdir_with_parents(dir, 0700) != 0 && errno != EEXIST) {
@@ -147,6 +150,7 @@ const gchar *preferences_get_project_file(Preferences *self) {
 }
 
 void preferences_set_project_file(Preferences *self, const gchar *file) {
+  g_debug("preferences_set_project_file %s", file);
   if (g_strcmp0(self->project_file, file) != 0) {
     g_free(self->project_file);
     self->project_file = g_strdup(file);


### PR DESCRIPTION
## Summary
- Avoid clearing project file preference on application quit so last project reopens on restart
- Add detailed g_debug logging for preference load/save and project file updates
- Log file_open_path and clarify project closing behavior

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68aa29baa3c08328a35f8cb9a5892bd7