### PR TITLE
Refactor menu and action handling

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,8 @@ SOURCES += \
   swank_session.c \
   evaluate.c \
   interactions_view.c \
+  actions.c \
+  menu_bar.c \
   app.c \
   lisp_source_notebook.c \
   lisp_source_view.c \

--- a/src/actions.c
+++ b/src/actions.c
@@ -1,0 +1,182 @@
+#include "actions.h"
+#include "file_save.h"
+#include "file_open.h"
+#include "file_rename.h"
+#include "evaluate.h"
+#include "lisp_parser_view.h"
+#include "project_file.h"
+#include "lisp_source_notebook.h"
+#include "lisp_source_view.h"
+
+static gboolean app_maybe_save_all(App *self);
+
+void
+on_show_parser(App *self)
+{
+  GtkWidget *win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  gtk_window_set_title(GTK_WINDOW(win), "Parser View");
+  LispSourceNotebook *notebook = app_get_notebook(self);
+  LispSourceView *current = lisp_source_notebook_get_current_view(notebook);
+  ProjectFile *file = lisp_source_view_get_file(current);
+  GtkWidget *view = lisp_parser_view_new(file);
+  GtkWidget *scrolled = gtk_scrolled_window_new(NULL, NULL);
+  gtk_container_add(GTK_CONTAINER(scrolled), view);
+  gtk_container_add(GTK_CONTAINER(win), scrolled);
+  gtk_widget_show_all(win);
+}
+
+void
+on_extend_selection(GtkWidget * /*item*/, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  LispSourceNotebook *notebook = app_get_notebook(self);
+  LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+  if (view)
+    lisp_source_view_extend_selection(view);
+}
+
+void
+on_shrink_selection(GtkWidget * /*item*/, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  LispSourceNotebook *notebook = app_get_notebook(self);
+  LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+  if (view)
+    lisp_source_view_shrink_selection(view);
+}
+
+void
+on_save_all(GtkWidget * /*item*/, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  file_save_all(app_get_project(self));
+}
+
+void
+on_close_project(GtkWidget * /*item*/, gpointer data)
+{
+  g_debug("Actions.on_close_project");
+  app_close_project(GLIDE_APP(data), TRUE);
+}
+
+void
+on_quit_menu(GtkWidget * /*item*/, gpointer data)
+{
+  g_debug("Actions.on_quit_menu");
+  app_on_quit(GLIDE_APP(data));
+}
+
+gboolean
+on_quit_delete_event(GtkWidget * /*widget*/, GdkEvent * /*event*/, gpointer data)
+{
+  g_debug("Actions.on_quit_delete_event");
+  app_on_quit(GLIDE_APP(data));
+  return TRUE;
+}
+
+void
+on_recent_project(GtkWidget *item, gpointer data)
+{
+  App *self = GLIDE_APP(data);
+  const gchar *path = g_object_get_data(G_OBJECT(item), "project-path");
+  if (path)
+    file_open_path(self, path);
+}
+
+gboolean
+on_key_press(GtkWidget * /*widget*/, GdkEventKey *event, gpointer user_data)
+{
+  App *self = (App *) user_data;
+
+  if ((event->keyval == GDK_KEY_Return) &&
+      (event->state & GDK_MOD1_MASK))
+  {
+    on_evaluate(NULL, self);
+    return TRUE;
+  }
+  if ((event->keyval == GDK_KEY_p || event->keyval == GDK_KEY_P) &&
+      (event->state & GDK_MOD1_MASK))
+  {
+    on_show_parser(self);
+    return TRUE;
+  }
+  if ((event->keyval == GDK_KEY_w || event->keyval == GDK_KEY_W) &&
+      ((event->state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) ==
+       (GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
+  {
+    LispSourceNotebook *notebook = app_get_notebook(self);
+    LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+    if (view)
+      lisp_source_view_shrink_selection(view);
+    return TRUE;
+  }
+  if ((event->keyval == GDK_KEY_w || event->keyval == GDK_KEY_W) &&
+      ((event->state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) ==
+       GDK_CONTROL_MASK))
+  {
+    LispSourceNotebook *notebook = app_get_notebook(self);
+    LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+    if (view)
+      lisp_source_view_extend_selection(view);
+    return TRUE;
+  }
+  if ((event->keyval == GDK_KEY_F6) &&
+      (event->state & GDK_SHIFT_MASK))
+  {
+    file_rename(NULL, self);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static gboolean
+app_maybe_save_all(App *self)
+{
+  LispSourceNotebook *notebook = app_get_notebook(self);
+  if (!notebook)
+    return TRUE;
+  gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(notebook));
+  gboolean modified = FALSE;
+  for (gint i = 0; i < pages; i++) {
+    GtkWidget *view = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
+    GtkTextBuffer *buffer = view ? GTK_TEXT_BUFFER(lisp_source_view_get_buffer(LISP_SOURCE_VIEW(view))) : NULL;
+    if (buffer && gtk_text_buffer_get_modified(buffer)) {
+      modified = TRUE;
+      break;
+    }
+  }
+  if (!modified)
+    return TRUE;
+  GtkWidget *dialog = gtk_message_dialog_new(NULL, GTK_DIALOG_MODAL,
+      GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+      "Save changes to project?");
+  gtk_dialog_add_button(GTK_DIALOG(dialog), "_Cancel", GTK_RESPONSE_CANCEL);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), "_Discard", GTK_RESPONSE_REJECT);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), "_Save", GTK_RESPONSE_ACCEPT);
+  gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+  if (res == GTK_RESPONSE_CANCEL)
+    return FALSE;
+  if (res == GTK_RESPONSE_ACCEPT)
+    file_save_all(app_get_project(self));
+  return TRUE;
+}
+
+gboolean
+app_close_project(App *self, gboolean forget_project)
+{
+  g_debug("Actions.app_close_project forget=%d", forget_project);
+  g_return_val_if_fail(GLIDE_IS_APP(self), FALSE);
+  if (!app_maybe_save_all(self))
+    return FALSE;
+  Project *project = app_get_project(self);
+  project_clear(project);
+  Preferences *prefs = app_get_preferences(self);
+  if (prefs && forget_project) {
+    preferences_set_project_file(prefs, NULL);
+    preferences_set_last_file(prefs, NULL);
+    preferences_set_cursor_position(prefs, 0);
+  }
+  app_update_asdf_view(self);
+  return TRUE;
+}

--- a/src/actions.h
+++ b/src/actions.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include "app.h"
+
+G_BEGIN_DECLS
+
+gboolean on_quit_delete_event(GtkWidget * /*widget*/, GdkEvent * /*event*/, gpointer data);
+void on_quit_menu(GtkWidget * /*item*/, gpointer data);
+void on_close_project(GtkWidget * /*item*/, gpointer data);
+void on_save_all(GtkWidget * /*item*/, gpointer data);
+void on_extend_selection(GtkWidget * /*item*/, gpointer data);
+void on_shrink_selection(GtkWidget * /*item*/, gpointer data);
+void on_recent_project(GtkWidget *item, gpointer data);
+void on_show_parser(App *self);
+gboolean on_key_press(GtkWidget * /*widget*/, GdkEventKey *event, gpointer user_data);
+gboolean app_close_project(App *self, gboolean forget_project);
+
+G_END_DECLS

--- a/src/app.h
+++ b/src/app.h
@@ -31,6 +31,7 @@ STATIC SwankSession *app_get_swank(App *self);
 STATIC void app_on_quit(App *self);
 STATIC void app_quit(App *self);
 STATIC StatusService *app_get_status_service(App *self);
+void app_set_recent_menu(App *self, GtkWidget *menu);
 
 G_END_DECLS
 

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,8 @@
 #include "analyse.c"
 #include "analyse_defpackage.c"
 #include "analyse_defun.c"
+#include "actions.c"
+#include "menu_bar.c"
 #include "app.c"
 #include "asdf.c"
 #include "asdf_view.c"

--- a/src/menu_bar.c
+++ b/src/menu_bar.c
@@ -1,0 +1,96 @@
+#include "menu_bar.h"
+#include "actions.h"
+#include "file_open.h"
+#include "file_new.h"
+#include "file_add.h"
+#include "file_rename.h"
+#include "file_delete.h"
+#include "project_new_wizard.h"
+#include "preferences_dialog.h"
+#include "evaluate.h"
+
+GtkWidget *
+menu_bar_new(App *self)
+{
+  GtkWidget *menu_bar      = gtk_menu_bar_new();
+  GtkWidget *file_menu     = gtk_menu_new();
+  GtkWidget *file_item     = gtk_menu_item_new_with_label("File");
+
+  GtkWidget *edit_menu     = gtk_menu_new();
+  GtkWidget *edit_item     = gtk_menu_item_new_with_label("Edit");
+  GtkWidget *extend_item   = gtk_menu_item_new_with_label("Extend selection");
+  GtkWidget *shrink_item   = gtk_menu_item_new_with_label("Shrink selection");
+
+  GtkWidget *refactor_menu = gtk_menu_new();
+  GtkWidget *refactor_item = gtk_menu_item_new_with_label("Refactor");
+  GtkWidget *refactor_file_menu = gtk_menu_new();
+  GtkWidget *refactor_file_item = gtk_menu_item_new_with_label("File");
+  GtkWidget *rename_item   = gtk_menu_item_new_with_label("Rename");
+  GtkWidget *delete_item   = gtk_menu_item_new_with_label("Delete");
+
+  GtkWidget *run_menu      = gtk_menu_new();
+  GtkWidget *run_item      = gtk_menu_item_new_with_label("Run");
+  GtkWidget *eval_item     = gtk_menu_item_new_with_label("Eval toplevel");
+
+  GtkWidget *project_menu  = gtk_menu_new();
+  GtkWidget *project_item  = gtk_menu_item_new_with_label("Project");
+  GtkWidget *proj_new_item = gtk_menu_item_new_with_label("New…");
+  GtkWidget *proj_open_item = gtk_menu_item_new_with_label("Open…");
+  GtkWidget *proj_recent_item = gtk_menu_item_new_with_label("Recent");
+  GtkWidget *recent_menu   = gtk_menu_new();
+  app_set_recent_menu(self, recent_menu);
+
+  GtkWidget *newfile_item  = gtk_menu_item_new_with_label("New file");
+  GtkWidget *addfile_item  = gtk_menu_item_new_with_label("Add file");
+  GtkWidget *saveall_item  = gtk_menu_item_new_with_label("Save all");
+  GtkWidget *closeproj_item = gtk_menu_item_new_with_label("Close project");
+  GtkWidget *settings_item = gtk_menu_item_new_with_label("Settings…");
+  GtkWidget *exit_item     = gtk_menu_item_new_with_label("Exit");
+
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(file_item), file_menu);
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(project_item), project_menu);
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(proj_recent_item), recent_menu);
+  gtk_menu_shell_append(GTK_MENU_SHELL(project_menu), proj_new_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(project_menu), proj_open_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(project_menu), proj_recent_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), project_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), newfile_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), addfile_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), saveall_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), closeproj_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), gtk_separator_menu_item_new());
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), settings_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), gtk_separator_menu_item_new());
+  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), exit_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), file_item);
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(edit_item), edit_menu);
+  gtk_menu_shell_append(GTK_MENU_SHELL(edit_menu), extend_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(edit_menu), shrink_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), edit_item);
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(refactor_item), refactor_menu);
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(refactor_file_item), refactor_file_menu);
+  gtk_menu_shell_append(GTK_MENU_SHELL(refactor_file_menu), rename_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(refactor_file_menu), delete_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(refactor_menu), refactor_file_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), refactor_item);
+
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(run_item), run_menu);
+  gtk_menu_shell_append(GTK_MENU_SHELL(run_menu), eval_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), run_item);
+
+  g_signal_connect(proj_new_item, "activate", G_CALLBACK(project_new_wizard), self);
+  g_signal_connect(proj_open_item, "activate", G_CALLBACK(file_open), self);
+  g_signal_connect(newfile_item, "activate", G_CALLBACK(file_new), self);
+  g_signal_connect(addfile_item, "activate", G_CALLBACK(file_add), self);
+  g_signal_connect(saveall_item, "activate", G_CALLBACK(on_save_all), self);
+  g_signal_connect(closeproj_item, "activate", G_CALLBACK(on_close_project), self);
+  g_signal_connect(settings_item, "activate", G_CALLBACK(on_preferences), self);
+  g_signal_connect(exit_item, "activate", G_CALLBACK(on_quit_menu), self);
+  g_signal_connect(rename_item, "activate", G_CALLBACK(file_rename), self);
+  g_signal_connect(delete_item, "activate", G_CALLBACK(file_delete), self);
+  g_signal_connect(extend_item, "activate", G_CALLBACK(on_extend_selection), self);
+  g_signal_connect(shrink_item, "activate", G_CALLBACK(on_shrink_selection), self);
+  g_signal_connect(eval_item, "activate", G_CALLBACK(on_evaluate), self);
+
+  return menu_bar;
+}

--- a/src/menu_bar.h
+++ b/src/menu_bar.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include "app.h"
+
+GtkWidget *menu_bar_new(App *self);


### PR DESCRIPTION
## Summary
- move menu bar construction to dedicated module
- centralize user-triggered actions in actions.c
- update app to use new menu and actions helpers

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68aec5accfcc8328aaa8ef4c5b1f2762