### PR TITLE
Preserve initial buffer in undo stack

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -167,3 +167,10 @@ continue.
 could update an interaction concurrently, freeing or replacing those strings while the UI still held references.
 `Interaction` now guards its fields with a mutex, and both the session and view lock around any access,
 copying text as needed to keep pointers valid.
+
+## Undo cleared buffer with no edits
+
+Pressing `Ctrl-z` immediately after opening a file erased its contents. Loading the file text was recorded as
+an undoable action, so the first undo reverted the buffer to empty. Wrapping the initial load in a
+non-undoable action initializes the undo stack with the file's contents, so undo before any edits now leaves
+the text unchanged.

--- a/src/editor.c
+++ b/src/editor.c
@@ -91,11 +91,13 @@ editor_new_for_file (Project *project, ProjectFile *file)
   self->project = project_ref(project);
   self->file = file;
 
-  TextProvider *existing = project_file_get_provider (self->file);
+  TextProvider *existing = project_file_get_provider(self->file);
   if (existing) {
     gsize len = text_provider_get_length(existing);
     gchar *text = text_provider_get_text(existing, 0, len);
-    gtk_text_buffer_set_text (GTK_TEXT_BUFFER (self->buffer), text, -1);
+    gtk_source_buffer_begin_not_undoable_action(self->buffer);
+    gtk_text_buffer_set_text(GTK_TEXT_BUFFER(self->buffer), text, -1);
+    gtk_source_buffer_end_not_undoable_action(self->buffer);
     g_free(text);
   }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,9 +5,9 @@ endif
 
 VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
-CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0`
-LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0`
-TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test project_test asdf_test analyser_test package_test status_service_test
+CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
+LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
+TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test project_test asdf_test analyser_test package_test status_service_test editor_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -42,6 +42,9 @@ package_test: package_test.c package.c node.c
 status_service_test: status_service_test.c status_service.c
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
+editor_test: editor_test.c editor.c gtk_text_provider.c project.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c
+:$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
 run: all
 :./preferences_test
 :./process_test
@@ -53,6 +56,7 @@ run: all
 :./analyser_test
 :./package_test
 :./status_service_test
+:./editor_test
 
 clean:
 :rm -f $(CLEANABLES)

--- a/tests/editor_test.c
+++ b/tests/editor_test.c
@@ -1,0 +1,42 @@
+#include "editor.h"
+#include "string_text_provider.h"
+#include <gtk/gtk.h>
+
+static gboolean have_display;
+
+static void test_undo_pristine(void)
+{
+  if (!have_display) {
+    g_test_skip("no display");
+    return;
+  }
+  Project *project = project_new(NULL);
+  TextProvider *provider = string_text_provider_new("(a b)");
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
+  text_provider_unref(provider);
+
+  GtkWidget *widget = editor_new_for_file(project, file);
+  Editor *editor = GLIDE_EDITOR(widget);
+  GtkSourceBuffer *buffer = editor_get_buffer(editor);
+
+  g_assert_false(gtk_source_buffer_can_undo(buffer));
+  gtk_source_buffer_undo(buffer);
+  GtkTextIter start;
+  GtkTextIter end;
+  gtk_text_buffer_get_bounds(GTK_TEXT_BUFFER(buffer), &start, &end);
+  gchar *text = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(buffer), &start, &end, FALSE);
+  g_assert_cmpstr(text, ==, "(a b)");
+  g_free(text);
+
+  g_object_unref(widget);
+  project_unref(project);
+}
+
+int main(int argc, char *argv[])
+{
+  g_test_init(&argc, &argv, NULL);
+  have_display = gtk_init_check(&argc, &argv);
+  g_test_add_func("/editor/undo_pristine", test_undo_pristine);
+  return g_test_run();
+}
+


### PR DESCRIPTION
## Summary
- avoid clearing editor when undoing before edits by resetting undo stack after loading file
- document the fix and add headless regression test

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b4884155808328b385cf720bc3fbbf