### PR TITLE
Fix crash when restoring last file

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -1,5 +1,5 @@
-The application crashed on startup because `lisp_source_view_dispose` explicitly
-unreferenced its `GtkSourceView` child widget. The `GtkScrolledWindow` parent
-already disposes of its children, so unreferencing the view again left GTK
-trying to dispose an already finalized object, triggering the GLib critical
-`instance with invalid (NULL) class pointer`.
+The application crashed when restoring the previously opened file at startup. 
+`app_activate` tried to scroll the view by casting a `LispSourceView` to 
+`GtkTextView`. Since `LispSourceView` is a `GtkScrolledWindow` containing the
+actual `GtkSourceView`, the invalid cast triggered a GLib critical and
+terminated the program.

--- a/BUGS.md
+++ b/BUGS.md
@@ -3,3 +3,5 @@
 ## Crash while clearing the project at startup
 
 
+## Crash when restoring last file at startup
+

--- a/src/app.c
+++ b/src/app.c
@@ -196,11 +196,14 @@ app_activate (GApplication *app)
             gtk_notebook_set_current_page(GTK_NOTEBOOK(self->notebook), i);
             LispSourceView *view = lisp_source_notebook_get_current_view(self->notebook);
             if (view) {
-              GtkTextBuffer *buffer = GTK_TEXT_BUFFER(lisp_source_view_get_buffer(view));
+              GtkWidget *text_view = lisp_source_view_get_view(view);
+              GtkTextBuffer *buffer =
+                  GTK_TEXT_BUFFER(lisp_source_view_get_buffer(view));
               GtkTextIter iter;
               gtk_text_buffer_get_iter_at_offset(buffer, &iter, pos);
               gtk_text_buffer_place_cursor(buffer, &iter);
-              gtk_text_view_scroll_to_iter(GTK_TEXT_VIEW(view), &iter, 0.0, FALSE, 0, 0);
+              gtk_text_view_scroll_to_iter(GTK_TEXT_VIEW(text_view), &iter,
+                  0.0, FALSE, 0, 0);
               app_connect_view(self, view);
             }
             break;
@@ -213,7 +216,7 @@ app_activate (GApplication *app)
   gtk_widget_show_all(self->window);
   LispSourceView *current_view = lisp_source_notebook_get_current_view(self->notebook);
   if (current_view)
-    gtk_widget_grab_focus(GTK_WIDGET(current_view));
+    gtk_widget_grab_focus(lisp_source_view_get_view(current_view));
 }
 
 static void


### PR DESCRIPTION
## Summary
- resolve invalid cast when restoring last open file by scrolling using the inner text view
- document startup crash cause

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68ab0ee89e188328b8f21ec4fee07f2f