### PR TITLE
Scroll interactions view when content changes

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -129,3 +129,9 @@ scrollbars. The `GtkViewport` inside the view was marked as vertically
 expandable, so it shrank along with the scrolled window and never exceeded its
 allocation. Removing the expansion flag lets the viewport keep its natural
 height, allowing the scrollbars to appear when the pane is too small.
+
+## Interactions view left updates off screen
+
+New interactions or additional output could appear below the visible area while
+the scroll position stayed unchanged. The view now scrolls to keep the most
+recent interaction in sight.


### PR DESCRIPTION
## Summary
- ensure interactions view scrolls to reveal newly added or updated rows
- document fix for missing auto-scroll in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b1964e7cd48328a8be3f7b4fd82974