### PR TITLE
Rename package info to package definition

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -167,3 +167,9 @@ continue.
 could update an interaction concurrently, freeing or replacing those strings while the UI still held references.
 `Interaction` now guards its fields with a mutex, and both the session and view lock around any access,
 copying text as needed to keep pointers valid.
+
+## Package info name mismatch
+
+`Project` asked the server for `glide:package-definition`, but the Lisp code exported `package-info`
+under a different name. The missing function prevented fetching package metadata. Renaming the file and
+function to `package-definition` synchronized the API and restored package lookup.

--- a/src/glide-package.lisp
+++ b/src/glide-package.lisp
@@ -1,6 +1,6 @@
 (defpackage :glide
   (:use :cl)
   (:export :package-symbols
-           :package-info
+           :package-definition
            :eval-and-capture
            :start-server))

--- a/src/glide.asd
+++ b/src/glide.asd
@@ -1,5 +1,5 @@
 (defsystem "glide"
   :description "List symbols of a given package"
   :serial t
-  :components ((:file "glide-package") (:file "symbol-info") (:file "package-info") (:file "server"))
+  :components ((:file "glide-package") (:file "symbol-info") (:file "package-definition") (:file "server"))
 )

--- a/src/package-definition.lisp
+++ b/src/package-definition.lisp
@@ -1,6 +1,6 @@
 (in-package :glide)
 
-(defun package-info (package-name)
+(defun package-definition (package-name)
   (let ((pkg (find-package package-name)))
     (when pkg
       (list :name (package-name pkg)


### PR DESCRIPTION
## Summary
- Rename Lisp helper `package-info` to `package-definition`
- Export and build the new `package-definition` component
- Record mismatch fix in BUGS log

## Testing
- `make app-full`
- `make run` *(fails: ERROR:repl_session_test.c:39:test_eval: assertion failed (status == INTERACTION_OK): (1 == 2))*

------
https://chatgpt.com/codex/tasks/task_e_68b48f04ca4c8328a7d971249aab05c1