### PR TITLE
Fix interactions view scrolling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -96,3 +96,11 @@ accessible.
 The interactions list was added directly to the `GtkScrolledWindow` without a
 `GtkViewport`, so the scrollbars never appeared when the view was shorter than
 its contents. Wrapping the box in a viewport allows the window to scroll.
+
+## Interactions view hid new interactions without scrollbars
+
+When evaluation produced many interactions, new rows were appended below the
+visible area. The window neither grew nor displayed a scrollbar, so the only
+way to see the new interactions was to drag the pane divider to enlarge the
+view. The scrolled window now disables natural height propagation so the window
+scrolls when content exceeds the available space.

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -175,6 +175,8 @@ interactions_view_init(InteractionsView *self)
   g_debug("InteractionsView.init");
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self),
       GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_propagate_natural_height(GTK_SCROLLED_WINDOW(self),
+      FALSE);
   GtkWidget *viewport = gtk_viewport_new(NULL, NULL);
   self->box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_hexpand(self->box, TRUE);


### PR DESCRIPTION
## Summary
- prevent InteractionsView from growing with content by disabling natural-height propagation
- document that interactions view hid new interactions without scrollbars

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b17774c9ac8328b9f8304de7bbfce2