### PR TITLE
Fix top-level evaluation selection

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -57,3 +57,12 @@ the `App` instance before evaluating the current form.
 Evaluating expressions kept `swank:*swank-debug-p*` set to `t`, so swank printed
 verbose debugging information during normal evaluations. The evaluation code now
 invokes `:emacs-rex` with the debug flag set to `nil`, keeping swank quiet.
+
+## Eval toplevel always picked first expression
+
+Using the "Run > Eval toplevel" action evaluated the first form in the buffer
+regardless of the cursor position. The search for the surrounding form scanned
+backward for parentheses and stopped at the buffer start when invoked at the
+beginning of a line. Evaluation now asks `LispSourceView` for the enclosing
+top‑level range, which is shared with the selection expansion logic, so the
+correct expression is sent to swank.

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -23,46 +23,32 @@ on_evaluate(GtkWidget * /*item*/, gpointer data) /* actually App* */
   App *self = (App *) data;
   g_debug("Evaluate.on_evaluate");
   g_return_if_fail(GLIDE_IS_APP(self));
-  GtkSourceBuffer *source_buffer =
-      lisp_source_view_get_buffer(app_get_source_view(self));
-  GtkTextMark *insert_mark = gtk_text_buffer_get_insert(GTK_TEXT_BUFFER(source_buffer));
+  LispSourceView *view = app_get_source_view(self);
+  GtkSourceBuffer *source_buffer = lisp_source_view_get_buffer(view);
+  GtkTextMark *insert_mark =
+      gtk_text_buffer_get_insert(GTK_TEXT_BUFFER(source_buffer));
   GtkTextIter cursor_iter;
-  gtk_text_buffer_get_iter_at_mark(GTK_TEXT_BUFFER(source_buffer), &cursor_iter, insert_mark);
+  gtk_text_buffer_get_iter_at_mark(GTK_TEXT_BUFFER(source_buffer),
+      &cursor_iter, insert_mark);
+  gsize offset = gtk_text_iter_get_offset(&cursor_iter);
 
-  GtkTextIter start = cursor_iter;
-  gint depth = 0;
-  while (gtk_text_iter_backward_char(&start)) {
-    gunichar ch = gtk_text_iter_get_char(&start);
-    if (ch == ')')
-      depth++;
-    else if (ch == '(') {
-      if (depth == 0)
-        break;
-      depth--;
-    }
+  gsize start_offset;
+  gsize end_offset;
+  if (!lisp_source_view_get_toplevel_range(view, offset, &start_offset,
+      &end_offset)) {
+    g_debug("Evaluate.on_evaluate: nothing to evaluate");
+    return;
   }
 
-  GtkTextIter end = start;
-  depth = 0;
-  do {
-    gunichar ch = gtk_text_iter_get_char(&end);
-    if (ch == '(')
-      depth++;
-    else if (ch == ')') {
-      depth--;
-      if (depth == 0) {
-        gtk_text_iter_forward_char(&end);
-        break;
-      }
-    }
-  } while (gtk_text_iter_forward_char(&end));
-
+  GtkTextIter start_iter;
+  GtkTextIter end_iter;
+  gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(source_buffer),
+      &start_iter, start_offset);
+  gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(source_buffer),
+      &end_iter, end_offset);
   gchar *expr = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(source_buffer),
-      &start,
-      &end,
-      FALSE);
-
-  if (expr == NULL || *expr == '\0') {
+      &start_iter, &end_iter, FALSE);
+  if (!expr || *expr == '\0') {
     g_debug("Evaluate.on_evaluate: nothing to evaluate");
     g_free(expr);
     return;

--- a/src/lisp_source_view.h
+++ b/src/lisp_source_view.h
@@ -14,6 +14,8 @@ GtkWidget      *lisp_source_view_new_for_file (Project *project, ProjectFile *fi
 GtkSourceBuffer *lisp_source_view_get_buffer (LispSourceView *self);
 ProjectFile    *lisp_source_view_get_file (LispSourceView *self);
 GtkWidget      *lisp_source_view_get_view (LispSourceView *self);
+gboolean        lisp_source_view_get_toplevel_range (LispSourceView *self,
+                    gsize offset, gsize *start, gsize *end);
 void            lisp_source_view_extend_selection (LispSourceView *self);
 void            lisp_source_view_shrink_selection (LispSourceView *self);
 


### PR DESCRIPTION
## Summary
- use AST-based helper in `LispSourceView` to locate enclosing form for evaluation
- share top-level lookup with selection expansion
- document fix for evaluating the wrong form

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68aed07dfe648328af8a3d15a2e1c782