### PR TITLE
Fix window size restoration

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -121,3 +121,12 @@ checked complete lines during startup. The state machine therefore stalled on
 "* " waiting for a newline that never arrived, leaving the server unstarted.
 Startup handling now inspects the partial buffer for prompts and clears it once
 consumed, so Glide no longer requires newline‑terminated prompts.
+
+## Window height increased on each launch
+
+The application grew taller by around 100 pixels every time it started. The
+saved window size included the window manager decorations, but the restored
+size interpreted the value as the client area, so the extra decoration height
+was added on each run. The size allocation handler now records the interior
+window size via `gtk_window_get_size`, so the saved height matches the restored
+height.

--- a/src/app.c
+++ b/src/app.c
@@ -16,7 +16,7 @@ STATIC void     on_notebook_paned_position(GObject *object, GParamSpec *pspec, g
 STATIC void     app_update_recent_menu(App *self);
 STATIC void     on_asdf_view_selection_changed(GtkTreeSelection *selection, gpointer data);
 STATIC void     on_notebook_switch_page(GtkNotebook *notebook, GtkWidget *page, guint page_num, gpointer data);
-STATIC void     on_window_size_allocate(GtkWidget * /*widget*/, GtkAllocation *allocation, gpointer data);
+STATIC void     on_window_size_allocate(GtkWidget *widget, GtkAllocation * /*allocation*/, gpointer data);
 
 /* === Instance structure ================================================= */
 struct _App
@@ -37,11 +37,14 @@ struct _App
 };
 
 STATIC void
-on_window_size_allocate(GtkWidget * /*widget*/, GtkAllocation *allocation, gpointer data)
+on_window_size_allocate(GtkWidget *widget, GtkAllocation * /*allocation*/, gpointer data)
 {
   App *self = (App *) data;
-  preferences_set_window_width(self->preferences, allocation->width);
-  preferences_set_window_height(self->preferences, allocation->height);
+  gint width;
+  gint height;
+  gtk_window_get_size(GTK_WINDOW(widget), &width, &height);
+  preferences_set_window_width(self->preferences, width);
+  preferences_set_window_height(self->preferences, height);
 }
 
 


### PR DESCRIPTION
## Summary
- save the interior window size instead of the decorated size so the window height restores correctly
- document the window height inflation bug and its resolution

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68b02ffa6890832896685666f7ec1b96