### PR TITLE
Disable Swank debug output by clearing global debugger

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -55,8 +55,9 @@ the `App` instance before evaluating the current form.
 ## Swank debug mode left enabled
 
 Evaluating expressions kept `swank:*swank-debug-p*` set to `t`, so swank printed
-verbose debugging information during normal evaluations. The evaluation code now
-invokes `:emacs-rex` with the debug flag set to `nil`, keeping swank quiet.
+verbose debugging information during normal evaluations. The swank process now
+evaluates `(setf swank:*global-debugger* nil)` before starting the server,
+keeping swank quiet.
 
 ## Eval toplevel always picked first expression
 

--- a/src/real_swank_process.c
+++ b/src/real_swank_process.c
@@ -109,6 +109,10 @@ static void start_swank(RealSwankProcess *self) {
   process_write(self->proc, ql_cmd, -1);
   read_until(self, "(\"SB-INTROSPECT\" \"SB-CLTL2\")");
   read_until(self, "* ");
+  const char *dbg_cmd = "(setf swank:*global-debugger* nil)\n";
+  g_debug("RealSwankProcess.start_swank send:%s", dbg_cmd);
+  process_write(self->proc, dbg_cmd, -1);
+  read_until(self, "* ");
   char create_cmd[128];
   g_snprintf(create_cmd, sizeof(create_cmd),
       "(swank:create-server :port %d :dont-close t)\n", self->port);

--- a/src/real_swank_session.c
+++ b/src/real_swank_session.c
@@ -82,7 +82,7 @@ static gpointer real_swank_session_thread(gpointer data) {
     if (added_cb)
       added_cb((SwankSession*)self, interaction, added_cb_data);
     gchar *escaped = escape_string(interaction->expression);
-    gchar *rpc = g_strdup_printf("(:emacs-rex (swank:eval-and-grab-output \"%s\") \"COMMON-LISP-USER\" nil %u)", escaped, interaction->tag);
+    gchar *rpc = g_strdup_printf("(:emacs-rex (swank:eval-and-grab-output \"%s\") \"COMMON-LISP-USER\" t %u)", escaped, interaction->tag);
     GString *payload = g_string_new(rpc);
     g_free(escaped);
     g_free(rpc);

--- a/tests/swank_session_test.c
+++ b/tests/swank_session_test.c
@@ -78,7 +78,7 @@ static void test_eval(void)
   interaction_clear(&interaction);
   g_assert_cmpint(interaction.tag, ==, 1);
   g_assert_cmpstr(mock_swank_process->last->str, ==,
-      "(:emacs-rex (swank:eval-and-grab-output \"(+ 1 2)\") \"COMMON-LISP-USER\" nil 1)");
+      "(:emacs-rex (swank:eval-and-grab-output \"(+ 1 2)\") \"COMMON-LISP-USER\" t 1)");
   g_assert_cmpint(mock_swank_process->start_count, ==, 1);
   swank_session_unref(sess);
   status_service_free(status_service);


### PR DESCRIPTION
## Summary
- revert previous attempt to toggle swank debug through RPC flag
- set `swank:*global-debugger*` to nil before creating the Swank server to avoid verbose debug output
- document fix in BUGS

## Testing
- `cd src && make app-full`
- `cd ../tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68aedba584348328b9a6813d288fbd50