### PR TITLE
Add ASDF system listing package symbols

### DIFF
--- a/src/glide.asd
+++ b/src/glide.asd
@@ -1,0 +1,5 @@
+(asdf:defsystem "glide"
+  :description "List symbols of a given package"
+  :version "0.0.1"
+  :serial t
+  :components ((:file "symbols")))

--- a/src/symbols.lisp
+++ b/src/symbols.lisp
@@ -1,0 +1,11 @@
+(defpackage :glide
+  (:use :cl)
+  (:export :package-symbols))
+
+(in-package :glide)
+
+(defun package-symbols (package-name)
+  (let ((pkg (find-package package-name)))
+    (when pkg
+      (loop for symbol being the symbols of pkg
+            collect symbol))))


### PR DESCRIPTION
## Summary
- add `glide.asd` ASDF definition
- add `package-symbols` function to list all symbols of a package

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68ab74dff29c8328a58d8703ee3e2af5