### PR TITLE
Add run menu and evaluate current top-level form

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -137,6 +137,10 @@ app_activate (GApplication *app)
   GtkWidget *rename_item   = gtk_menu_item_new_with_label("Rename");
   GtkWidget *delete_item   = gtk_menu_item_new_with_label("Delete");
 
+  GtkWidget *run_menu      = gtk_menu_new();
+  GtkWidget *run_item      = gtk_menu_item_new_with_label("Run");
+  GtkWidget *eval_item     = gtk_menu_item_new_with_label("Eval toplevel");
+
   GtkWidget *project_menu  = gtk_menu_new();
   GtkWidget *project_item  = gtk_menu_item_new_with_label("Project");
   GtkWidget *proj_new_item = gtk_menu_item_new_with_label("New…");
@@ -173,6 +177,10 @@ app_activate (GApplication *app)
   gtk_menu_shell_append(GTK_MENU_SHELL(refactor_menu), refactor_file_item);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), refactor_item);
 
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(run_item), run_menu);
+  gtk_menu_shell_append(GTK_MENU_SHELL(run_menu), eval_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), run_item);
+
   g_signal_connect(proj_new_item, "activate", G_CALLBACK(project_new_wizard), self);
   g_signal_connect(proj_open_item, "activate", G_CALLBACK(file_open), self);
   g_signal_connect(newfile_item, "activate", G_CALLBACK(file_new), self);
@@ -182,6 +190,7 @@ app_activate (GApplication *app)
   g_signal_connect(exit_item, "activate", G_CALLBACK(quit_menu_item), self);
   g_signal_connect(rename_item, "activate", G_CALLBACK(file_rename), self);
   g_signal_connect(delete_item, "activate", G_CALLBACK(file_delete), self);
+  g_signal_connect(eval_item, "activate", G_CALLBACK(on_evaluate), self);
 
   GtkWidget *interactions = GTK_WIDGET(interactions_view_new(self->swank));
   GtkWidget *paned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1,6 +1,6 @@
 /* evaluate.c
  *
- * Implements evaluation of the code found on the current line in the
+ * Implements evaluation of the top-level form at the caret in the
  * GtkSourceView buffer.  The text is forwarded to the Swank backend for
  * remote execution.
  */
@@ -14,7 +14,7 @@
 #include <gtksourceview/gtksource.h>
 
 /* ------------------------------------------------------------------------- */
-/* Callback triggered when the user requests evaluation of the current line. */
+/* Callback triggered when the user requests evaluation of the current form. */
 /* ------------------------------------------------------------------------- */
 void
 on_evaluate(App *self)
@@ -22,32 +22,49 @@ on_evaluate(App *self)
   g_debug("Evaluate.on_evaluate");
   GtkSourceBuffer *source_buffer =
       lisp_source_view_get_buffer(app_get_source_view(self));
-
-  /* 1. Locate the iterator at the caret (insert mark). */
   GtkTextMark *insert_mark = gtk_text_buffer_get_insert(GTK_TEXT_BUFFER(source_buffer));
   GtkTextIter cursor_iter;
   gtk_text_buffer_get_iter_at_mark(GTK_TEXT_BUFFER(source_buffer), &cursor_iter, insert_mark);
 
-  /* 2. Create iterators for the start and end of the current line. */
-  GtkTextIter line_start = cursor_iter;
-  gtk_text_iter_set_line_offset(&line_start, 0);           /* column 0 */
+  GtkTextIter start = cursor_iter;
+  gint depth = 0;
+  while (gtk_text_iter_backward_char(&start)) {
+    gunichar ch = gtk_text_iter_get_char(&start);
+    if (ch == ')')
+      depth++;
+    else if (ch == '(') {
+      if (depth == 0)
+        break;
+      depth--;
+    }
+  }
 
-  GtkTextIter line_end = line_start;
-  gtk_text_iter_forward_to_line_end(&line_end);            /* move to EOL */
+  GtkTextIter end = start;
+  depth = 0;
+  do {
+    gunichar ch = gtk_text_iter_get_char(&end);
+    if (ch == '(')
+      depth++;
+    else if (ch == ')') {
+      depth--;
+      if (depth == 0) {
+        gtk_text_iter_forward_char(&end);
+        break;
+      }
+    }
+  } while (gtk_text_iter_forward_char(&end));
 
-  /* 3. Extract the line‟s contents (excluding the trailing newline). */
   gchar *expr = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(source_buffer),
-      &line_start,
-      &line_end,
-      FALSE);          /* no hidden chars */
+      &start,
+      &end,
+      FALSE);
 
   if (expr == NULL || *expr == '\0') {
-    g_debug("Evaluate.on_evaluate: nothing to evaluate on the current line");
+    g_debug("Evaluate.on_evaluate: nothing to evaluate");
     g_free(expr);
     return;
   }
 
-  /* 4. Send the expression to SWANK for remote execution. */
   SwankSession *swank = app_get_swank(self);
   if (swank) {
     Interaction *interaction = g_new0(Interaction, 1);


### PR DESCRIPTION
## Summary
- Introduce a Run menu with an "Eval toplevel" action
- Evaluate the Lisp top-level form at the caret instead of just the current line

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68add185fa888328ba97ddbb9b935614