### PR TITLE
Allow interactions view to scroll

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -112,3 +112,12 @@ expanded with its contents and never triggered the scrollbars. The surrounding
 viewport did not advertise that it could shrink, so the scrolled window kept
 resizing to fit the growing box. Marking the viewport as vertically expandable
 prevents this, letting the view scroll when there are many interactions.
+
+## Interactions view packed without resizing
+
+The interactions pane was inserted into the main window's `GtkPaned` with the
+`resize` flag set to `FALSE`. As interactions accumulated, the pane grew to fit
+its contents instead of allowing the embedded scrolled window to show
+scrollbars. Packing the pane with `resize` set to `TRUE` and marking the widget
+as vertically expandable keeps the pane at a fixed height and enables scrolling
+when needed.

--- a/src/app.c
+++ b/src/app.c
@@ -85,9 +85,10 @@ app_activate (GApplication *app)
   GtkWidget *menu_bar = menu_bar_new(self);
 
   GtkWidget *interactions = GTK_WIDGET(interactions_view_new(self->glide));
+  gtk_widget_set_vexpand(interactions, TRUE);
   GtkWidget *paned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
   gtk_paned_pack1(GTK_PANED(paned), self->notebook_paned, TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(paned), interactions, FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(paned), interactions, TRUE, TRUE);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox), menu_bar, FALSE, FALSE, 0);


### PR DESCRIPTION
## Summary
- make interactions pane resizable so scrolled window shows scrollbars
- document the resize flag issue in BUGS

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b18c5c07f88328adaefbffbbde3a82