### PR TITLE
Fix dispose crash when reopening project

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -541,9 +541,7 @@ app_close_project(App *self, gboolean forget_project)
   if (!app_maybe_save_all(self))
     return FALSE;
   Project *project = app_get_project(self);
-  LispSourceNotebook *notebook = app_get_notebook(self);
   project_clear(project);
-  lisp_source_notebook_clear(notebook);
   Preferences *prefs = app_get_preferences(self);
   if (prefs && forget_project) {
     preferences_set_project_file(prefs, NULL);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -49,7 +49,6 @@ gboolean file_open_path(App *app, const gchar *filename) {
   Project *project = app_get_project(app);
   LispSourceNotebook *notebook = app_get_notebook(app);
   project_clear(project);
-  lisp_source_notebook_clear(notebook);
 
   gboolean is_asdf = g_str_has_suffix(filename, ".asd");
   if (is_asdf) {

--- a/src/project.h
+++ b/src/project.h
@@ -10,11 +10,13 @@ typedef struct _GtkTextBuffer GtkTextBuffer;
 typedef struct _Project Project;
 
 typedef void (*ProjectFileLoadedCb)(Project *self, ProjectFile *file, gpointer user_data);
+typedef void (*ProjectFileRemovedCb)(Project *self, ProjectFile *file, gpointer user_data);
 
 Project       *project_new(void);
 Project       *project_ref(Project *self);
 void           project_unref(Project *self);
 void           project_set_file_loaded_cb(Project *self, ProjectFileLoadedCb cb, gpointer user_data);
+void           project_set_file_removed_cb(Project *self, ProjectFileRemovedCb cb, gpointer user_data);
 ProjectFile   *project_create_scratch(Project *self);
 ProjectFile   *project_get_file(Project *self, guint index);
 guint          project_get_file_count(Project *self);
@@ -22,6 +24,7 @@ ProjectFile   *project_add_file(Project *self, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
 void           project_file_changed(Project *self, ProjectFile *file);
 void           project_file_loaded(Project *self, ProjectFile *file);
+void           project_file_removed(Project *self, ProjectFile *file);
 void           project_index_add(Project *self, Node *node);
 GHashTable    *project_get_index(Project *self, StringDesignatorType sd_type);
 void           project_set_asdf(Project *self, Asdf *asdf);


### PR DESCRIPTION
## Summary
- notify notebooks when project files are removed so views are dropped before data is freed
- remove redundant notebook clearing calls during project close/open

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68aaeaf61ac48328bbdfd361a11d565b