### PR TITLE
Rename eval function and tag responses

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -61,9 +61,9 @@ beginning of a line. Evaluation now asks `Editor` for the enclosing
 top‑level range, which is shared with the selection expansion logic, so the
 correct expression is sent to swank.
 
-## glide-eval evaluated raw strings
+## eval-and-capture evaluated raw strings
 
-`glide-eval` expected a parsed form but the server sent it expressions as
+`eval-and-capture` expected a parsed form but the server sent it expressions as
 strings, leading to evaluation failures. The function now reads the string into
 an s-expression before evaluating it.
 

--- a/src/glide-package.lisp
+++ b/src/glide-package.lisp
@@ -2,5 +2,5 @@
   (:use :cl)
   (:export :package-symbols
            :package-info
-           :glide-eval
+           :eval-and-capture
            :start-server))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -4,28 +4,29 @@
 (defvar *real-standard-output* *standard-output*)
 
 (defclass repl-stream (sb-gray:fundamental-character-output-stream)
-  ((label :initarg :label)))
+  ((label :initarg :label)
+   (id :initarg :id)))
 
 (defmethod sb-gray:stream-write-string ((s repl-stream) string &optional start end)
-  (format *real-standard-output* "(~a ~S)~%" (slot-value s 'label) string))
+  (format *real-standard-output* "(~a ~a ~S)~%" (slot-value s 'label) (slot-value s 'id) string))
 
 (defmethod sb-gray:stream-write-char ((s repl-stream) char)
-  (format *real-standard-output* "(~a ~S)~%" (slot-value s 'label) (string char)))
+  (format *real-standard-output* "(~a ~a ~S)~%" (slot-value s 'label) (slot-value s 'id) (string char)))
 
-(defun glide-eval (form-string)
+(defun eval-and-capture (id form-string)
   (setf *real-standard-output* *standard-output*)
   (handler-case
-      (let* ((out (make-instance 'repl-stream :label "stdout"))
-             (err (make-instance 'repl-stream :label "stderr"))
+      (let* ((out (make-instance 'repl-stream :label "stdout" :id id))
+             (err (make-instance 'repl-stream :label "stderr" :id id))
              (*standard-output* out)
              (*standard-error* err)
              (*error-output* err))
         (multiple-value-bind (form /*remaining*/)
             (read-from-string form-string)
           (let ((res (cl:eval form)))
-            (format *real-standard-output* "(result ~S)~%" res))))
+            (format *real-standard-output* "(result ~a ~S)~%" id res))))
     (error (e)
-      (format *real-standard-output* "(error ~S)~%" (princ-to-string e)))))
+      (format *real-standard-output* "(error ~a ~S)~%" id (princ-to-string e)))))
 
 (defun start-server ()
   (loop for form = (read *standard-input* nil :eof)


### PR DESCRIPTION
## Summary
- rename Lisp eval helper to `eval-and-capture` and tag stdout/stderr/error/result with interaction id
- send interaction id in requests and parse it in responses
- track pending interactions in a hash table keyed by id instead of a single current pointer
- document the rename in BUGS

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b1c73a4e18832891edc824cad64d81