### PR TITLE
Sync notebook and ASDF selections

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -24,6 +24,9 @@ STATIC void     app_update_recent_menu(App *self);
 STATIC void     on_recent_project_activate(GtkWidget *item, gpointer data);
 STATIC gboolean app_maybe_save_all(App *self);
 STATIC gboolean app_close_project(App *self, gboolean forget_project);
+STATIC void     on_asdf_view_selection_changed(GtkTreeSelection *selection, gpointer data);
+STATIC void     on_notebook_switch_page(GtkNotebook *notebook, GtkWidget *page, guint page_num, gpointer data);
+STATIC gboolean component_matches(const gchar *comp, const gchar *rel);
 
 /* === Instance structure ================================================= */
 struct _App
@@ -109,6 +112,8 @@ app_activate (GApplication *app)
   g_signal_connect(self->notebook_paned, "notify::position",
       G_CALLBACK(on_notebook_paned_position), self);
   gtk_paned_pack2(GTK_PANED(self->notebook_paned), notebook, TRUE, TRUE);
+  g_signal_connect(self->notebook, "switch-page",
+      G_CALLBACK(on_notebook_switch_page), self);
 
   LispSourceView *view = lisp_source_notebook_get_current_view(self->notebook);
   g_signal_connect (view, "key-press-event", G_CALLBACK (on_key_press), self);
@@ -301,6 +306,22 @@ app_get_current_file(App *self)
   return view ? lisp_source_view_get_file(view) : NULL;
 }
 
+STATIC gboolean
+component_matches(const gchar *comp, const gchar *rel)
+{
+  if (!comp || !rel)
+    return FALSE;
+  if (g_strcmp0(comp, rel) == 0)
+    return TRUE;
+  gchar *base = g_path_get_basename(rel);
+  gchar *dot = g_strrstr(base, ".");
+  if (dot)
+    *dot = '\0';
+  gboolean match = g_strcmp0(comp, base) == 0;
+  g_free(base);
+  return match;
+}
+
 STATIC void
 app_update_asdf_view(App *self)
 {
@@ -315,6 +336,8 @@ app_update_asdf_view(App *self)
   if (!asdf)
     return;
   GtkWidget *view = asdf_view_new(asdf);
+  GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
+  g_signal_connect(sel, "changed", G_CALLBACK(on_asdf_view_selection_changed), self);
   self->asdf_scrolled = gtk_scrolled_window_new(NULL, NULL);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self->asdf_scrolled),
       GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
@@ -323,6 +346,8 @@ app_update_asdf_view(App *self)
   gtk_paned_pack1(GTK_PANED(self->notebook_paned), self->asdf_scrolled, FALSE, TRUE);
   gint width = preferences_get_asdf_view_width(self->preferences);
   gtk_paned_set_position(GTK_PANED(self->notebook_paned), width);
+  on_notebook_switch_page(GTK_NOTEBOOK(self->notebook), NULL,
+      gtk_notebook_get_current_page(GTK_NOTEBOOK(self->notebook)), self);
 }
 
 STATIC void
@@ -336,6 +361,60 @@ on_notebook_paned_position(GObject *object, GParamSpec * /*pspec*/, gpointer dat
     return;
   gint pos = gtk_paned_get_position(GTK_PANED(object));
   preferences_set_asdf_view_width(prefs, pos);
+}
+
+STATIC void
+on_asdf_view_selection_changed(GtkTreeSelection *selection, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  GtkTreeModel *model;
+  GtkTreeIter iter;
+  if (!gtk_tree_selection_get_selected(selection, &model, &iter))
+    return;
+  GtkTreeIter parent;
+  if (!gtk_tree_model_iter_parent(model, &parent, &iter))
+    return;
+  gchar *parent_text = NULL;
+  gtk_tree_model_get(model, &parent, 0, &parent_text, -1);
+  gboolean is_component = g_strcmp0(parent_text, "components") == 0;
+  g_free(parent_text);
+  if (!is_component)
+    return;
+  gchar *comp = NULL;
+  gtk_tree_model_get(model, &iter, 0, &comp, -1);
+  if (!comp)
+    return;
+  guint count = project_get_file_count(self->project);
+  for (guint i = 0; i < count; i++) {
+    ProjectFile *file = project_get_file(self->project, i);
+    const gchar *rel = project_file_get_relative_path(file);
+    if (component_matches(comp, rel)) {
+      gtk_notebook_set_current_page(GTK_NOTEBOOK(self->notebook), i);
+      break;
+    }
+  }
+  g_free(comp);
+}
+
+STATIC void
+on_notebook_switch_page(GtkNotebook * /*notebook*/, GtkWidget * /*page*/, guint /*page_num*/, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  if (!self->asdf_scrolled)
+    return;
+  GtkWidget *view = gtk_bin_get_child(GTK_BIN(self->asdf_scrolled));
+  if (!view)
+    return;
+  LispSourceView *lsv = lisp_source_notebook_get_current_view(self->notebook);
+  if (!lsv)
+    return;
+  ProjectFile *file = lisp_source_view_get_file(lsv);
+  if (!file)
+    return;
+  const gchar *rel = project_file_get_relative_path(file);
+  if (!rel)
+    return;
+  asdf_view_select_file(ASDF_VIEW(view), rel);
 }
 
 STATIC void

--- a/src/asdf_view.c
+++ b/src/asdf_view.c
@@ -11,6 +11,8 @@ G_DEFINE_TYPE(AsdfView, asdf_view, GTK_TYPE_TREE_VIEW)
 enum { COL_TEXT, ASDF_VIEW_N_COLS };
 
 static void asdf_view_populate_store(AsdfView *self);
+static gboolean filename_matches(const gchar *component, const gchar *file);
+static gchar *get_selected_component(AsdfView *self);
 
 static void
 asdf_view_init(AsdfView *self)
@@ -89,5 +91,89 @@ asdf_view_new(Asdf *asdf)
   self->asdf = g_object_ref(asdf);
   asdf_view_populate_store(self);
   return GTK_WIDGET(self);
+}
+
+static gboolean
+filename_matches(const gchar *component, const gchar *file)
+{
+  if (!component || !file)
+    return FALSE;
+  if (g_strcmp0(component, file) == 0)
+    return TRUE;
+  gchar *base = g_path_get_basename(file);
+  gchar *dot = g_strrstr(base, ".");
+  if (dot)
+    *dot = '\0';
+  gboolean match = g_strcmp0(component, base) == 0;
+  g_free(base);
+  return match;
+}
+
+static gchar *
+get_selected_component(AsdfView *self)
+{
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(self));
+  GtkTreeModel *model;
+  GtkTreeIter iter;
+  if (!gtk_tree_selection_get_selected(selection, &model, &iter))
+    return NULL;
+  GtkTreeIter parent;
+  if (!gtk_tree_model_iter_parent(model, &parent, &iter))
+    return NULL;
+  gchar *parent_text = NULL;
+  gtk_tree_model_get(model, &parent, COL_TEXT, &parent_text, -1);
+  gboolean is_component = g_strcmp0(parent_text, "components") == 0;
+  g_free(parent_text);
+  if (!is_component)
+    return NULL;
+  gchar *comp = NULL;
+  gtk_tree_model_get(model, &iter, COL_TEXT, &comp, -1);
+  return comp;
+}
+
+void
+asdf_view_select_file(AsdfView *self, const gchar *file)
+{
+  g_return_if_fail(ASDF_IS_VIEW(self));
+  g_return_if_fail(file != NULL);
+  gchar *current = get_selected_component(self);
+  if (filename_matches(current, file)) {
+    g_free(current);
+    return;
+  }
+  g_free(current);
+  GtkTreeModel *model = GTK_TREE_MODEL(self->store);
+  GtkTreeIter root;
+  GtkTreeIter iter;
+  GtkTreeIter child;
+  if (!gtk_tree_model_get_iter_first(model, &root))
+    return;
+  if (!gtk_tree_model_iter_children(model, &iter, &root))
+    return;
+  do {
+    gchar *text = NULL;
+    gtk_tree_model_get(model, &iter, COL_TEXT, &text, -1);
+    gboolean is_components = g_strcmp0(text, "components") == 0;
+    g_free(text);
+    if (is_components) {
+      if (gtk_tree_model_iter_children(model, &child, &iter)) {
+        do {
+          gchar *comp = NULL;
+          gtk_tree_model_get(model, &child, COL_TEXT, &comp, -1);
+          if (filename_matches(comp, file)) {
+            GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(self));
+            GtkTreePath *path = gtk_tree_model_get_path(model, &child);
+            gtk_tree_selection_select_path(sel, path);
+            gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(self), path, NULL, FALSE, 0, 0);
+            gtk_tree_path_free(path);
+            g_free(comp);
+            return;
+          }
+          g_free(comp);
+        } while (gtk_tree_model_iter_next(model, &child));
+      }
+      break;
+    }
+  } while (gtk_tree_model_iter_next(model, &iter));
 }
 

--- a/src/asdf_view.h
+++ b/src/asdf_view.h
@@ -9,5 +9,6 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(AsdfView, asdf_view, ASDF, VIEW, GtkTreeView)
 
 GtkWidget *asdf_view_new(Asdf *asdf);
+void asdf_view_select_file(AsdfView *self, const gchar *file);
 
 G_END_DECLS


### PR DESCRIPTION
## Summary
- Sync file selections between source notebook and ASDF view in both directions
- Add helper to select files within ASDF view

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68aa3beb146483289aa2a38ed7c7b97f