### PR TITLE
Refactor file saving to use project data

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -28,6 +28,7 @@ STATIC gboolean app_maybe_save_all(App *self);
 STATIC gboolean app_close_project(App *self, gboolean forget_project);
 STATIC void     on_asdf_view_selection_changed(GtkTreeSelection *selection, gpointer data);
 STATIC void     on_notebook_switch_page(GtkNotebook *notebook, GtkWidget *page, guint page_num, gpointer data);
+STATIC void     on_save_all(GtkWidget * /*item*/, gpointer data);
 
 /* === Instance structure ================================================= */
 struct _App
@@ -171,7 +172,7 @@ app_activate (GApplication *app)
   g_signal_connect(proj_new_item, "activate", G_CALLBACK(project_new_wizard), self);
   g_signal_connect(proj_open_item, "activate", G_CALLBACK(file_open), self);
   g_signal_connect(newfile_item, "activate", G_CALLBACK(file_new), self);
-  g_signal_connect(saveall_item, "activate", G_CALLBACK(file_save_all), self);
+  g_signal_connect(saveall_item, "activate", G_CALLBACK(on_save_all), self);
   g_signal_connect(closeproj_item, "activate", G_CALLBACK(close_project_menu_item), self);
   g_signal_connect(settings_item, "activate", G_CALLBACK(on_preferences), self);
   g_signal_connect(exit_item, "activate", G_CALLBACK(quit_menu_item), self);
@@ -466,6 +467,13 @@ on_recent_project_activate(GtkWidget *item, gpointer data)
     file_open_path(self, path);
 }
 
+STATIC void
+on_save_all(GtkWidget * /*item*/, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  file_save_all(app_get_project(self));
+}
+
 
 STATIC Preferences *
 app_get_preferences (App *self)
@@ -517,7 +525,7 @@ app_maybe_save_all(App *self)
   if (res == GTK_RESPONSE_CANCEL)
     return FALSE;
   if (res == GTK_RESPONSE_ACCEPT)
-    file_save_all(NULL, self);
+    file_save_all(app_get_project(self));
   return TRUE;
 }
 

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -35,7 +35,7 @@ static gboolean save_if_modified(App *app) {
     if (res == GTK_RESPONSE_CANCEL)
       return FALSE;
     if (res == GTK_RESPONSE_ACCEPT)
-      file_save(NULL, app);
+      file_save(file);
   }
   return TRUE;
 }

--- a/src/file_save.c
+++ b/src/file_save.c
@@ -1,65 +1,31 @@
 #include <gtk/gtk.h>
-#include <gtksourceview/gtksource.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <string.h>
 #include "reloc.h"
 #include "syscalls.h"
 #include "file_save.h"
-#include "app.h"
-#include "lisp_source_view.h"
+#include "project.h"
+#include "project_file.h"
 
-void file_save(GtkWidget *, gpointer data) {
-  App *app = (App *) data;
-  GtkSourceBuffer *source_buffer =
-      lisp_source_view_get_buffer(app_get_source_view(app));
-  ProjectFile *file = lisp_source_view_get_file(app_get_source_view(app));
+void file_save(ProjectFile *file) {
+  g_return_if_fail(file != NULL);
+
   const gchar *filename = project_file_get_path(file);
-  gboolean unnamed = filename && g_strcmp0(filename, "unnamed.lisp") == 0;
+  if (!filename)
+    return;
 
-  gchar *chosen_filename = NULL;
+  GtkTextBuffer *buffer = project_file_get_buffer(file);
+  g_return_if_fail(buffer != NULL);
 
-  // Check if we already have a filename
-  if (!filename || unnamed) {
-    // We do not have a known filename -> use a "Save As" dialog
-    GtkWidget *dialog = gtk_file_chooser_dialog_new(
-        "Save File",
-        NULL,
-        GTK_FILE_CHOOSER_ACTION_SAVE,
-        "_Cancel", GTK_RESPONSE_CANCEL,
-        "_Save", GTK_RESPONSE_ACCEPT,
-        NULL
-        );
-
-    // Suggest a name or remember the last directory, etc.
-    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
-
-    if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-      chosen_filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-      project_file_set_path(file, chosen_filename);
-      project_file_set_state(file, PROJECT_FILE_LIVE);
-      filename = chosen_filename;
-    }
-
-    gtk_widget_destroy(dialog);
-
-    // If the user canceled, filename is still NULL
-    if (!filename) {
-      return; // bail out
-    }
-  }
-
-  // At this point, we have a valid filename (either from opening a file or from Save As).
-  // Get the text from the buffer
   GtkTextIter start, end;
-  gtk_text_buffer_get_start_iter(GTK_TEXT_BUFFER(source_buffer), &start);
-  gtk_text_buffer_get_end_iter(GTK_TEXT_BUFFER(source_buffer), &end);
+  gtk_text_buffer_get_start_iter(buffer, &start);
+  gtk_text_buffer_get_end_iter(buffer, &end);
 
-  gchar *buffer_text = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(source_buffer),
-      &start, &end, FALSE);
+  gchar *buffer_text = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
 
-  // Open (or create/truncate) the file for writing using syscalls
   int fd = sys_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
   if (fd == -1) {
     g_printerr("Failed to open file for writing: %s (errno: %d)\n", filename, errno);
@@ -67,7 +33,6 @@ void file_save(GtkWidget *, gpointer data) {
     return;
   }
 
-  // Write the text to the file using a loop to handle partial writes
   size_t to_write = strlen(buffer_text);
   size_t total_written = 0;
   while (total_written < to_write) {
@@ -81,29 +46,22 @@ void file_save(GtkWidget *, gpointer data) {
     total_written += written;
   }
 
-  // Close the file
-  if (sys_close(fd) == -1) {
+  if (sys_close(fd) == -1)
     g_printerr("Error closing file: %s (errno: %d)\n", filename, errno);
-  }
 
+  gtk_text_buffer_set_modified(buffer, FALSE);
   g_free(buffer_text);
-  g_free(chosen_filename);
 }
 
-void file_save_all(GtkWidget * /*widget*/, gpointer data) {
-  App *app = (App *) data;
-  LispSourceNotebook *notebook = app_get_notebook(app);
-  if (!notebook)
-    return;
-  gint current = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
-  gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
-  for (gint i = 0; i < pages; i++) {
-    GtkWidget *view = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
-    GtkTextBuffer *buffer = GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(view)));
-    if (buffer && gtk_text_buffer_get_modified(buffer)) {
-      gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), i);
-      file_save(NULL, app);
-    }
+void file_save_all(Project *project) {
+  g_return_if_fail(project != NULL);
+
+  guint count = project_get_file_count(project);
+  for (guint i = 0; i < count; i++) {
+    ProjectFile *file = project_get_file(project, i);
+    GtkTextBuffer *buffer = project_file_get_buffer(file);
+    if (buffer && gtk_text_buffer_get_modified(buffer))
+      file_save(file);
   }
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), current);
 }
+

--- a/src/file_save.h
+++ b/src/file_save.h
@@ -1,5 +1,8 @@
 #pragma once
 
-void file_save(GtkWidget *, gpointer data);
-void file_save_all(GtkWidget *, gpointer data);
+typedef struct _Project Project;
+typedef struct _ProjectFile ProjectFile;
+
+void file_save(ProjectFile *file);
+void file_save_all(Project *project);
 


### PR DESCRIPTION
## Summary
- decouple file saving from GTK UI by using Project and ProjectFile
- iterate project files to implement save all
- update callers to use new saving API

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68acd71acf048328a7b81bb4780c5e30