### PR TITLE
Fix interactions view scrolling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -104,3 +104,11 @@ visible area. The window neither grew nor displayed a scrollbar, so the only
 way to see the new interactions was to drag the pane divider to enlarge the
 view. The scrolled window now disables natural height propagation so the window
 scrolls when content exceeds the available space.
+
+## Interactions view still did not scroll
+
+Even after disabling natural height propagation, the interactions list still
+expanded with its contents and never triggered the scrollbars. The surrounding
+viewport did not advertise that it could shrink, so the scrolled window kept
+resizing to fit the growing box. Marking the viewport as vertically expandable
+prevents this, letting the view scroll when there are many interactions.

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -178,6 +178,7 @@ interactions_view_init(InteractionsView *self)
   gtk_scrolled_window_set_propagate_natural_height(GTK_SCROLLED_WINDOW(self),
       FALSE);
   GtkWidget *viewport = gtk_viewport_new(NULL, NULL);
+  gtk_widget_set_vexpand(viewport, TRUE);
   self->box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_hexpand(self->box, TRUE);
   gtk_container_add(GTK_CONTAINER(viewport), self->box);


### PR DESCRIPTION
## Summary
- prevent interactions viewport from resizing to content
- document interactions view scrolling fix

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b189f53bd483289e2160e9f49e1252