### PR TITLE
Let debugger hook inside evaluated form

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -74,3 +74,10 @@ Disabling swank's global debugger was not enough to prevent the debugger from
 grabbing control. The swank process now let-binds `*debugger-hook*` to `nil`
 when evaluating forms and sends them in the `CL-USER` package, so evaluations
 no longer drop into the debugger unexpectedly.
+
+## Debugger hook bound outside evaluated form
+
+`*debugger-hook*` was `let`-bound around `swank:eval-and-grab-output`, leaving
+the evaluated form itself unprotected. Errors inside the form still invoked the
+debugger. The binding is now wrapped around the expression passed to swank so
+evaluations run with the debugger hook disabled.

--- a/src/real_swank_session.c
+++ b/src/real_swank_session.c
@@ -83,7 +83,7 @@ static gpointer real_swank_session_thread(gpointer data) {
       added_cb((SwankSession*)self, interaction, added_cb_data);
     gchar *escaped = escape_string(interaction->expression);
     gchar *rpc = g_strdup_printf(
-        "(:emacs-rex (let ((*debugger-hook* nil)) (swank:eval-and-grab-output \"%s\\n\")) :cl-user t %u)",
+        "(:emacs-rex (swank:eval-and-grab-output \"(let ((*debugger-hook* nil)) %s)\\n\") :cl-user t %u)",
         escaped, interaction->tag);
     GString *payload = g_string_new(rpc);
     g_free(escaped);

--- a/tests/swank_session_test.c
+++ b/tests/swank_session_test.c
@@ -78,7 +78,7 @@ static void test_eval(void)
   interaction_clear(&interaction);
   g_assert_cmpint(interaction.tag, ==, 1);
   g_assert_cmpstr(mock_swank_process->last->str, ==,
-      "(:emacs-rex (let ((*debugger-hook* nil)) (swank-repl:listener-eval \"(+ 1 2)\\n\")) :cl-user t 1)");
+      "(:emacs-rex (swank:eval-and-grab-output \"(let ((*debugger-hook* nil)) (+ 1 2))\\n\") :cl-user t 1)");
   g_assert_cmpint(mock_swank_process->start_count, ==, 1);
   swank_session_unref(sess);
   status_service_free(status_service);


### PR DESCRIPTION
## Summary
- move *debugger-hook* binding inside form sent to swank
- update session test for new eval message
- document debugger hook scope fix

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68aeeda6d6308328a4df9b905ae52ae0