### PR TITLE
Add description field to ASDF and use keyword components

### DIFF
--- a/src/asdf.h
+++ b/src/asdf.h
@@ -10,6 +10,8 @@ G_DECLARE_FINAL_TYPE(Asdf, asdf, GLIDE, ASDF, GObject)
 Asdf *asdf_new(void);
 Asdf *asdf_new_from_file(const gchar *filename);
 const gchar *asdf_get_filename(Asdf *self);
+void asdf_set_description(Asdf *self, const gchar *description);
+const gchar *asdf_get_description(Asdf *self);
 void asdf_set_serial(Asdf *self, gboolean serial);
 gboolean asdf_get_serial(Asdf *self);
 void asdf_add_component(Asdf *self, const gchar *file);


### PR DESCRIPTION
## Summary
- support reading/writing `:description` in ASDF files
- serialize components using keyword `:file`
- extend tests for parsing and saving ASDF with description

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68adc81fe23c8328b529cbb49c08d370