### PR TITLE
Trigger updates on stdout and stderr messages

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -142,3 +142,9 @@ Scrolling to the latest interaction relied on an idle callback that sometimes
 ran before GTK completed its resize, leaving the view above the newest content.
 The interactions box now scrolls in response to its size allocating growing, so
 the view reliably follows new output without race conditions.
+
+## Stdout and stderr output did not update interactions
+
+REPL sessions appended stdout and stderr text to the interaction but did not
+invoke the update callback, so the UI missed incremental output. The session now
+notifies listeners when stdout or stderr arrives.

--- a/src/repl_session.c
+++ b/src/repl_session.c
@@ -163,6 +163,8 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
         interaction->output = old ? g_strconcat(old, text, NULL) : g_strdup(text);
         g_free(old);
         g_free(text);
+        updated_cb = self->updated_cb;
+        updated_cb_data = self->updated_cb_data;
       }
     }
   } else if (g_str_has_prefix(str, "(stderr ")) {
@@ -180,6 +182,8 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
         interaction->output = old ? g_strconcat(old, text, NULL) : g_strdup(text);
         g_free(old);
         g_free(text);
+        updated_cb = self->updated_cb;
+        updated_cb_data = self->updated_cb_data;
       }
     }
   } else if (g_str_has_prefix(str, "(result ")) {
@@ -224,11 +228,13 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
         g_free(err);
       }
     }
+  } else {
+    g_message("ReplSession.on_message unknown message: %s", str);
   }
   g_mutex_unlock(&self->lock);
+  if (updated_cb)
+    updated_cb(self, interaction, updated_cb_data);
   if (finished) {
-    if (updated_cb)
-      updated_cb(self, interaction, updated_cb_data);
     if (done_cb)
       done_cb(interaction, done_cb_data);
     g_mutex_lock(&self->lock);


### PR DESCRIPTION
## Summary
- notify listeners when stdout or stderr output arrives
- document missing updates in BUGS
- log unrecognized REPL messages for easier debugging

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68b323bbee488328b86359e4a9a4c688