### PR TITLE
Disable swank debug mode during evaluation

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -51,3 +51,9 @@ program. The "activate" signal for the menu item invoked `on_evaluate` with the
 menu item as the first argument, but the handler expected only an `App*`. The
 function now uses the standard `GtkWidget *, gpointer` signature and verifies
 the `App` instance before evaluating the current form.
+
+## Swank debug mode left enabled
+
+Evaluating expressions kept `swank:*swank-debug-p*` set to `t`, so swank printed
+verbose debugging information during normal evaluations. The evaluation code now
+invokes `:emacs-rex` with the debug flag set to `nil`, keeping swank quiet.

--- a/src/real_swank_session.c
+++ b/src/real_swank_session.c
@@ -82,7 +82,7 @@ static gpointer real_swank_session_thread(gpointer data) {
     if (added_cb)
       added_cb((SwankSession*)self, interaction, added_cb_data);
     gchar *escaped = escape_string(interaction->expression);
-    gchar *rpc = g_strdup_printf("(:emacs-rex (swank:eval-and-grab-output \"%s\") \"COMMON-LISP-USER\" t %u)", escaped, interaction->tag);
+    gchar *rpc = g_strdup_printf("(:emacs-rex (swank:eval-and-grab-output \"%s\") \"COMMON-LISP-USER\" nil %u)", escaped, interaction->tag);
     GString *payload = g_string_new(rpc);
     g_free(escaped);
     g_free(rpc);

--- a/tests/swank_session_test.c
+++ b/tests/swank_session_test.c
@@ -78,7 +78,7 @@ static void test_eval(void)
   interaction_clear(&interaction);
   g_assert_cmpint(interaction.tag, ==, 1);
   g_assert_cmpstr(mock_swank_process->last->str, ==,
-      "(:emacs-rex (swank:eval-and-grab-output \"(+ 1 2)\") \"COMMON-LISP-USER\" t 1)");
+      "(:emacs-rex (swank:eval-and-grab-output \"(+ 1 2)\") \"COMMON-LISP-USER\" nil 1)");
   g_assert_cmpint(mock_swank_process->start_count, ==, 1);
   swank_session_unref(sess);
   status_service_free(status_service);


### PR DESCRIPTION
## Summary
- Avoid Swank's verbose output by invoking `:emacs-rex` with debug flag set to nil
- Update evaluation test to expect nil debug flag
- Document the fix in BUGS.md

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68aec9d9798c8328b559432967ab9756