### PR TITLE
Add REPL server with encapsulated output handling

### DIFF
--- a/src/glide.asd
+++ b/src/glide.asd
@@ -1,5 +1,9 @@
 (defsystem "glide"
   :description "List symbols of a given package"
+  :depends-on (#:trivial-gray-streams)
   :serial t
-  :components ((:file "glide-package") (:file "symbol-info") (:file "package-info") (:file "t"))
-)
+  :components ((:file "glide-package")
+               (:file "symbol-info")
+               (:file "package-info")
+               (:file "server")
+               (:file "t")))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -1,0 +1,36 @@
+(in-package :glide)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (require :trivial-gray-streams))
+
+(defvar *standard-error* *error-output*)
+(defvar *real-standard-output* *standard-output*)
+
+(defclass repl-stream (trivial-gray-streams:fundamental-character-output-stream)
+  ((label :initarg :label)))
+
+(defmethod trivial-gray-streams:stream-write-string ((s repl-stream) string start end)
+  (declare (ignore start end))
+  (format *real-standard-output* "(~a ~S)~%" (slot-value s 'label) string))
+
+(defmethod trivial-gray-streams:stream-write-char ((s repl-stream) char)
+  (format *real-standard-output* "(~a ~S)~%" (slot-value s 'label) (string char)))
+
+(defun eval (form)
+  (setf *real-standard-output* *standard-output*)
+  (handler-case
+      (let* ((out (make-instance 'repl-stream :label "stdout"))
+             (err (make-instance 'repl-stream :label "stderr"))
+             (*standard-output* out)
+             (*standard-error* err)
+             (*error-output* err))
+        (let ((res (cl:eval form)))
+          (format *real-standard-output* "(result ~S)~%" res)))
+    (error (e)
+      (format *real-standard-output* "(error ~S)~%" (princ-to-string e)))))
+
+(defun start-server ()
+  (loop for form = (read *standard-input* nil :eof)
+        until (eq form :eof)
+        do (eval form)))
+


### PR DESCRIPTION
## Summary
- add REPL server and evaluation wrapper that routes stdout, stderr, results, and errors through formatted messages
- register new server component in ASDF system with trivial-gray-streams dependency

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68af0778d69c83289d75e9fe71cba4a1