### PR TITLE
Encapsulate Package struct

### DIFF
--- a/src/package.c
+++ b/src/package.c
@@ -1,5 +1,16 @@
 #include "package.h"
 
+struct Package {
+  gint ref;
+  gchar *name;
+  gchar *description;
+  GHashTable *nicknames;
+  GHashTable *uses;
+  GHashTable *exports;
+  GHashTable *shadows;
+  GHashTable *import_from; /* symbol -> package */
+};
+
 Package *package_new(const gchar *name) {
   Package *package = g_new0(Package, 1);
   g_atomic_int_set(&package->ref, 1);
@@ -70,4 +81,32 @@ void package_add_shadow(Package *package, const gchar *symbol) {
 void package_add_import_from(Package *package, const gchar *symbol, const gchar *from) {
   if (!package || !symbol || !from) return;
   g_hash_table_insert(package->import_from, g_strdup(symbol), g_strdup(from));
+}
+
+const gchar *package_get_name(const Package *package) {
+  return package ? package->name : NULL;
+}
+
+const gchar *package_get_description(const Package *package) {
+  return package ? package->description : NULL;
+}
+
+GHashTable *package_get_nicknames(const Package *package) {
+  return package ? package->nicknames : NULL;
+}
+
+GHashTable *package_get_uses(const Package *package) {
+  return package ? package->uses : NULL;
+}
+
+GHashTable *package_get_exports(const Package *package) {
+  return package ? package->exports : NULL;
+}
+
+GHashTable *package_get_shadows(const Package *package) {
+  return package ? package->shadows : NULL;
+}
+
+GHashTable *package_get_import_from(const Package *package) {
+  return package ? package->import_from : NULL;
 }

--- a/src/package.h
+++ b/src/package.h
@@ -4,17 +4,6 @@
 
 typedef struct Package Package;
 
-struct Package {
-  gint ref;
-  gchar *name;
-  gchar *description;
-  GHashTable *nicknames;
-  GHashTable *uses;
-  GHashTable *exports;
-  GHashTable *shadows;
-  GHashTable *import_from; /* symbol -> package */
-};
-
 Package *package_new(const gchar *name);
 Package *package_ref(Package *package);
 void package_unref(Package *package);
@@ -24,4 +13,12 @@ void package_add_use(Package *package, const gchar *use);
 void package_add_export(Package *package, const gchar *symbol);
 void package_add_shadow(Package *package, const gchar *symbol);
 void package_add_import_from(Package *package, const gchar *symbol, const gchar *from);
+
+const gchar *package_get_name(const Package *package);
+const gchar *package_get_description(const Package *package);
+GHashTable *package_get_nicknames(const Package *package);
+GHashTable *package_get_uses(const Package *package);
+GHashTable *package_get_exports(const Package *package);
+GHashTable *package_get_shadows(const Package *package);
+GHashTable *package_get_import_from(const Package *package);
 

--- a/tests/package_common_lisp_test.c
+++ b/tests/package_common_lisp_test.c
@@ -11,15 +11,15 @@ static void test_singleton(void) {
 
 static void test_exports(void) {
   Package *p = package_common_lisp_get_instance();
-  g_assert_true(g_hash_table_contains(p->exports, "CAR"));
-  g_assert_true(g_hash_table_contains(p->exports, "*PRINT-LEVEL*"));
-  g_assert_true(g_hash_table_contains(p->exports, "&REST"));
+  g_assert_true(g_hash_table_contains(package_get_exports(p), "CAR"));
+  g_assert_true(g_hash_table_contains(package_get_exports(p), "*PRINT-LEVEL*"));
+  g_assert_true(g_hash_table_contains(package_get_exports(p), "&REST"));
   package_unref(p);
 }
 
 static void test_nickname(void) {
   Package *p = package_common_lisp_get_instance();
-  g_assert_true(g_hash_table_contains(p->nicknames, "CL"));
+  g_assert_true(g_hash_table_contains(package_get_nicknames(p), "CL"));
   package_unref(p);
 }
 

--- a/tests/package_test.c
+++ b/tests/package_test.c
@@ -12,18 +12,18 @@ int main(void) {
   package_add_shadow(package, "BAR");
   package_add_import_from(package, "BAZ", "OTHER");
 
-  assert(g_strcmp0(package->name, "CL-USER") == 0);
-  assert(g_strcmp0(package->description, "desc") == 0);
-  assert(g_hash_table_contains(package->nicknames, "USER"));
-  assert(g_hash_table_contains(package->uses, "COMMON-LISP"));
-  assert(g_hash_table_contains(package->exports, "FOO"));
-  assert(g_hash_table_contains(package->shadows, "BAR"));
-  assert(g_strcmp0(g_hash_table_lookup(package->import_from, "BAZ"), "OTHER") == 0);
+  assert(g_strcmp0(package_get_name(package), "CL-USER") == 0);
+  assert(g_strcmp0(package_get_description(package), "desc") == 0);
+  assert(g_hash_table_contains(package_get_nicknames(package), "USER"));
+  assert(g_hash_table_contains(package_get_uses(package), "COMMON-LISP"));
+  assert(g_hash_table_contains(package_get_exports(package), "FOO"));
+  assert(g_hash_table_contains(package_get_shadows(package), "BAR"));
+  assert(g_strcmp0(g_hash_table_lookup(package_get_import_from(package), "BAZ"), "OTHER") == 0);
 
   Package *user = package_common_lisp_user_get_instance();
-  assert(g_strcmp0(user->name, "COMMON-LISP-USER") == 0);
-  assert(g_hash_table_contains(user->nicknames, "CL-USER"));
-  assert(g_hash_table_contains(user->uses, "COMMON-LISP"));
+  assert(g_strcmp0(package_get_name(user), "COMMON-LISP-USER") == 0);
+  assert(g_hash_table_contains(package_get_nicknames(user), "CL-USER"));
+  assert(g_hash_table_contains(package_get_uses(user), "COMMON-LISP"));
 
   Node *node = g_new0(Node, 1);
   g_atomic_int_set(&node->ref, 1);


### PR DESCRIPTION
## Summary
- move `Package` struct definition from header to implementation
- add accessor functions for `Package` internals
- update tests to use new accessors

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68ad5128d16c8328ba42c9c74ae0cc84