### PR TITLE
Add package info utilities and rename symbol file

### DIFF
--- a/src/glide-package.lisp
+++ b/src/glide-package.lisp
@@ -1,0 +1,4 @@
+(defpackage :glide
+  (:use :cl)
+  (:export :package-symbols
+           :package-info))

--- a/src/glide.asd
+++ b/src/glide.asd
@@ -2,4 +2,6 @@
   :description "List symbols of a given package"
   :version "0.0.1"
   :serial t
-  :components ((:file "symbols")))
+  :components ((:file "glide-package")
+               (:file "symbol-info")
+               (:file "package-info")))

--- a/src/package-info.lisp
+++ b/src/package-info.lisp
@@ -1,0 +1,17 @@
+(in-package :glide)
+
+(defun package-info (package-name)
+  (let ((pkg (find-package package-name)))
+    (when pkg
+      (list :name (package-name pkg)
+            :description (documentation pkg t)
+            :nicknames (package-nicknames pkg)
+            :uses (mapcar #'package-name (package-use-list pkg))
+            :exports (loop for sym being the external-symbols of pkg
+                           collect (symbol-name sym))
+            :shadows (mapcar #'symbol-name (package-shadowing-symbols pkg))
+            :import-from (loop for sym being the present-symbols of pkg
+                               for home = (symbol-package sym)
+                               unless (eq pkg home)
+                               collect (list (symbol-name sym)
+                                             (package-name home))))))

--- a/src/symbol-info.lisp
+++ b/src/symbol-info.lisp
@@ -1,7 +1,3 @@
-(defpackage :glide
-  (:use :cl)
-  (:export :package-symbols))
-
 (in-package :glide)
 
 (defun package-symbols (package-name)


### PR DESCRIPTION
## Summary
- rename `symbols.lisp` to `symbol-info.lisp` and export `package-info`
- add `package-info.lisp` providing package metadata for populating C `Package`
- extract `defpackage` into standalone `glide-package.lisp`
- update `glide.asd` to load new Lisp source files

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68adc871f77483288efc48e7b40572c2