### PR TITLE
Protect Interaction text with mutex

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -160,3 +160,10 @@ The helper now escapes newline characters so each debug message stays on a singl
 sexp. The missing unlock left the mutex held, so the next chunk blocked waiting for the lock and tests hung.
 `on_proc_out` now releases the mutex before returning when output is incomplete, allowing processing to
 continue.
+
+## Interactions view accessed freed text
+
+`InteractionsView` filled its widgets with pointers to strings stored in `Interaction`. The session thread
+could update an interaction concurrently, freeing or replacing those strings while the UI still held references.
+`Interaction` now guards its fields with a mutex, and both the session and view lock around any access,
+copying text as needed to keep pointers valid.

--- a/src/interaction.h
+++ b/src/interaction.h
@@ -19,6 +19,7 @@ typedef enum {
 } InteractionType;
 
 struct _Interaction {
+  GMutex lock;
   gchar *expression;
   guint32 tag;
   InteractionStatus status;
@@ -31,6 +32,8 @@ struct _Interaction {
 };
 
 static inline void interaction_init(Interaction *self, const gchar *expr) {
+  g_mutex_init(&self->lock);
+  g_mutex_lock(&self->lock);
   self->expression = g_strdup(expr);
   self->tag = 0;
   self->status = INTERACTION_CREATED;
@@ -40,14 +43,18 @@ static inline void interaction_init(Interaction *self, const gchar *expr) {
   self->error = NULL;
   self->done_cb = NULL;
   self->done_cb_data = NULL;
+  g_mutex_unlock(&self->lock);
 }
 
 static inline void interaction_clear(Interaction *self) {
+  g_mutex_lock(&self->lock);
   g_free(self->expression);
   g_free(self->result);
   g_free(self->output);
   g_free(self->error);
   self->done_cb = NULL;
   self->done_cb_data = NULL;
+  g_mutex_unlock(&self->lock);
+  g_mutex_clear(&self->lock);
 }
 


### PR DESCRIPTION
## Summary
- Add a mutex to `Interaction` and initialize/clear it
- Lock around interaction field access in `ReplSession`, `InteractionsView`, and project callbacks
- Document the interaction text race and adjust related tests

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b4783b01d08328addfecd7f0480cf1