### PR TITLE
Fix ReplProcess deadlock in incomplete messages

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -153,3 +153,10 @@ notifies listeners when stdout or stderr arrives.
 
 Messages containing newlines caused `g_debug_160` to emit multi-line log entries, making logs harder to read.
 The helper now escapes newline characters so each debug message stays on a single line.
+
+## ReplProcess deadlocked on incomplete messages
+
+`ReplProcess` locked its mutex while accumulating output but returned early when the buffer lacked a complete
+sexp. The missing unlock left the mutex held, so the next chunk blocked waiting for the lock and tests hung.
+`on_proc_out` now releases the mutex before returning when output is incomplete, allowing processing to
+continue.

--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -53,6 +53,7 @@ static void on_proc_out(GString *data, gpointer user_data) {
     }
     if (!complete) {
       g_debug_160("ReplProcess.on_proc_out incomplete: ", self->buffer->str);
+      g_mutex_unlock(&self->mutex);
       return;
     }
     GString *line = g_string_new_len(self->buffer->str, i + 1);


### PR DESCRIPTION
## Summary
- release ReplProcess mutex when partial output arrives to avoid deadlocks
- document the deadlock fix in BUGS.md

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b420396c4c832892db199d7ff3e540