### PR TITLE
Encapsulate Process struct

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -7,6 +7,22 @@
 #include <signal.h>
 #include <sys/prctl.h>
 
+struct _Process {
+  GPid pid;
+  int refcnt;
+  int in_fd;
+  int out_fd;
+  int err_fd;
+  GThread *out_thread;
+  GThread *err_thread;
+  ProcessCallback out_cb;
+  gpointer out_user;
+  ProcessCallback err_cb;
+  gpointer err_user;
+  gchar **argv;
+  gboolean started;
+};
+
 static gpointer stdout_thread(gpointer data) {
   Process *process = data;
   char buf[256];

--- a/src/process.h
+++ b/src/process.h
@@ -1,27 +1,10 @@
 #pragma once
 
 #include <glib.h>
-#include <gio/gio.h>
 
 typedef struct _Process Process;
 
 typedef void (*ProcessCallback)(GString *data, gpointer user_data);
-
-struct _Process {
-  GPid pid;
-  int refcnt;
-  int in_fd;
-  int out_fd;
-  int err_fd;
-  GThread *out_thread;
-  GThread *err_thread;
-  ProcessCallback out_cb;
-  gpointer out_user;
-  ProcessCallback err_cb;
-  gpointer err_user;
-  gchar **argv;
-  gboolean started;
-};
 
 Process *process_new(const gchar *cmd);
 Process *process_new_from_argv(const gchar *const *argv);


### PR DESCRIPTION
## Summary
- hide `Process` internals by moving its struct definition into `process.c`
- trim public header to a forward declaration and callback typedef

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b0611a822c832894f94bb627b7d5ea