### PR TITLE
Use SBCL gray streams

### DIFF
--- a/src/glide.asd
+++ b/src/glide.asd
@@ -1,6 +1,5 @@
 (defsystem "glide"
   :description "List symbols of a given package"
-  :depends-on (#:trivial-gray-streams)
   :serial t
   :components ((:file "glide-package")
                (:file "symbol-info")

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -1,19 +1,19 @@
 (in-package :glide)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (require :trivial-gray-streams))
+  (require :sb-gray))
 
 (defvar *standard-error* *error-output*)
 (defvar *real-standard-output* *standard-output*)
 
-(defclass repl-stream (trivial-gray-streams:fundamental-character-output-stream)
+(defclass repl-stream (sb-gray:fundamental-character-output-stream)
   ((label :initarg :label)))
 
-(defmethod trivial-gray-streams:stream-write-string ((s repl-stream) string start end)
+(defmethod sb-gray:stream-write-string ((s repl-stream) string start end)
   (declare (ignore start end))
   (format *real-standard-output* "(~a ~S)~%" (slot-value s 'label) string))
 
-(defmethod trivial-gray-streams:stream-write-char ((s repl-stream) char)
+(defmethod sb-gray:stream-write-char ((s repl-stream) char)
   (format *real-standard-output* "(~a ~S)~%" (slot-value s 'label) (string char)))
 
 (defun eval (form)


### PR DESCRIPTION
## Summary
- Remove dependency on trivial-gray-streams in `glide.asd`
- Switch server stream implementation to SBCL's built-in `sb-gray`

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68af0c58d2fc832889ba2bb181751b72