### PR TITLE
Avoid double unref of child view

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -1,0 +1,5 @@
+The application crashed on startup because `lisp_source_view_dispose` explicitly
+unreferenced its `GtkSourceView` child widget. The `GtkScrolledWindow` parent
+already disposes of its children, so unreferencing the view again left GTK
+trying to dispose an already finalized object, triggering the GLib critical
+`instance with invalid (NULL) class pointer`.

--- a/src/lisp_source_view.c
+++ b/src/lisp_source_view.c
@@ -57,7 +57,7 @@ lisp_source_view_dispose (GObject *object)
   }
 
   g_clear_object (&self->buffer);
-  g_clear_object (&self->view);
+  self->view = NULL;
 
   G_OBJECT_CLASS (lisp_source_view_parent_class)->dispose (object);
 }


### PR DESCRIPTION
## Summary
- avoid manual unref of `GtkSourceView` in `lisp_source_view_dispose`
- explain crash cause in BUG.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68ab03729afc832881da48d51f4e2120