### PR TITLE
Default create action on Enter in new file dialog

### DIFF
--- a/src/file_new.c
+++ b/src/file_new.c
@@ -20,6 +20,8 @@ void file_new(GtkWidget */*widget*/, gpointer data) {
   GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   GtkWidget *entry = gtk_entry_new();
   gtk_container_add(GTK_CONTAINER(content), entry);
+  gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   gtk_widget_show_all(dialog);
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     const gchar *name = gtk_entry_get_text(GTK_ENTRY(entry));


### PR DESCRIPTION
## Summary
- allow pressing Enter in the "new file" dialog to trigger Create

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68aa457945908328ae39cea14cbebd22