### PR TITLE
Refactor LispSourceView to include scrolling

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -117,7 +117,8 @@ app_activate (GApplication *app)
       G_CALLBACK(on_notebook_switch_page), self);
 
   LispSourceView *view = lisp_source_notebook_get_current_view(self->notebook);
-  g_signal_connect (view, "key-press-event", G_CALLBACK (on_key_press), self);
+  g_signal_connect (lisp_source_view_get_view(view), "key-press-event",
+      G_CALLBACK (on_key_press), self);
 
   /* Menu bar ------------------------------------------------------ */
   GtkWidget *menu_bar      = gtk_menu_bar_new ();
@@ -323,7 +324,8 @@ app_connect_view(App *self, LispSourceView *view)
 {
   g_return_if_fail(GLIDE_IS_APP(self));
   g_return_if_fail(LISP_IS_SOURCE_VIEW(view));
-  g_signal_connect(view, "key-press-event", G_CALLBACK(on_key_press), self);
+  g_signal_connect(lisp_source_view_get_view(view), "key-press-event",
+      G_CALLBACK(on_key_press), self);
 }
 
 STATIC ProjectFile *
@@ -435,10 +437,7 @@ on_notebook_switch_page(GtkNotebook * /*notebook*/, GtkWidget *page, guint /*pag
     return;
   if (!page)
     return;
-  GtkWidget *child = gtk_bin_get_child(GTK_BIN(page));
-  if (!child)
-    return;
-  ProjectFile *file = lisp_source_view_get_file(LISP_SOURCE_VIEW(child));
+  ProjectFile *file = lisp_source_view_get_file(LISP_SOURCE_VIEW(page));
   if (!file)
     return;
   const gchar *rel = project_file_get_relative_path(file);
@@ -510,8 +509,7 @@ app_maybe_save_all(App *self)
   gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
   gboolean modified = FALSE;
   for (gint i = 0; i < pages; i++) {
-    GtkWidget *child = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
-    GtkWidget *view = child ? gtk_bin_get_child(GTK_BIN(child)) : NULL;
+    GtkWidget *view = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
     GtkTextBuffer *buffer = view ? GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(view))) : NULL;
     if (buffer && gtk_text_buffer_get_modified(buffer)) {
       modified = TRUE;

--- a/src/file_save.c
+++ b/src/file_save.c
@@ -113,8 +113,7 @@ void file_save_all(GtkWidget * /*widget*/, gpointer data) {
   gint current = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
   gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
   for (gint i = 0; i < pages; i++) {
-    GtkWidget *scrolled = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
-    GtkWidget *view = gtk_bin_get_child(GTK_BIN(scrolled));
+    GtkWidget *view = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
     GtkTextBuffer *buffer = GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(view)));
     if (buffer && gtk_text_buffer_get_modified(buffer)) {
       gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), i);

--- a/src/lisp_source_notebook.c
+++ b/src/lisp_source_notebook.c
@@ -55,17 +55,6 @@ lisp_source_notebook_new(Project *project)
   return GTK_WIDGET(self);
 }
 
-static GtkWidget *
-create_scrolled_view(LispSourceNotebook *self, ProjectFile *file)
-{
-  GtkWidget *view = lisp_source_view_new_for_file(self->project, file);
-  GtkWidget *scrolled = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
-      GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-  gtk_container_add(GTK_CONTAINER(scrolled), view);
-  return scrolled;
-}
-
 static void
 on_file_loaded(Project * /*project*/, ProjectFile *file, gpointer user_data)
 {
@@ -80,10 +69,10 @@ lisp_source_notebook_add_file(LispSourceNotebook *self, ProjectFile *file)
   g_return_val_if_fail(LISP_IS_SOURCE_NOTEBOOK(self), -1);
   g_return_val_if_fail(file != NULL, -1);
 
-  GtkWidget *scrolled = create_scrolled_view(self, file);
+  GtkWidget *view = lisp_source_view_new_for_file(self->project, file);
   const gchar *path = project_file_get_relative_path(file);
   GtkWidget *label = gtk_label_new(path ? path : "untitled");
-  gint page = gtk_notebook_append_page(GTK_NOTEBOOK(self), scrolled, label);
+  gint page = gtk_notebook_append_page(GTK_NOTEBOOK(self), view, label);
   gtk_widget_show_all(gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page));
   return page;
 }
@@ -102,10 +91,9 @@ lisp_source_notebook_get_current_view(LispSourceNotebook *self)
 {
   g_return_val_if_fail(LISP_IS_SOURCE_NOTEBOOK(self), NULL);
   gint page = gtk_notebook_get_current_page(GTK_NOTEBOOK(self));
-  GtkWidget *scrolled = gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page);
-  if (!scrolled)
+  GtkWidget *view = gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page);
+  if (!view)
     return NULL;
-  GtkWidget *view = gtk_bin_get_child(GTK_BIN(scrolled));
   return LISP_SOURCE_VIEW(view);
 }
 

--- a/src/lisp_source_view.h
+++ b/src/lisp_source_view.h
@@ -8,10 +8,11 @@
 G_BEGIN_DECLS
 
 #define LISP_TYPE_SOURCE_VIEW (lisp_source_view_get_type ())
-G_DECLARE_FINAL_TYPE (LispSourceView, lisp_source_view, LISP, SOURCE_VIEW, GtkSourceView)
+G_DECLARE_FINAL_TYPE (LispSourceView, lisp_source_view, LISP, SOURCE_VIEW, GtkScrolledWindow)
 
 GtkWidget      *lisp_source_view_new_for_file (Project *project, ProjectFile *file);
 GtkSourceBuffer *lisp_source_view_get_buffer (LispSourceView *self);
 ProjectFile    *lisp_source_view_get_file (LispSourceView *self);
+GtkWidget      *lisp_source_view_get_view (LispSourceView *self);
 
 G_END_DECLS


### PR DESCRIPTION
## Summary
- Make `LispSourceView` inherit from `GtkScrolledWindow` and embed a `GtkSourceView`
- Simplify notebook and saving logic to use `LispSourceView` directly
- Update app signal connections and project closing logic accordingly

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68aadf72a9608328a32d77dc1d3c67b8