### PR TITLE
encapsulate GlideProcess and GlideSession structs

### DIFF
--- a/src/glide_process.c
+++ b/src/glide_process.c
@@ -3,6 +3,18 @@
 
 #include <string.h>
 
+struct _GlideProcess {
+  int refcnt;
+  Process *proc;
+  GString *buffer;
+  GMutex mutex;
+  GCond cond;
+  GlideProcessMessageCallback msg_cb;
+  gpointer msg_cb_data;
+  gboolean started;
+  int start_state;
+};
+
 enum {
   START_STATE_IDLE = 0,
   START_STATE_WAIT_PROMPT,

--- a/src/glide_process.h
+++ b/src/glide_process.h
@@ -6,18 +6,6 @@
 typedef struct _GlideProcess GlideProcess;
 typedef void (*GlideProcessMessageCallback)(GString *msg, gpointer user_data);
 
-struct _GlideProcess {
-  int refcnt;
-  Process *proc;
-  GString *buffer;
-  GMutex mutex;
-  GCond cond;
-  GlideProcessMessageCallback msg_cb;
-  gpointer msg_cb_data;
-  gboolean started;
-  int start_state;
-};
-
 GlideProcess *glide_process_new(Process *proc);
 void          glide_process_start(GlideProcess *self);
 void          glide_process_send(GlideProcess *self, const GString *payload);

--- a/src/glide_session.c
+++ b/src/glide_session.c
@@ -3,6 +3,22 @@
 
 #include <string.h>
 
+struct _GlideSession {
+  int refcnt;
+  GlideProcess *proc;
+  StatusService *status_service;
+  gboolean started;
+  GAsyncQueue *queue;
+  GThread *thread;
+  GMutex lock;
+  GCond cond;
+  Interaction *current;
+  GlideSessionCallback added_cb;
+  gpointer added_cb_data;
+  GlideSessionCallback updated_cb;
+  gpointer updated_cb_data;
+};
+
 static gpointer glide_session_thread(gpointer data);
 static gchar *escape_string(const char *str) {
   GString *out = g_string_new(NULL);

--- a/src/glide_session.h
+++ b/src/glide_session.h
@@ -9,22 +9,6 @@
 typedef struct _GlideSession GlideSession;
 typedef void (*GlideSessionCallback)(GlideSession *self, Interaction *interaction, gpointer user_data);
 
-struct _GlideSession {
-  int refcnt;
-  GlideProcess *proc;
-  StatusService *status_service;
-  gboolean started;
-  GAsyncQueue *queue;
-  GThread *thread;
-  GMutex lock;
-  GCond cond;
-  Interaction *current;
-  GlideSessionCallback added_cb;
-  gpointer added_cb_data;
-  GlideSessionCallback updated_cb;
-  gpointer updated_cb_data;
-};
-
 GlideSession *glide_session_new(GlideProcess *proc, StatusService *status_service);
 void          glide_session_eval(GlideSession *self, Interaction *interaction);
 void          glide_session_set_interaction_added_cb(GlideSession *self, GlideSessionCallback cb, gpointer user_data);


### PR DESCRIPTION
## Summary
- hide GlideProcess internals by moving its struct definition into glide_process.c
- move GlideSession struct into glide_session.c so only the public API stays in the header

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b0681aee488328b4d2f1defe7243d5