### PR TITLE
Buffer REPL output until messages complete

### DIFF
--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -17,13 +17,62 @@ static void on_proc_out(GString *data, gpointer user_data) {
   ReplProcess *self = user_data;
   g_mutex_lock(&self->mutex);
   g_string_append_len(self->buffer, data->str, data->len);
-  while (TRUE) {
-    char *newline = memchr(self->buffer->str, '\n', self->buffer->len);
-    if (!newline)
+  while (self->buffer->len > 0) {
+    if (self->buffer->str[0] == '\n') {
+      g_string_erase(self->buffer, 0, 1);
+      continue;
+    }
+    if (self->buffer->str[0] == ';') {
+      char *newline = memchr(self->buffer->str, '\n', self->buffer->len);
+      if (!newline)
+        break;
+      gsize len = newline - self->buffer->str;
+      GString *line = g_string_new_len(self->buffer->str, len);
+      g_string_erase(self->buffer, 0, len + 1);
+      ReplProcessMessageCallback cb = self->msg_cb;
+      gpointer cb_data = self->msg_cb_data;
+      g_mutex_unlock(&self->mutex);
+      if (cb)
+        cb(line, cb_data);
+      g_string_free(line, TRUE);
+      g_mutex_lock(&self->mutex);
+      continue;
+    }
+    gsize i;
+    int level = 0;
+    gboolean in_string = FALSE;
+    gboolean escape = FALSE;
+    gboolean complete = FALSE;
+    for (i = 0; i < self->buffer->len; i++) {
+      char c = self->buffer->str[i];
+      if (in_string) {
+        if (escape)
+          escape = FALSE;
+        else if (c == '\\')
+          escape = TRUE;
+        else if (c == '"')
+          in_string = FALSE;
+      } else {
+        if (c == '"')
+          in_string = TRUE;
+        else if (c == '(')
+          level++;
+        else if (c == ')') {
+          if (level > 0)
+            level--;
+          if (level == 0) {
+            complete = TRUE;
+            break;
+          }
+        }
+      }
+    }
+    if (!complete)
       break;
-    gsize len = newline - self->buffer->str;
-    GString *line = g_string_new_len(self->buffer->str, len);
-    g_string_erase(self->buffer, 0, len + 1);
+    GString *line = g_string_new_len(self->buffer->str, i + 1);
+    g_string_erase(self->buffer, 0, i + 1);
+    if (self->buffer->len > 0 && self->buffer->str[0] == '\n')
+      g_string_erase(self->buffer, 0, 1);
     ReplProcessMessageCallback cb = self->msg_cb;
     gpointer cb_data = self->msg_cb_data;
     g_mutex_unlock(&self->mutex);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0`
-TESTS = preferences_test process_test repl_session_test lisp_parser_test project_test asdf_test analyser_test package_test package_common_lisp_test status_service_test
+TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test project_test asdf_test analyser_test package_test package_common_lisp_test status_service_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -16,6 +16,9 @@ preferences_test: preferences_test.c preferences.c
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 process_test: process_test.c process.c
+:$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
+repl_process_test: repl_process_test.c process.c
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
@@ -45,6 +48,7 @@ status_service_test: status_service_test.c status_service.c
 run: all
 :./preferences_test
 :./process_test
+:./repl_process_test
 :./repl_session_test
 :./lisp_parser_test
 :./project_test

--- a/tests/repl_process_test.c
+++ b/tests/repl_process_test.c
@@ -1,0 +1,42 @@
+#include <glib.h>
+
+#include "../src/repl_process.c"
+
+static GPtrArray *messages;
+
+static void on_msg(GString *msg, gpointer /*user*/) {
+  g_ptr_array_add(messages, g_string_new_len(msg->str, msg->len));
+}
+
+static void test_messages(void) {
+  ReplProcess *rp = repl_process_new(NULL);
+  messages = g_ptr_array_new_with_free_func((GDestroyNotify)g_string_free);
+  repl_process_set_message_cb(rp, on_msg, NULL);
+
+  GString *chunk = g_string_new("(:first");
+  on_proc_out(chunk, rp);
+  g_string_free(chunk, TRUE);
+  g_assert_cmpuint(messages->len, ==, 0);
+
+  chunk = g_string_new(")\n(:second \"a\\\" )b\")");
+  on_proc_out(chunk, rp);
+  g_string_free(chunk, TRUE);
+  g_assert_cmpuint(messages->len, ==, 2);
+  g_assert_cmpstr(((GString*)messages->pdata[0])->str, ==, "(:first)");
+  g_assert_cmpstr(((GString*)messages->pdata[1])->str, ==, "(:second \"a\\\" )b\")");
+
+  chunk = g_string_new("\n(:third\n:fourth)");
+  on_proc_out(chunk, rp);
+  g_string_free(chunk, TRUE);
+  g_assert_cmpuint(messages->len, ==, 3);
+  g_assert_cmpstr(((GString*)messages->pdata[2])->str, ==, "(:third\n:fourth)");
+
+  repl_process_unref(rp);
+  g_ptr_array_unref(messages);
+}
+
+int main(int argc, char *argv[]) {
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/repl_process/messages", test_messages);
+  return g_test_run();
+}


### PR DESCRIPTION
## Summary
- ensure `ReplProcess` waits for matching parentheses before invoking callbacks
- forward semicolon comment lines separately and skip blank separators
- add unit test covering multi-line and escaped output parsing

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b0a43d14e88328bee6b18e875eef5f