### PR TITLE
Fix ASDF viewer notebook selection

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -16,3 +16,11 @@ The application crashed when restoring the previously opened file at startup.
 `GtkTextView`. Since `LispSourceView` is a `GtkScrolledWindow` containing the
 actual `GtkSourceView`, the invalid cast triggered a GLib critical and
 terminated the program.
+
+## ASDF viewer no longer selected files
+
+Clicking a filename in the ASDF viewer stopped switching the notebook to that
+file. The viewer's model uses a parent node labelled "src" for components, but
+the selection handler still expected "components" and ignored selections. The
+handler now checks for the correct "src" label so selecting a file in the
+viewer updates the notebook.

--- a/src/app.c
+++ b/src/app.c
@@ -413,7 +413,7 @@ on_asdf_view_selection_changed(GtkTreeSelection *selection, gpointer data)
     return;
   gchar *parent_text = NULL;
   gtk_tree_model_get(model, &parent, 0, &parent_text, -1);
-  gboolean is_component = g_strcmp0(parent_text, "components") == 0;
+  gboolean is_component = g_strcmp0(parent_text, "src") == 0;
   g_free(parent_text);
   if (!is_component)
     return;


### PR DESCRIPTION
## Summary
- ensure ASDF viewer selections match updated tree structure so selecting a file focuses it in the notebook
- record regression in BUGS log

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68ab474dda3c8328b9e786a580e996f1