### PR TITLE
Start SBCL without leaking prompts

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -95,3 +95,13 @@ Evaluations occasionally displayed only the entered expression with no result.
 backend could return a result before the row was created. The "updated"
 handler now ensures the row exists and updates it, so results are always shown.
 Debug logging was added to `RealGlideSession` to help trace message handling.
+
+## Evaluation result hidden by startup prompt
+
+Selecting an expression sometimes displayed only the form with no result.
+SBCL prints a `*` prompt and its `NIL` result while loading Glide. Those
+startup lines arrived just before the first evaluation and confused the
+session, so the interaction row missed the real result. `RealGlideProcess`
+now waits for SBCL's initial prompt, ignores the `NIL` and second prompt from
+`(require :glide)`, and only then starts the server, so sessions receive the
+actual evaluation results.

--- a/src/real_glide_process.c
+++ b/src/real_glide_process.c
@@ -3,6 +3,14 @@
 
 #include <string.h>
 
+enum {
+  START_STATE_IDLE = 0,
+  START_STATE_WAIT_PROMPT,
+  START_STATE_WAIT_NIL,
+  START_STATE_WAIT_PROMPT2,
+  START_STATE_DONE,
+};
+
 static void gp_start(GlideProcess *base);
 static void gp_send(GlideProcess *base, const GString *payload);
 static void gp_set_message_cb(GlideProcess *base, GlideProcessMessageCallback cb,
@@ -28,6 +36,19 @@ static void on_proc_out(GString *data, gpointer user_data) {
     gsize len = newline - self->buffer->str;
     GString *line = g_string_new_len(self->buffer->str, len);
     g_string_erase(self->buffer, 0, len + 1);
+    if (self->start_state != START_STATE_DONE) {
+      if (self->start_state == START_STATE_WAIT_PROMPT && strcmp(line->str, "*") == 0) {
+        self->start_state = START_STATE_WAIT_NIL;
+        g_cond_broadcast(&self->cond);
+      } else if (self->start_state == START_STATE_WAIT_NIL && strcmp(line->str, "NIL") == 0) {
+        self->start_state = START_STATE_WAIT_PROMPT2;
+      } else if (self->start_state == START_STATE_WAIT_PROMPT2 && strcmp(line->str, "*") == 0) {
+        self->start_state = START_STATE_DONE;
+        g_cond_broadcast(&self->cond);
+      }
+      g_string_free(line, TRUE);
+      continue;
+    }
     GlideProcessMessageCallback cb = self->msg_cb;
     gpointer cb_data = self->msg_cb_data;
     g_mutex_unlock(&self->mutex);
@@ -48,10 +69,25 @@ static void gp_start(GlideProcess *base) {
   RealGlideProcess *self = (RealGlideProcess*)base;
   if (self->started || !self->proc)
     return;
+  g_mutex_lock(&self->mutex);
+  self->start_state = START_STATE_WAIT_PROMPT;
+  g_mutex_unlock(&self->mutex);
   process_start(self->proc);
-  const char *init = "(require :glide)\n(glide:start-server)\n";
-  process_write(self->proc, init, -1);
+  g_mutex_lock(&self->mutex);
+  while (self->start_state == START_STATE_WAIT_PROMPT)
+    g_cond_wait(&self->cond, &self->mutex);
+  g_mutex_unlock(&self->mutex);
+  const char *req = "(require :glide)\n";
+  process_write(self->proc, req, -1);
+  g_mutex_lock(&self->mutex);
+  while (self->start_state != START_STATE_DONE)
+    g_cond_wait(&self->cond, &self->mutex);
+  g_mutex_unlock(&self->mutex);
+  const char *start = "(glide:start-server)\n";
+  process_write(self->proc, start, -1);
+  g_mutex_lock(&self->mutex);
   self->started = TRUE;
+  g_mutex_unlock(&self->mutex);
 }
 
 static void gp_send(GlideProcess *base, const GString *payload) {
@@ -73,6 +109,7 @@ static void gp_destroy(GlideProcess *base) {
     process_unref(self->proc);
   g_string_free(self->buffer, TRUE);
   g_mutex_clear(&self->mutex);
+  g_cond_clear(&self->cond);
   g_free(self);
 }
 
@@ -84,9 +121,11 @@ GlideProcess *real_glide_process_new(Process *proc) {
   self->proc = proc ? process_ref(proc) : NULL;
   self->buffer = g_string_new(NULL);
   g_mutex_init(&self->mutex);
+  g_cond_init(&self->cond);
   self->msg_cb = NULL;
   self->msg_cb_data = NULL;
   self->started = FALSE;
+  self->start_state = START_STATE_IDLE;
   if (proc) {
     process_set_stdout_cb(proc, on_proc_out, self);
     process_set_stderr_cb(proc, on_proc_err, self);

--- a/src/real_glide_process.h
+++ b/src/real_glide_process.h
@@ -7,9 +7,11 @@ typedef struct {
   Process *proc;
   GString *buffer;
   GMutex mutex;
+  GCond cond;
   GlideProcessMessageCallback msg_cb;
   gpointer msg_cb_data;
   gboolean started;
+  int start_state;
 } RealGlideProcess;
 
 GlideProcess *real_glide_process_new(Process *proc);

--- a/src/real_glide_session.c
+++ b/src/real_glide_session.c
@@ -1,5 +1,6 @@
 #include "real_glide_session.h"
 #include "util.h"
+#include <string.h>
 
 static gpointer real_glide_session_thread(gpointer data);
 static void real_glide_session_eval(GlideSession *session, Interaction *interaction);

--- a/tests/glide_process_test.c
+++ b/tests/glide_process_test.c
@@ -8,14 +8,47 @@
 typedef struct {
   Process base;
   int fd;
+  ProcessCallback out_cb;
+  gpointer out_data;
 } MockProcess;
 
-static void mp_set_out(Process *p, ProcessCallback cb, gpointer data) { (void)p; (void)cb; (void)data; }
+static void mp_set_out(Process *p, ProcessCallback cb, gpointer data) {
+  MockProcess *mp = (MockProcess*)p;
+  mp->out_cb = cb;
+  mp->out_data = data;
+}
 static void mp_set_err(Process *p, ProcessCallback cb, gpointer data) { (void)p; (void)cb; (void)data; }
+static void mp_start(Process *p) {
+  MockProcess *mp = (MockProcess*)p;
+  if (mp->out_cb) {
+    GString *line = g_string_new("banner\n");
+    mp->out_cb(line, mp->out_data);
+    g_string_free(line, TRUE);
+    line = g_string_new("*\n");
+    mp->out_cb(line, mp->out_data);
+    g_string_free(line, TRUE);
+  }
+}
 static gboolean mp_write(Process *p, const gchar *d, gssize len) {
   MockProcess *mp = (MockProcess*)p;
   if (len < 0) len = strlen(d);
-  return write(mp->fd, d, len) == len;
+  if (mp->fd >= 0)
+    write(mp->fd, d, len);
+  if (mp->out_cb) {
+    if (strstr(d, "(require :glide)")) {
+      GString *line = g_string_new("NIL\n");
+      mp->out_cb(line, mp->out_data);
+      g_string_free(line, TRUE);
+      line = g_string_new("*\n");
+      mp->out_cb(line, mp->out_data);
+      g_string_free(line, TRUE);
+    } else if (strstr(d, "(glide:start-server)")) {
+      GString *line = g_string_new("READY\n");
+      mp->out_cb(line, mp->out_data);
+      g_string_free(line, TRUE);
+    }
+  }
+  return TRUE;
 }
 static void mp_destroy(Process *p) {
   MockProcess *mp = (MockProcess*)p;
@@ -24,7 +57,7 @@ static void mp_destroy(Process *p) {
 }
 
 static const ProcessOps mock_process_ops = {
-  .start = NULL,
+  .start = mp_start,
   .set_stdout_cb = mp_set_out,
   .set_stderr_cb = mp_set_err,
   .write = mp_write,
@@ -36,6 +69,8 @@ static MockProcess *mock_process_new(void) {
   mp->base.ops = &mock_process_ops;
   mp->base.refcnt = 1;
   mp->fd = -1;
+  mp->out_cb = NULL;
+  mp->out_data = NULL;
   return mp;
 }
 
@@ -62,8 +97,27 @@ static void test_send(void) {
   close(fds[1]);
 }
 
+static void on_start_msg(GString *msg, gpointer user_data) {
+  GPtrArray *msgs = user_data;
+  g_ptr_array_add(msgs, g_strdup(msg->str));
+}
+
+static void test_start_consumes_prompts(void) {
+  MockProcess *mp = mock_process_new();
+  GlideProcess *sp = real_glide_process_new((Process*)mp);
+  GPtrArray *msgs = g_ptr_array_new_with_free_func(g_free);
+  glide_process_set_message_cb(sp, on_start_msg, msgs);
+  glide_process_start(sp);
+  g_assert_cmpint(msgs->len, ==, 1);
+  g_assert_cmpstr(g_ptr_array_index(msgs, 0), ==, "READY");
+  g_ptr_array_free(msgs, TRUE);
+  glide_process_unref(sp);
+  process_unref((Process*)mp);
+}
+
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/glide/send", test_send);
+  g_test_add_func("/glide/start_prompts", test_start_consumes_prompts);
   return g_test_run();
 }

--- a/tests/glide_session_test.c
+++ b/tests/glide_session_test.c
@@ -187,6 +187,7 @@ static void test_interaction_done_callback(void)
   glide_process_unref((GlideProcess*)proc);
 }
 
+
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);


### PR DESCRIPTION
## Summary
- wait for SBCL's initial prompt and `(require :glide)` result before starting the server
- drop prompt-stripping logic from `RealGlideSession`
- test that startup prompts never reach the session

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68af7533df508328a518d9e3e0f2772b