### PR TITLE
Fix Run menu evaluate crash

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -43,3 +43,11 @@ selection algorithm climbed only one level and returned the same bounds. The
 search now skips parents with identical ranges and therefore reaches the
 correct enclosing expression. Debug logging was also added to help diagnose
 future issues.
+
+## Crash when evaluating from the Run menu
+
+Selecting "Run > Eval toplevel" triggered a GLib critical and terminated the
+program. The "activate" signal for the menu item invoked `on_evaluate` with the
+menu item as the first argument, but the handler expected only an `App*`. The
+function now uses the standard `GtkWidget *, gpointer` signature and verifies
+the `App` instance before evaluating the current form.

--- a/src/app.c
+++ b/src/app.c
@@ -101,7 +101,7 @@ on_key_press(GtkWidget * /*widget*/,
   if ((event->keyval == GDK_KEY_Return) &&
       (event->state  & GDK_MOD1_MASK))      /* Alt+Enter */
   {
-    on_evaluate(self);
+    on_evaluate(NULL, self);
     return TRUE;                  /* stop further propagation */
   }
   if ((event->keyval == GDK_KEY_p || event->keyval == GDK_KEY_P) &&

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -5,21 +5,24 @@
  * remote execution.
  */
 
+#include <gtk/gtk.h>
+#include <gtksourceview/gtksource.h>
+
 #include "swank_session.h"
 #include "interaction.h"
 #include "evaluate.h"
 #include "lisp_source_view.h"
-
-#include <gtk/gtk.h>
-#include <gtksourceview/gtksource.h>
+#include "app.h"
 
 /* ------------------------------------------------------------------------- */
 /* Callback triggered when the user requests evaluation of the current form. */
 /* ------------------------------------------------------------------------- */
 void
-on_evaluate(App *self)
+on_evaluate(GtkWidget * /*item*/, gpointer data) /* actually App* */
 {
+  App *self = (App *) data;
   g_debug("Evaluate.on_evaluate");
+  g_return_if_fail(GLIDE_IS_APP(self));
   GtkSourceBuffer *source_buffer =
       lisp_source_view_get_buffer(app_get_source_view(self));
   GtkTextMark *insert_mark = gtk_text_buffer_get_insert(GTK_TEXT_BUFFER(source_buffer));

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "app.h"
-
 void
-on_evaluate(App *self);
+on_evaluate(GtkWidget * /*item*/, gpointer data);
 


### PR DESCRIPTION
## Summary
- fix Evaluate menu handler signature to accept the widget and app user data
- validate App instance before evaluating
- document crash in BUGS

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68ae3acc420c8328a2a7eb8ecf9ccd3c