### PR TITLE
Escape newlines in debug logging

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -148,3 +148,8 @@ the view reliably follows new output without race conditions.
 REPL sessions appended stdout and stderr text to the interaction but did not
 invoke the update callback, so the UI missed incremental output. The session now
 notifies listeners when stdout or stderr arrives.
+
+## Debug logging split across lines
+
+Messages containing newlines caused `g_debug_160` to emit multi-line log entries, making logs harder to read.
+The helper now escapes newline characters so each debug message stays on a single line.

--- a/src/util.h
+++ b/src/util.h
@@ -4,9 +4,12 @@
 
 static inline void g_debug_160(const char *string, const char *msg)
 {
-  if (strlen(msg) > 160)
-    g_debug("%s%.160s...", string, msg);
+  char *escaped = g_strescape(msg, NULL);
+  size_t len = strlen(escaped);
+  if (len > 160)
+    g_debug("%s%.80s...%s", string, escaped, escaped + len - 80);
   else
-    g_debug("%s%s", string, msg);
+    g_debug("%s%s", string, escaped);
+  g_free(escaped);
 }
 


### PR DESCRIPTION
## Summary
- escape newline characters in g_debug_160 so debug messages stay on one line
- truncate long debug messages to the first and last 80 characters
- document the bug fix in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run` *(hangs during repl_process_test)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b0b0bf08328872093d432c774ef