### PR TITLE
Start SBCL with Glide server and simplify process setup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -62,11 +62,17 @@ main (int argc, char *argv[])
 
   Preferences *prefs = preferences_new (g_get_user_config_dir ());
 
-  const gchar *sdk_path = preferences_get_sdk (prefs);
-  Process *proc = process_new (sdk_path);
-  ReplProcess *repl_proc = repl_process_new (proc);
+  const gchar *sdk_path = preferences_get_sdk(prefs);
+  const gchar *proc_argv[] = {
+    sdk_path, "--noinform",
+    "--eval", "(require :glide)",
+    "--eval", "(glide:start-server)",
+    NULL
+  };
+  Process *proc = process_new_from_argv(proc_argv);
+  ReplProcess *repl_proc = repl_process_new(proc);
   StatusService *status_service = status_service_new();
-  ReplSession *repl = repl_session_new (repl_proc, status_service);
+  ReplSession *repl = repl_session_new(repl_proc, status_service);
   Project *project = project_new();
   App *app     = app_new (prefs, repl, project, status_service);
 

--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -8,39 +8,10 @@ struct _ReplProcess {
   Process *proc;
   GString *buffer;
   GMutex mutex;
-  GCond cond;
   ReplProcessMessageCallback msg_cb;
   gpointer msg_cb_data;
   gboolean started;
-  int start_state;
 };
-
-enum {
-  START_STATE_IDLE = 0,
-  START_STATE_WAIT_PROMPT,
-  START_STATE_WAIT_NIL,
-  START_STATE_WAIT_PROMPT2,
-  START_STATE_DONE,
-};
-
-static gboolean consume_startup_line(ReplProcess *self, const gchar *line) {
-  gchar *trimmed = g_strstrip(g_strdup(line));
-  gboolean consumed = FALSE;
-  if (self->start_state == START_STATE_WAIT_PROMPT && strcmp(trimmed, "*") == 0) {
-    self->start_state = START_STATE_WAIT_NIL;
-    g_cond_broadcast(&self->cond);
-    consumed = TRUE;
-  } else if (self->start_state == START_STATE_WAIT_NIL && strcmp(trimmed, "NIL") == 0) {
-    self->start_state = START_STATE_WAIT_PROMPT2;
-    consumed = TRUE;
-  } else if (self->start_state == START_STATE_WAIT_PROMPT2 && strcmp(trimmed, "*") == 0) {
-    self->start_state = START_STATE_DONE;
-    g_cond_broadcast(&self->cond);
-    consumed = TRUE;
-  }
-  g_free(trimmed);
-  return consumed;
-}
 
 static void on_proc_out(GString *data, gpointer user_data) {
   ReplProcess *self = user_data;
@@ -53,11 +24,6 @@ static void on_proc_out(GString *data, gpointer user_data) {
     gsize len = newline - self->buffer->str;
     GString *line = g_string_new_len(self->buffer->str, len);
     g_string_erase(self->buffer, 0, len + 1);
-    if (self->start_state != START_STATE_DONE) {
-      consume_startup_line(self, line->str);
-      g_string_free(line, TRUE);
-      continue;
-    }
     ReplProcessMessageCallback cb = self->msg_cb;
     gpointer cb_data = self->msg_cb_data;
     g_mutex_unlock(&self->mutex);
@@ -65,10 +31,6 @@ static void on_proc_out(GString *data, gpointer user_data) {
       cb(line, cb_data);
     g_string_free(line, TRUE);
     g_mutex_lock(&self->mutex);
-  }
-  if (self->start_state != START_STATE_DONE && self->buffer->len > 0 &&
-      consume_startup_line(self, self->buffer->str)) {
-    g_string_truncate(self->buffer, 0);
   }
   g_mutex_unlock(&self->mutex);
 }
@@ -88,7 +50,6 @@ static void repl_process_destroy(ReplProcess *self) {
     process_unref(self->proc);
   g_string_free(self->buffer, TRUE);
   g_mutex_clear(&self->mutex);
-  g_cond_clear(&self->cond);
   g_free(self);
 }
 
@@ -105,11 +66,9 @@ ReplProcess *repl_process_new(Process *proc) {
   self->proc = proc ? process_ref(proc) : NULL;
   self->buffer = g_string_new(NULL);
   g_mutex_init(&self->mutex);
-  g_cond_init(&self->cond);
   self->msg_cb = NULL;
   self->msg_cb_data = NULL;
   self->started = FALSE;
-  self->start_state = START_STATE_IDLE;
   if (proc) {
     process_set_stdout_cb(proc, on_proc_out, self);
     process_set_stderr_cb(proc, on_proc_err, self);
@@ -121,20 +80,7 @@ void repl_process_start(ReplProcess *self) {
   g_return_if_fail(self);
   if (self->started || !self->proc)
     return;
-  g_mutex_lock(&self->mutex);
-  self->start_state = START_STATE_WAIT_PROMPT;
-  g_mutex_unlock(&self->mutex);
   process_start(self->proc);
-  g_mutex_lock(&self->mutex);
-  while (self->start_state == START_STATE_WAIT_PROMPT)
-    g_cond_wait(&self->cond, &self->mutex);
-  g_mutex_unlock(&self->mutex);
-  process_write(self->proc, "(require :glide)\n", -1);
-  g_mutex_lock(&self->mutex);
-  while (self->start_state != START_STATE_DONE)
-    g_cond_wait(&self->cond, &self->mutex);
-  g_mutex_unlock(&self->mutex);
-  process_write(self->proc, "(glide:start-server)\n", -1);
   g_mutex_lock(&self->mutex);
   self->started = TRUE;
   g_mutex_unlock(&self->mutex);

--- a/tests/repl_session_test.c
+++ b/tests/repl_session_test.c
@@ -10,6 +10,8 @@ static void test_eval(void) {
     "sbcl", "--noinform",
     "--eval", "(require :asdf)",
     "--eval", "(pushnew (truename \"../src/\") asdf:*central-registry*)",
+    "--eval", "(require :glide)",
+    "--eval", "(glide:start-server)",
     NULL
   };
   Process *proc = process_new_from_argv(argv);


### PR DESCRIPTION
## Summary
- Launch SBCL with Glide preloaded and server started
- Remove REPL startup handshake code from ReplProcess
- Adjust tests and main initialization for new SBCL arguments

## Testing
- `sbcl --noinform --eval '(require :glide)' --eval '(glide:start-server)'` (fails: Don't know how to REQUIRE GLIDE.)
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b06dc0ce288328906bb14a12c2cbc5