### PR TITLE
Use GAction for menus and shortcuts

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -6,14 +6,7 @@
 G_BEGIN_DECLS
 
 gboolean on_quit_delete_event(GtkWidget * /*widget*/, GdkEvent * /*event*/, gpointer data);
-void on_quit_menu(GtkWidget * /*item*/, gpointer data);
-void on_close_project(GtkWidget * /*item*/, gpointer data);
-void on_save_all(GtkWidget * /*item*/, gpointer data);
-void on_extend_selection(GtkWidget * /*item*/, gpointer data);
-void on_shrink_selection(GtkWidget * /*item*/, gpointer data);
-void on_recent_project(GtkWidget *item, gpointer data);
-void on_show_parser(App *self);
-gboolean on_key_press(GtkWidget * /*widget*/, GdkEventKey *event, gpointer user_data);
+void actions_init(App *self);
 gboolean app_close_project(App *self, gboolean forget_project);
 
 G_END_DECLS

--- a/src/app.h
+++ b/src/app.h
@@ -31,7 +31,7 @@ STATIC ReplSession *app_get_glide(App *self);
 STATIC void app_on_quit(App *self);
 STATIC void app_quit(App *self);
 STATIC StatusService *app_get_status_service(App *self);
-void app_set_recent_menu(App *self, GtkWidget *menu);
+void app_set_recent_menu(App *self, GMenu *menu);
 
 G_END_DECLS
 

--- a/src/menu_bar.c
+++ b/src/menu_bar.c
@@ -1,99 +1,58 @@
 #include "menu_bar.h"
-#include "actions.h"
-#include "file_open.h"
-#include "file_new.h"
-#include "file_add.h"
-#include "file_rename.h"
-#include "file_delete.h"
-#include "project_new_wizard.h"
-#include "preferences_dialog.h"
-#include "evaluate.h"
 
 GtkWidget *
 menu_bar_new(App *self)
 {
-  GtkWidget *menu_bar      = gtk_menu_bar_new();
-  GtkWidget *file_menu     = gtk_menu_new();
-  GtkWidget *file_item     = gtk_menu_item_new_with_label("File");
+  GMenu *menu_bar = g_menu_new();
 
-  GtkWidget *edit_menu     = gtk_menu_new();
-  GtkWidget *edit_item     = gtk_menu_item_new_with_label("Edit");
-  GtkWidget *extend_item   = gtk_menu_item_new_with_label("Extend selection");
-  GtkWidget *shrink_item   = gtk_menu_item_new_with_label("Shrink selection");
-
-  GtkWidget *refactor_menu = gtk_menu_new();
-  GtkWidget *refactor_item = gtk_menu_item_new_with_label("Refactor");
-  GtkWidget *refactor_file_menu = gtk_menu_new();
-  GtkWidget *refactor_file_item = gtk_menu_item_new_with_label("File");
-  GtkWidget *rename_item   = gtk_menu_item_new_with_label("Rename");
-  GtkWidget *delete_item   = gtk_menu_item_new_with_label("Delete");
-
-  GtkWidget *run_menu      = gtk_menu_new();
-  GtkWidget *run_item      = gtk_menu_item_new_with_label("Run");
-  GtkWidget *eval_item     = gtk_menu_item_new_with_label("Eval toplevel");
-  GtkWidget *eval_sel_item = gtk_menu_item_new_with_label("Eval selection");
-
-  GtkWidget *project_menu  = gtk_menu_new();
-  GtkWidget *project_item  = gtk_menu_item_new_with_label("Project");
-  GtkWidget *proj_new_item = gtk_menu_item_new_with_label("New…");
-  GtkWidget *proj_open_item = gtk_menu_item_new_with_label("Open…");
-  GtkWidget *proj_recent_item = gtk_menu_item_new_with_label("Recent");
-  GtkWidget *recent_menu   = gtk_menu_new();
+  GMenu *file_menu = g_menu_new();
+  GMenu *project_menu = g_menu_new();
+  g_menu_append(project_menu, "New…", "app.project-new");
+  g_menu_append(project_menu, "Open…", "app.project-open");
+  GMenu *recent_menu = g_menu_new();
+  g_menu_append_submenu(project_menu, "Recent", G_MENU_MODEL(recent_menu));
   app_set_recent_menu(self, recent_menu);
+  g_menu_append_submenu(file_menu, "Project", G_MENU_MODEL(project_menu));
+  g_menu_append(file_menu, "New file", "app.file-new");
+  g_menu_append(file_menu, "Add file", "app.file-add");
+  g_menu_append(file_menu, "Save all", "app.save-all");
+  g_menu_append(file_menu, "Close project", "app.close-project");
+  GMenu *sep = g_menu_new();
+  g_menu_append_section(file_menu, NULL, G_MENU_MODEL(sep));
+  g_object_unref(sep);
+  g_menu_append(file_menu, "Settings…", "app.preferences");
+  sep = g_menu_new();
+  g_menu_append_section(file_menu, NULL, G_MENU_MODEL(sep));
+  g_object_unref(sep);
+  g_menu_append(file_menu, "Exit", "app.quit");
+  g_menu_append_submenu(menu_bar, "File", G_MENU_MODEL(file_menu));
 
-  GtkWidget *newfile_item  = gtk_menu_item_new_with_label("New file");
-  GtkWidget *addfile_item  = gtk_menu_item_new_with_label("Add file");
-  GtkWidget *saveall_item  = gtk_menu_item_new_with_label("Save all");
-  GtkWidget *closeproj_item = gtk_menu_item_new_with_label("Close project");
-  GtkWidget *settings_item = gtk_menu_item_new_with_label("Settings…");
-  GtkWidget *exit_item     = gtk_menu_item_new_with_label("Exit");
+  GMenu *edit_menu = g_menu_new();
+  g_menu_append(edit_menu, "Extend selection", "app.extend-selection");
+  g_menu_append(edit_menu, "Shrink selection", "app.shrink-selection");
+  g_menu_append_submenu(menu_bar, "Edit", G_MENU_MODEL(edit_menu));
 
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(file_item), file_menu);
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(project_item), project_menu);
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(proj_recent_item), recent_menu);
-  gtk_menu_shell_append(GTK_MENU_SHELL(project_menu), proj_new_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(project_menu), proj_open_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(project_menu), proj_recent_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), project_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), newfile_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), addfile_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), saveall_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), closeproj_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), gtk_separator_menu_item_new());
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), settings_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), gtk_separator_menu_item_new());
-  gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), exit_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), file_item);
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(edit_item), edit_menu);
-  gtk_menu_shell_append(GTK_MENU_SHELL(edit_menu), extend_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(edit_menu), shrink_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), edit_item);
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(refactor_item), refactor_menu);
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(refactor_file_item), refactor_file_menu);
-  gtk_menu_shell_append(GTK_MENU_SHELL(refactor_file_menu), rename_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(refactor_file_menu), delete_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(refactor_menu), refactor_file_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), refactor_item);
+  GMenu *refactor_menu = g_menu_new();
+  GMenu *refactor_file_menu = g_menu_new();
+  g_menu_append(refactor_file_menu, "Rename", "app.file-rename");
+  g_menu_append(refactor_file_menu, "Delete", "app.file-delete");
+  g_menu_append_submenu(refactor_menu, "File", G_MENU_MODEL(refactor_file_menu));
+  g_menu_append_submenu(menu_bar, "Refactor", G_MENU_MODEL(refactor_menu));
 
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(run_item), run_menu);
-  gtk_menu_shell_append(GTK_MENU_SHELL(run_menu), eval_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(run_menu), eval_sel_item);
-  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), run_item);
+  GMenu *run_menu = g_menu_new();
+  g_menu_append(run_menu, "Eval toplevel", "app.eval-toplevel");
+  g_menu_append(run_menu, "Eval selection", "app.eval-selection");
+  g_menu_append_submenu(menu_bar, "Run", G_MENU_MODEL(run_menu));
 
-  g_signal_connect(proj_new_item, "activate", G_CALLBACK(project_new_wizard), self);
-  g_signal_connect(proj_open_item, "activate", G_CALLBACK(file_open), self);
-  g_signal_connect(newfile_item, "activate", G_CALLBACK(file_new), self);
-  g_signal_connect(addfile_item, "activate", G_CALLBACK(file_add), self);
-  g_signal_connect(saveall_item, "activate", G_CALLBACK(on_save_all), self);
-  g_signal_connect(closeproj_item, "activate", G_CALLBACK(on_close_project), self);
-  g_signal_connect(settings_item, "activate", G_CALLBACK(on_preferences), self);
-  g_signal_connect(exit_item, "activate", G_CALLBACK(on_quit_menu), self);
-  g_signal_connect(rename_item, "activate", G_CALLBACK(file_rename), self);
-  g_signal_connect(delete_item, "activate", G_CALLBACK(file_delete), self);
-  g_signal_connect(extend_item, "activate", G_CALLBACK(on_extend_selection), self);
-  g_signal_connect(shrink_item, "activate", G_CALLBACK(on_shrink_selection), self);
-  g_signal_connect(eval_item, "activate", G_CALLBACK(on_evaluate_toplevel), self);
-  g_signal_connect(eval_sel_item, "activate", G_CALLBACK(on_evaluate_selection), self);
+  GtkWidget *widget = gtk_menu_bar_new_from_model(G_MENU_MODEL(menu_bar));
+  g_object_unref(menu_bar);
+  g_object_unref(file_menu);
+  g_object_unref(project_menu);
+  g_object_unref(edit_menu);
+  g_object_unref(refactor_menu);
+  g_object_unref(refactor_file_menu);
+  g_object_unref(run_menu);
 
-  return menu_bar;
+  return widget;
 }
+


### PR DESCRIPTION
## Summary
- Replace manual menu signals with `GAction` entries and hook up accelerators
- Build menubar from `GMenu` models referencing application actions
- Track recent projects via `GMenu` items and parameterized action

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b15f1502908328a11c9d960561ed6f