### PR TITLE
Carry kind and object in asdf view tree store

### DIFF
--- a/src/asdf_view.h
+++ b/src/asdf_view.h
@@ -2,13 +2,29 @@
 
 #include <gtk/gtk.h>
 #include "asdf.h"
+#include "project.h"
 
 G_BEGIN_DECLS
 
 #define ASDF_VIEW_TYPE (asdf_view_get_type())
 G_DECLARE_FINAL_TYPE(AsdfView, asdf_view, ASDF, VIEW, GtkTreeView)
 
-GtkWidget *asdf_view_new(Asdf *asdf);
+typedef enum {
+  ASDF_VIEW_COL_TEXT,
+  ASDF_VIEW_COL_KIND,
+  ASDF_VIEW_COL_OBJECT,
+  ASDF_VIEW_N_COLS
+} AsdfViewColumn;
+
+typedef enum {
+  ASDF_VIEW_KIND_ROOT,
+  ASDF_VIEW_KIND_SRC,
+  ASDF_VIEW_KIND_COMPONENT,
+  ASDF_VIEW_KIND_LIBRARIES,
+  ASDF_VIEW_KIND_LIBRARY
+} AsdfViewKind;
+
+GtkWidget *asdf_view_new(Asdf *asdf, Project *project);
 void asdf_view_select_file(AsdfView *self, const gchar *file);
 
 G_END_DECLS


### PR DESCRIPTION
## Summary
- Extend AsdfView tree model with kind and object columns so each row knows its context
- Populate rows with ProjectFile pointers and type info for fast selection and future menus
- Simplify selection handling to rely on stored context rather than parent row names
- Use AsdfView column constants directly to avoid inline build conflicts

## Testing
- `make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d157818832883e1f7c853b309c4