### PR TITLE
Remove debugger hook binding

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -137,3 +137,9 @@ Long evaluation sessions pushed earlier interactions off screen because
 `InteractionsView` was a plain `GtkBox` without scrollbars. The widget now
 embeds its rows in a `GtkScrolledWindow`, so previous interactions remain
 accessible.
+
+## Debugger hook disabled debugging
+
+Evaluations wrapped with `(let ((*debugger-hook* nil)) ...)` prevented the
+debugger from handling errors. Removing the binding restores normal debugger
+behavior during evaluations.

--- a/src/glide_session.c
+++ b/src/glide_session.c
@@ -86,7 +86,7 @@ static gpointer glide_session_thread(gpointer data) {
     if (added_cb)
       added_cb(self, interaction, added_cb_data);
     gchar *escaped = escape_string(interaction->expression);
-    gchar *cmd = g_strdup_printf("(glide:glide-eval \"(let ((*debugger-hook* nil)) %s)\\n\")\n", escaped);
+    gchar *cmd = g_strdup_printf("(glide:glide-eval \"%s\\n\")\n", escaped);
     GString *payload = g_string_new(cmd);
     g_free(escaped);
     g_free(cmd);


### PR DESCRIPTION
## Summary
- stop wrapping evaluated forms with a `(let ((*debugger-hook* nil)) ...)` binding so errors can reach the debugger
- document the removal in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b04da8f74c8328a3e13cf5d722b204