### PR TITLE
Parse defpackage forms and register packages

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,6 +23,7 @@ SOURCES += \
   lisp_lexer.c \
   lisp_parser.c \
   analyser.c \
+  defpackage.c \
   package.c \
   package_common_lisp_user.c \
   package_common_lisp.c \

--- a/src/analyser.c
+++ b/src/analyser.c
@@ -1,8 +1,9 @@
 #include "analyser.h"
 #include "node.h"
+#include "defpackage.h"
 #include <string.h>
 
-static void analyse_node(Node *node, gchar **context) {
+static void analyse_node(Project *project, Node *node, gchar **context) {
   if (!node)
     return;
 
@@ -25,6 +26,9 @@ static void analyse_node(Node *node, gchar **context) {
               g_free(*context);
               *context = g_strdup(pkg_name);
             }
+          } else if (strcmp(name, "DEFPACKAGE") == 0) {
+            analyse_defpackage(project, node, *context);
+            return;
           }
         }
       }
@@ -33,14 +37,14 @@ static void analyse_node(Node *node, gchar **context) {
       Node *child = g_array_index(node->children, Node*, i);
       if (i > 0 && child->type == LISP_AST_NODE_TYPE_SYMBOL && !child->sd_type)
         node_set_sd_type(child, SDT_VAR_USE, *context);
-      analyse_node(child, context);
+      analyse_node(project, child, context);
     }
   }
 }
 
-void analyse_ast(Node *root) {
+void analyse_ast(Project *project, Node *root) {
   gchar *context = g_strdup("COMMON-LISP-USER");
-  analyse_node(root, &context);
+  analyse_node(project, root, &context);
   g_free(context);
 }
 

--- a/src/analyser.h
+++ b/src/analyser.h
@@ -2,5 +2,7 @@
 
 #include "node.h"
 
-void analyse_ast(Node *root);
+typedef struct _Project Project;
+
+void analyse_ast(Project *project, Node *root);
 

--- a/src/defpackage.c
+++ b/src/defpackage.c
@@ -1,0 +1,75 @@
+#include "defpackage.h"
+#include "package.h"
+#include <string.h>
+
+static void parse_symbols(Node *list, guint start,
+    void (*add)(Package *package, const gchar *symbol), Package *package,
+    const gchar *context, StringDesignatorType sd_type) {
+  if (!list || !list->children) return;
+  for (guint i = start; i < list->children->len; i++) {
+    Node *sym = g_array_index(list->children, Node*, i);
+    const gchar *name = node_get_name(sym);
+    if (name) {
+      if (add)
+        add(package, name);
+      if (sd_type != SDT_NONE)
+        node_set_sd_type(sym, sd_type, context);
+    }
+  }
+}
+
+void analyse_defpackage(Project *project, Node *expr, const gchar *context) {
+  if (!project || !expr || !expr->children || expr->children->len < 2) return;
+
+  Node *name_node = g_array_index(expr->children, Node*, 1);
+  const gchar *pkg_name = node_get_name(name_node);
+  if (!pkg_name) return;
+
+  Package *pkg = package_new(pkg_name);
+  node_set_sd_type(name_node, SDT_PACKAGE_DEF, context);
+
+  for (guint i = 2; i < expr->children->len; i++) {
+    Node *option = g_array_index(expr->children, Node*, i);
+    if (!option || option->type != LISP_AST_NODE_TYPE_LIST || !option->children || option->children->len == 0)
+      continue;
+    Node *keyword_node = g_array_index(option->children, Node*, 0);
+    const gchar *keyword = node_get_name(keyword_node);
+    if (!keyword) continue;
+
+    if (strcmp(keyword, "NICKNAMES") == 0) {
+      parse_symbols(option, 1, (void(*)(Package*, const gchar*))package_add_nickname, pkg, context, SDT_PACKAGE_DEF);
+    } else if (strcmp(keyword, "USE") == 0) {
+      parse_symbols(option, 1, (void(*)(Package*, const gchar*))package_add_use, pkg, context, SDT_PACKAGE_USE);
+    } else if (strcmp(keyword, "EXPORT") == 0) {
+      parse_symbols(option, 1, (void(*)(Package*, const gchar*))package_add_export, pkg, context, SDT_NONE);
+    } else if (strcmp(keyword, "SHADOW") == 0) {
+      parse_symbols(option, 1, (void(*)(Package*, const gchar*))package_add_shadow, pkg, context, SDT_NONE);
+    } else if (strcmp(keyword, "IMPORT-FROM") == 0) {
+      if (option->children->len > 2) {
+        Node *from_node = g_array_index(option->children, Node*, 1);
+        const gchar *from_name = node_get_name(from_node);
+        if (from_name) {
+          node_set_sd_type(from_node, SDT_PACKAGE_USE, context);
+          for (guint j = 2; j < option->children->len; j++) {
+            Node *sym = g_array_index(option->children, Node*, j);
+            const gchar *sym_name = node_get_name(sym);
+            if (sym_name) {
+              package_add_import_from(pkg, sym_name, from_name);
+            }
+          }
+        }
+      }
+    } else if (strcmp(keyword, "DOCUMENTATION") == 0) {
+      if (option->children->len > 1) {
+        Node *str = g_array_index(option->children, Node*, 1);
+        const gchar *desc = node_get_name(str);
+        if (desc)
+          package_set_description(pkg, desc);
+      }
+    }
+  }
+
+  project_add_package(project, pkg);
+  package_unref(pkg);
+}
+

--- a/src/defpackage.h
+++ b/src/defpackage.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "project.h"
+#include "node.h"
+
+void analyse_defpackage(Project *project, Node *node, const gchar *context);
+

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #ifdef INLINE
 #define STATIC static
 #include "analyser.c"
+#include "defpackage.c"
 #include "app.c"
 #include "asdf.c"
 #include "asdf_view.c"

--- a/src/project.h
+++ b/src/project.h
@@ -6,6 +6,7 @@ typedef struct _GtkTextBuffer GtkTextBuffer;
 #include "project_file.h"
 #include "node.h"
 #include "asdf.h"
+#include "package.h"
 
 typedef struct _Project Project;
 
@@ -27,8 +28,11 @@ void           project_file_loaded(Project *self, ProjectFile *file);
 void           project_file_removed(Project *self, ProjectFile *file);
 void           project_index_add(Project *self, Node *node);
 GHashTable    *project_get_index(Project *self, StringDesignatorType sd_type);
+void           project_add_package(Project *self, Package *package);
+Package       *project_get_package(Project *self, const gchar *name);
 void           project_set_asdf(Project *self, Asdf *asdf);
 Asdf          *project_get_asdf(Project *self);
 void           project_clear(Project *self);
 const gchar   *project_get_path(Project *self);
 void           project_set_path(Project *self, const gchar *path);
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,13 +22,13 @@ swank_session_test: swank_session_test.c swank_session.c swank_process.c real_sw
 lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project.c project_file.c analyser.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+project_test: project_test.c project.c project_file.c analyser.c defpackage.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c project_file.c analyser.c
+asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c project_file.c analyser.c defpackage.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-analyser_test: analyser_test.c analyser.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c
+analyser_test: analyser_test.c analyser.c defpackage.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c project.c project_file.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 package_test: package_test.c package.c package_common_lisp_user.c node.c

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -3,12 +3,14 @@
 #include "lisp_parser.h"
 #include "node.h"
 #include "string_text_provider.h"
+#include "project.h"
 #include <glib.h>
 
 int main(void) {
   const gchar *text =
+    "(defpackage :my-pack (:nicknames :mp) (:use :cl))\n"
     "(defun foo ())\n"
-    "(in-package \"MY-PACK\")\n"
+    "(in-package :my-pack)\n"
     "(defun bar ())\n"
     "(foo baz)";
   TextProvider *provider = string_text_provider_new(text);
@@ -19,17 +21,23 @@ int main(void) {
   lisp_parser_parse(parser, tokens);
   Node *ast = (Node*)lisp_parser_get_ast(parser);
 
-  analyse_ast(ast);
+  Project *project = project_new();
+  analyse_ast(project, ast);
 
-  Node *foo_expr = g_array_index(ast->children, Node*, 0);
+  Package *pkg = project_get_package(project, "MY-PACK");
+  g_assert(pkg);
+  g_assert(g_hash_table_contains(package_get_nicknames(pkg), "MP"));
+  g_assert(g_hash_table_contains(package_get_uses(pkg), "CL"));
+
+  Node *foo_expr = g_array_index(ast->children, Node*, 1);
   Node *foo_name = g_array_index(foo_expr->children, Node*, 1);
   g_assert_cmpstr(foo_name->package_context, ==, "COMMON-LISP-USER");
 
-  Node *bar_expr = g_array_index(ast->children, Node*, 2);
+  Node *bar_expr = g_array_index(ast->children, Node*, 3);
   Node *bar_name = g_array_index(bar_expr->children, Node*, 1);
   g_assert_cmpstr(bar_name->package_context, ==, "MY-PACK");
 
-  Node *call_expr = g_array_index(ast->children, Node*, 3);
+  Node *call_expr = g_array_index(ast->children, Node*, 4);
   Node *var_use = g_array_index(call_expr->children, Node*, 1);
   g_assert(node_is(var_use, SDT_VAR_USE));
   g_assert_cmpstr(var_use->package_context, ==, "MY-PACK");
@@ -37,5 +45,6 @@ int main(void) {
   lisp_parser_free(parser);
   lisp_lexer_free(lexer);
   text_provider_unref(provider);
+  project_unref(project);
   return 0;
 }


### PR DESCRIPTION
## Summary
- Parse `DEFPACKAGE` forms into `Package` objects and record them in the project
- Integrate defpackage analysis into AST analyser
- Expose project package lookup and update tests for package parsing

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68ad5a6cb8388328aa3c4b2642855cd9