### PR TITLE
Add evaluate selection action

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Running `make` will build 4 binaries:
 * open and save, and associated menu entries.
 * persisted settings
 * a settings dialog
-* can evaluate current line of code with alt-enter.
+* can evaluate selection or top-level form with alt-enter.
 
 # Installation instructions
 

--- a/src/actions.c
+++ b/src/actions.c
@@ -91,7 +91,17 @@ on_key_press(GtkWidget * /*widget*/, GdkEventKey *event, gpointer user_data)
   if ((event->keyval == GDK_KEY_Return) &&
       (event->state & GDK_MOD1_MASK))
   {
-    on_evaluate(NULL, self);
+    LispSourceNotebook *notebook = app_get_notebook(self);
+    LispSourceView *view = lisp_source_notebook_get_current_view(notebook);
+    GtkTextBuffer *buffer = view ?
+        GTK_TEXT_BUFFER(lisp_source_view_get_buffer(view)) : NULL;
+    GtkTextIter it_start;
+    GtkTextIter it_end;
+    if (buffer && gtk_text_buffer_get_selection_bounds(buffer,
+        &it_start, &it_end))
+      on_evaluate_selection(NULL, self);
+    else
+      on_evaluate_toplevel(NULL, self);
     return TRUE;
   }
   if ((event->keyval == GDK_KEY_p || event->keyval == GDK_KEY_P) &&

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1,8 +1,7 @@
 /* evaluate.c
  *
- * Implements evaluation of the top-level form at the caret in the
- * GtkSourceView buffer.  The text is forwarded to the Swank backend for
- * remote execution.
+ * Implements evaluation of Lisp code in the GtkSourceView buffer.  The text
+ * is forwarded to the Swank backend for remote execution.
  */
 
 #include <gtk/gtk.h>
@@ -18,10 +17,10 @@
 /* Callback triggered when the user requests evaluation of the current form. */
 /* ------------------------------------------------------------------------- */
 void
-on_evaluate(GtkWidget * /*item*/, gpointer data) /* actually App* */
+on_evaluate_toplevel(GtkWidget * /*item*/, gpointer data) /* actually App* */
 {
   App *self = (App *) data;
-  g_debug("Evaluate.on_evaluate");
+  g_debug("Evaluate.on_evaluate_toplevel");
   g_return_if_fail(GLIDE_IS_APP(self));
   LispSourceView *view = app_get_source_view(self);
   GtkSourceBuffer *source_buffer = lisp_source_view_get_buffer(view);
@@ -36,7 +35,7 @@ on_evaluate(GtkWidget * /*item*/, gpointer data) /* actually App* */
   gsize end_offset;
   if (!lisp_source_view_get_toplevel_range(view, offset, &start_offset,
       &end_offset)) {
-    g_debug("Evaluate.on_evaluate: nothing to evaluate");
+    g_debug("Evaluate.on_evaluate_toplevel: nothing to evaluate");
     return;
   }
 
@@ -49,7 +48,44 @@ on_evaluate(GtkWidget * /*item*/, gpointer data) /* actually App* */
   gchar *expr = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(source_buffer),
       &start_iter, &end_iter, FALSE);
   if (!expr || *expr == '\0') {
-    g_debug("Evaluate.on_evaluate: nothing to evaluate");
+    g_debug("Evaluate.on_evaluate_toplevel: nothing to evaluate");
+    g_free(expr);
+    return;
+  }
+
+  SwankSession *swank = app_get_swank(self);
+  if (swank) {
+    Interaction *interaction = g_new0(Interaction, 1);
+    interaction_init(interaction, expr);
+    swank_session_eval(swank, interaction);
+  }
+
+  g_free(expr);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Callback triggered when the user requests evaluation of the selection.   */
+/* ------------------------------------------------------------------------- */
+void
+on_evaluate_selection(GtkWidget * /*item*/, gpointer data) /* actually App* */
+{
+  App *self = (App *) data;
+  g_debug("Evaluate.on_evaluate_selection");
+  g_return_if_fail(GLIDE_IS_APP(self));
+  LispSourceView *view = app_get_source_view(self);
+  GtkSourceBuffer *source_buffer = lisp_source_view_get_buffer(view);
+  GtkTextIter start_iter;
+  GtkTextIter end_iter;
+  if (!gtk_text_buffer_get_selection_bounds(GTK_TEXT_BUFFER(source_buffer),
+      &start_iter, &end_iter)) {
+    g_debug("Evaluate.on_evaluate_selection: nothing to evaluate");
+    return;
+  }
+
+  gchar *expr = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(source_buffer),
+      &start_iter, &end_iter, FALSE);
+  if (!expr || *expr == '\0') {
+    g_debug("Evaluate.on_evaluate_selection: nothing to evaluate");
     g_free(expr);
     return;
   }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -1,5 +1,8 @@
 #pragma once
 
 void
-on_evaluate(GtkWidget * /*item*/, gpointer data);
+on_evaluate_toplevel(GtkWidget * /*item*/, gpointer data);
+
+void
+on_evaluate_selection(GtkWidget * /*item*/, gpointer data);
 

--- a/src/menu_bar.c
+++ b/src/menu_bar.c
@@ -31,6 +31,7 @@ menu_bar_new(App *self)
   GtkWidget *run_menu      = gtk_menu_new();
   GtkWidget *run_item      = gtk_menu_item_new_with_label("Run");
   GtkWidget *eval_item     = gtk_menu_item_new_with_label("Eval toplevel");
+  GtkWidget *eval_sel_item = gtk_menu_item_new_with_label("Eval selection");
 
   GtkWidget *project_menu  = gtk_menu_new();
   GtkWidget *project_item  = gtk_menu_item_new_with_label("Project");
@@ -76,6 +77,7 @@ menu_bar_new(App *self)
 
   gtk_menu_item_set_submenu(GTK_MENU_ITEM(run_item), run_menu);
   gtk_menu_shell_append(GTK_MENU_SHELL(run_menu), eval_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(run_menu), eval_sel_item);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), run_item);
 
   g_signal_connect(proj_new_item, "activate", G_CALLBACK(project_new_wizard), self);
@@ -90,7 +92,8 @@ menu_bar_new(App *self)
   g_signal_connect(delete_item, "activate", G_CALLBACK(file_delete), self);
   g_signal_connect(extend_item, "activate", G_CALLBACK(on_extend_selection), self);
   g_signal_connect(shrink_item, "activate", G_CALLBACK(on_shrink_selection), self);
-  g_signal_connect(eval_item, "activate", G_CALLBACK(on_evaluate), self);
+  g_signal_connect(eval_item, "activate", G_CALLBACK(on_evaluate_toplevel), self);
+  g_signal_connect(eval_sel_item, "activate", G_CALLBACK(on_evaluate_selection), self);
 
   return menu_bar;
 }


### PR DESCRIPTION
## Summary
- Support evaluating selected text separately from top-level forms
- Trigger selection or top-level evaluation via Alt-Enter depending on current selection
- Expose both "Eval toplevel" and new "Eval selection" entries in the Run menu and update documentation

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68aed4154b7c83289223248d05abdb9b