### PR TITLE
Simplify Node structure and remove variable info

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -1,38 +1,5 @@
 #include "node.h"
-#include "package.h"
 #include <string.h>
-
-VariableInfo *variable_info_new(void) {
-  VariableInfo *var = g_new0(VariableInfo, 1);
-  g_atomic_int_set(&var->ref, 1);
-  var->usages = g_ptr_array_new();
-  return var;
-}
-
-VariableInfo *variable_info_ref(VariableInfo *var) {
-  if (!var) return NULL;
-  g_atomic_int_inc(&var->ref);
-  return var;
-}
-
-void variable_info_unref(VariableInfo *var) {
-  if (!var) return;
-  if (g_atomic_int_dec_and_test(&var->ref)) {
-    if (var->usages)
-      g_ptr_array_free(var->usages, TRUE);
-    g_free(var);
-  }
-}
-
-FunctionInfo *function_info_ref(FunctionInfo *fn) {
-  if (!fn) return NULL;
-  return node_ref(fn);
-}
-
-void function_info_unref(FunctionInfo *fn) {
-  if (!fn) return;
-  node_unref(fn);
-}
 
 void node_set_sd_type(Node *node, StringDesignatorType sd_type, const gchar *package_context) {
   if (!node) return;
@@ -41,76 +8,8 @@ void node_set_sd_type(Node *node, StringDesignatorType sd_type, const gchar *pac
   node->package_context = package_context ? g_strdup(package_context) : NULL;
 }
 
-void node_set_var_use(Node *node, VariableInfo *var, const gchar *package_context) {
-  if (!node) return;
-  node_set_sd_type(node, SDT_VAR_USE, package_context);
-  node->var = var ? variable_info_ref(var) : NULL;
-  if (var && var->usages)
-    g_ptr_array_add(var->usages, node);
-}
-
-void node_set_var_def(Node *node, VariableInfo *var_new, const gchar *package_context) {
-  if (!node) return;
-  node_set_sd_type(node, SDT_VAR_DEF, package_context);
-  node->var = var_new ? variable_info_ref(var_new) : NULL;
-  if (var_new)
-    var_new->definition = node;
-}
-
-void node_set_struct_field(Node *node, const gchar *field_name, const gchar *package_context) {
-  if (!node) return;
-  node_set_sd_type(node, SDT_STRUCT_FIELD, package_context);
-  node->field_name = field_name ? g_strdup(field_name) : NULL;
-  node->methods = g_ptr_array_new();
-}
-
-void node_set_package_def(Node *node, Package *package, const gchar *package_context) {
-  if (!node) return;
-  node_set_sd_type(node, SDT_PACKAGE_DEF, package_context);
-  node->package = package ? package_ref(package) : NULL;
-}
-
-void node_set_package_use(Node *node, Package *package, const gchar *package_context) {
-  if (!node) return;
-  node_set_sd_type(node, SDT_PACKAGE_USE, package_context);
-  node->package = package ? package_ref(package) : NULL;
-}
 
 static void node_finalize(Node *node) {
-  switch (node->sd_type) {
-    case SDT_VAR_USE:
-      if (node->var) {
-        if (node->var->usages)
-          g_ptr_array_remove(node->var->usages, node);
-        variable_info_unref(node->var);
-      }
-      break;
-    case SDT_VAR_DEF:
-      if (node->var) {
-        if (node->var->definition == node)
-          node->var->definition = NULL;
-        variable_info_unref(node->var);
-      }
-      break;
-    case SDT_PACKAGE_DEF:
-    case SDT_PACKAGE_USE:
-      if (node->package)
-        package_unref(node->package);
-      break;
-    case SDT_STRUCT_FIELD:
-      g_clear_pointer(&node->field_name, g_free);
-      if (node->methods) {
-        for (guint i = 0; i < node->methods->len; i++) {
-          FunctionInfo *fn = g_ptr_array_index(node->methods, i);
-          function_info_unref(fn);
-        }
-        g_ptr_array_free(node->methods, TRUE);
-        node->methods = NULL;
-      }
-      break;
-    default:
-      break;
-  }
   g_clear_pointer(&node->package_context, g_free);
   g_clear_pointer(&node->name, g_free);
 }
@@ -150,14 +49,7 @@ gchar *node_to_string(const Node *node) {
   if (!node || node->sd_type == SDT_NONE)
     return NULL;
   const gchar *type = node_sd_type_to_string(node->sd_type);
-  switch(node->sd_type) {
-    case SDT_STRUCT_FIELD:
-      if (node->field_name)
-        return g_strdup_printf("%s %s", type, node->field_name);
-      return g_strdup(type);
-    default:
-      return g_strdup(type);
-  }
+  return g_strdup(type);
 }
 
 const gchar *node_get_name(const Node *node) {

--- a/src/node.h
+++ b/src/node.h
@@ -24,16 +24,7 @@ typedef enum {
   SDT_STRUCT_FIELD,
 } StringDesignatorType;
 
-typedef struct VariableInfo VariableInfo;
 typedef struct Node Node;
-typedef Node FunctionInfo;
-typedef struct Package Package;
-
-struct VariableInfo {
-  gint ref;
-  Node *definition; /* SDT_VAR_DEF */
-  GPtrArray *usages; /* Node* (SDT_VAR_USE) */
-};
 
 struct Node {
   LispAstNodeType type;
@@ -43,26 +34,10 @@ struct Node {
 
   StringDesignatorType sd_type;
   gint ref;
-  VariableInfo *var;
-  Package *package;
   gchar *package_context;
   gchar *name;
-  gchar *field_name;
-  GPtrArray *methods; /* FunctionInfo* */
 };
-
-VariableInfo *variable_info_new(void);
-VariableInfo *variable_info_ref(VariableInfo *var);
-void variable_info_unref(VariableInfo *var);
-FunctionInfo *function_info_ref(FunctionInfo *fn);
-void function_info_unref(FunctionInfo *fn);
-
 void node_set_sd_type(Node *node, StringDesignatorType sd_type, const gchar *package_context);
-void node_set_var_use(Node *node, VariableInfo *var, const gchar *package_context);
-void node_set_var_def(Node *node, VariableInfo *var_new, const gchar *package_context);
-void node_set_struct_field(Node *node, const gchar *field_name, const gchar *package_context);
-void node_set_package_def(Node *node, Package *package, const gchar *package_context);
-void node_set_package_use(Node *node, Package *package, const gchar *package_context);
 
 Node *node_ref(Node *node);
 void node_unref(Node *node);

--- a/tests/package_test.c
+++ b/tests/package_test.c
@@ -27,9 +27,8 @@ int main(void) {
 
   Node *node = g_new0(Node, 1);
   g_atomic_int_set(&node->ref, 1);
-  node_set_package_def(node, package, "COMMON-LISP-USER");
+  node_set_sd_type(node, SDT_PACKAGE_DEF, "COMMON-LISP-USER");
   assert(node_is(node, SDT_PACKAGE_DEF));
-  assert(node->package == package);
   assert(g_strcmp0(node->package_context, "COMMON-LISP-USER") == 0);
 
   node_unref(node);


### PR DESCRIPTION
## Summary
- drop VariableInfo type and related Node fields
- update Node helpers to only manage sd_type and context
- adjust package test for new Node API

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68ac5a9ea6f8832885cf238417cc58bb