### PR TITLE
Remove scratch file concept

### DIFF
--- a/src/file_save.c
+++ b/src/file_save.c
@@ -16,12 +16,12 @@ void file_save(GtkWidget *, gpointer data) {
       lisp_source_view_get_buffer(app_get_source_view(app));
   ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
   const gchar *filename = project_file_get_path(file);
-  gboolean scratch = project_file_get_state(file) == PROJECT_FILE_SCRATCH;
+  gboolean unnamed = filename && g_strcmp0(filename, "unnamed.lisp") == 0;
 
   gchar *chosen_filename = NULL;
 
   // Check if we already have a filename
-  if (!filename || scratch) {
+  if (!filename || unnamed) {
     // We do not have a known filename -> use a "Save As" dialog
     GtkWidget *dialog = gtk_file_chooser_dialog_new(
         "Save File",

--- a/src/project.h
+++ b/src/project.h
@@ -17,7 +17,6 @@ Project       *project_ref(Project *self);
 void           project_unref(Project *self);
 void           project_set_file_loaded_cb(Project *self, ProjectFileLoadedCb cb, gpointer user_data);
 void           project_set_file_removed_cb(Project *self, ProjectFileRemovedCb cb, gpointer user_data);
-ProjectFile   *project_create_scratch(Project *self);
 ProjectFile   *project_get_file(Project *self, guint index);
 guint          project_get_file_count(Project *self);
 ProjectFile   *project_add_file(Project *self, TextProvider *provider,

--- a/src/project_file.h
+++ b/src/project_file.h
@@ -10,8 +10,7 @@ typedef struct _Project Project;
 
 typedef enum {
   PROJECT_FILE_DORMANT,
-  PROJECT_FILE_LIVE,
-  PROJECT_FILE_SCRATCH
+  PROJECT_FILE_LIVE
 } ProjectFileState;
 
 typedef struct _ProjectFile ProjectFile;

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -5,13 +5,13 @@
 #include <glib/gstdio.h>
 #include <string.h>
 
-static void test_default_scratch(void)
+static void test_default_file(void)
 {
   Project *project = project_new();
   g_assert_cmpuint(project_get_file_count(project), ==, 1);
   ProjectFile *file = project_get_file(project, 0);
-  g_assert_cmpint(project_file_get_state(file), ==, PROJECT_FILE_SCRATCH);
-  g_assert_cmpstr(project_file_get_path(file), ==, "scratch00");
+  g_assert_cmpint(project_file_get_state(file), ==, PROJECT_FILE_LIVE);
+  g_assert_cmpstr(project_file_get_path(file), ==, "unnamed.lisp");
   project_unref(project);
 }
 
@@ -19,7 +19,7 @@ static void test_parse_on_change(void)
 {
   Project *project = project_new();
   TextProvider *provider = string_text_provider_new("(a)");
-  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_SCRATCH);
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
   LispParser *parser = project_file_get_parser(file);
@@ -79,7 +79,7 @@ static void test_function_analysis(void)
 {
   Project *project = project_new();
   TextProvider *provider = string_text_provider_new("(defun foo () (bar))");
-  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_SCRATCH);
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
   LispParser *parser = project_file_get_parser(file);
@@ -100,7 +100,7 @@ static void test_index(void)
   Project *project = project_new();
   TextProvider *provider = string_text_provider_new("(defun foo () (bar))");
   ProjectFile *file = project_add_file(project, provider, NULL, NULL,
-      PROJECT_FILE_SCRATCH);
+      PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
   LispParser *parser = project_file_get_parser(file);
@@ -171,7 +171,7 @@ static void test_remove_file(void)
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
-  g_test_add_func("/project/default_scratch", test_default_scratch);
+  g_test_add_func("/project/default_file", test_default_file);
   g_test_add_func("/project/parse_on_change", test_parse_on_change);
   g_test_add_func("/project/file_load", test_file_load);
   g_test_add_func("/project/function_analysis", test_function_analysis);


### PR DESCRIPTION
## Summary
- Drop scratch file state and default project now opens `unnamed.lisp`
- Treat `unnamed.lisp` as lacking a real path in `file_save`
- Update project tests for the new default file name

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68acb9eccdd083289aa062ef2a880f65