### PR TITLE
Bind debugger hook during swank eval

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -67,3 +67,10 @@ backward for parentheses and stopped at the buffer start when invoked at the
 beginning of a line. Evaluation now asks `LispSourceView` for the enclosing
 top‑level range, which is shared with the selection expansion logic, so the
 correct expression is sent to swank.
+
+## Debugger still activated during evaluations
+
+Disabling swank's global debugger was not enough to prevent the debugger from
+grabbing control. The swank process now let-binds `*debugger-hook*` to `nil`
+when evaluating forms and sends them in the `CL-USER` package, so evaluations
+no longer drop into the debugger unexpectedly.

--- a/src/analyse.c
+++ b/src/analyse.c
@@ -43,7 +43,7 @@ void analyse_node(Project *project, Node *node, gchar **context) {
 }
 
 void analyse_ast(Project *project, Node *root) {
-  gchar *context = g_strdup("COMMON-LISP-USER");
+  gchar *context = g_strdup("CL-USER");
   analyse_node(project, root, &context);
   g_free(context);
 }

--- a/src/real_swank_session.c
+++ b/src/real_swank_session.c
@@ -82,7 +82,9 @@ static gpointer real_swank_session_thread(gpointer data) {
     if (added_cb)
       added_cb((SwankSession*)self, interaction, added_cb_data);
     gchar *escaped = escape_string(interaction->expression);
-    gchar *rpc = g_strdup_printf("(:emacs-rex (swank:eval-and-grab-output \"%s\") \"COMMON-LISP-USER\" t %u)", escaped, interaction->tag);
+    gchar *rpc = g_strdup_printf(
+        "(:emacs-rex (let ((*debugger-hook* nil)) (swank-repl:listener-eval \"%s\\n\")) :cl-user t %u)",
+        escaped, interaction->tag);
     GString *payload = g_string_new(rpc);
     g_free(escaped);
     g_free(rpc);

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -31,7 +31,7 @@ int main(void) {
 
   Node *foo_expr = g_array_index(ast->children, Node*, 1);
   Node *foo_name = g_array_index(foo_expr->children, Node*, 1);
-  g_assert_cmpstr(foo_name->package_context, ==, "COMMON-LISP-USER");
+  g_assert_cmpstr(foo_name->package_context, ==, "CL-USER");
 
   Node *bar_expr = g_array_index(ast->children, Node*, 3);
   Node *bar_name = g_array_index(bar_expr->children, Node*, 1);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -140,7 +140,7 @@ static void test_functions_table(void)
   g_assert_nonnull(doc);
   g_assert_cmpstr(doc, ==, "doc");
   g_assert_cmpstr(function_get_name(fn), ==, "FOO");
-  g_assert_cmpstr(function_get_package(fn), ==, "COMMON-LISP-USER");
+  g_assert_cmpstr(function_get_package(fn), ==, "CL-USER");
   project_unref(project);
 }
 

--- a/tests/swank_session_test.c
+++ b/tests/swank_session_test.c
@@ -78,7 +78,7 @@ static void test_eval(void)
   interaction_clear(&interaction);
   g_assert_cmpint(interaction.tag, ==, 1);
   g_assert_cmpstr(mock_swank_process->last->str, ==,
-      "(:emacs-rex (swank:eval-and-grab-output \"(+ 1 2)\") \"COMMON-LISP-USER\" t 1)");
+      "(:emacs-rex (let ((*debugger-hook* nil)) (swank-repl:listener-eval \"(+ 1 2)\\n\")) :cl-user t 1)");
   g_assert_cmpint(mock_swank_process->start_count, ==, 1);
   swank_session_unref(sess);
   status_service_free(status_service);


### PR DESCRIPTION
## Summary
- eval forms with `swank-repl:listener-eval` while clearing `*debugger-hook*`
- default to the `CL-USER` package for analysis
- add regression note for debugger activation

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68aee058f4808328bfcb7ef05781d7de