### PR TITLE
Fix interactions view scrolling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -143,3 +143,9 @@ accessible.
 Evaluations wrapped with `(let ((*debugger-hook* nil)) ...)` prevented the
 debugger from handling errors. Removing the binding restores normal debugger
 behavior during evaluations.
+
+## Interactions view truncated without scrollbars
+
+The interactions list was added directly to the `GtkScrolledWindow` without a
+`GtkViewport`, so the scrollbars never appeared when the view was shorter than
+its contents. Wrapping the box in a viewport allows the window to scroll.

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -175,9 +175,11 @@ interactions_view_init(InteractionsView *self)
   g_debug("InteractionsView.init");
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self),
       GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+  GtkWidget *viewport = gtk_viewport_new(NULL, NULL);
   self->box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_hexpand(self->box, TRUE);
-  gtk_container_add(GTK_CONTAINER(self), self->box);
+  gtk_container_add(GTK_CONTAINER(viewport), self->box);
+  gtk_container_add(GTK_CONTAINER(self), viewport);
 
   // Load CSS
   GtkCssProvider *provider = gtk_css_provider_new();


### PR DESCRIPTION
## Summary
- wrap interaction list in a GtkViewport so scrollbars appear when contents exceed the view
- document scrolling bug in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b157b44d308328a2447591982791c6