### PR TITLE
Fix interactions view missing scrollbars when pane shrinks

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -121,3 +121,11 @@ its contents instead of allowing the embedded scrolled window to show
 scrollbars. Packing the pane with `resize` set to `TRUE` and marking the widget
 as vertically expandable keeps the pane at a fixed height and enables scrolling
 when needed.
+
+## Interactions view shrank with its viewport
+
+Dragging the pane divider to reduce the interactions view did not reveal
+scrollbars. The `GtkViewport` inside the view was marked as vertically
+expandable, so it shrank along with the scrolled window and never exceeded its
+allocation. Removing the expansion flag lets the viewport keep its natural
+height, allowing the scrollbars to appear when the pane is too small.

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -178,7 +178,6 @@ interactions_view_init(InteractionsView *self)
   gtk_scrolled_window_set_propagate_natural_height(GTK_SCROLLED_WINDOW(self),
       FALSE);
   GtkWidget *viewport = gtk_viewport_new(NULL, NULL);
-  gtk_widget_set_vexpand(viewport, TRUE);
   self->box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_hexpand(self->box, TRUE);
   gtk_container_add(GTK_CONTAINER(viewport), self->box);


### PR DESCRIPTION
## Summary
- keep interactions viewport at natural height so scrolled window shows scrollbars
- document viewport shrink bug in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b192261c488328b8859ef75451f804