### PR TITLE
Remember last file and cursor position

### DIFF
--- a/src/preferences.h
+++ b/src/preferences.h
@@ -19,4 +19,8 @@ gint         preferences_get_asdf_view_width(Preferences *self);
 void         preferences_set_asdf_view_width(Preferences *self, gint width);
 const GList *preferences_get_recent_projects(Preferences *self);
 void         preferences_add_recent_project(Preferences *self, const gchar *path);
+const gchar *preferences_get_last_file(Preferences *self);
+void         preferences_set_last_file(Preferences *self, const gchar *file);
+gint         preferences_get_cursor_position(Preferences *self);
+void         preferences_set_cursor_position(Preferences *self, gint pos);
 


### PR DESCRIPTION
## Summary
- track last focused file and cursor position in preferences
- restore last file and cursor on startup
- save last file and cursor when quitting or closing project

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68aa3b3865308328969acc0975171a42