### PR TITLE
Replace libraries with packages in ProjectView

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -249,6 +249,11 @@ Package *project_get_package(Project *self, const gchar *name) {
   return g_hash_table_lookup(self->packages, name);
 }
 
+gchar **project_get_package_names(Project *self, guint *length) {
+  g_return_val_if_fail(self != NULL, NULL);
+  return (gchar **) g_hash_table_get_keys_as_array(self->packages, length);
+}
+
 void project_set_asdf(Project *self, Asdf *asdf) {
   g_return_if_fail(self != NULL);
   g_debug("project_set_asdf %p", asdf);

--- a/src/project.h
+++ b/src/project.h
@@ -32,6 +32,7 @@ void           project_index_add(Project *self, Node *node);
 GHashTable    *project_get_index(Project *self, StringDesignatorType sd_type);
 void           project_add_package(Project *self, Package *package);
 Package       *project_get_package(Project *self, const gchar *name);
+gchar        **project_get_package_names(Project *self, guint *length);
 void           project_set_asdf(Project *self, Asdf *asdf);
 Asdf          *project_get_asdf(Project *self);
 void           project_clear(Project *self);

--- a/src/project_view.c
+++ b/src/project_view.c
@@ -106,26 +106,24 @@ project_view_populate_store(ProjectView *self)
 
   gtk_tree_store_append(self->store, &iter, &root);
   gtk_tree_store_set(self->store, &iter,
-      PROJECT_VIEW_COL_TEXT, "libraries",
-      PROJECT_VIEW_COL_KIND, PROJECT_VIEW_KIND_LIBRARIES,
+      PROJECT_VIEW_COL_TEXT, "packages",
+      PROJECT_VIEW_COL_KIND, PROJECT_VIEW_KIND_PACKAGES,
       PROJECT_VIEW_COL_OBJECT, NULL,
       -1);
-  gtk_tree_store_append(self->store, &child, &iter);
-  gtk_tree_store_set(self->store, &child,
-      PROJECT_VIEW_COL_TEXT, "COMMON-LISP",
-      PROJECT_VIEW_COL_KIND, PROJECT_VIEW_KIND_LIBRARY,
-      PROJECT_VIEW_COL_OBJECT, "COMMON-LISP",
-      -1);
-  for (guint i = 0; i < asdf_get_dependency_count(self->asdf); i++) {
-    const gchar *dep = asdf_get_dependency(self->asdf, i);
-    if (g_strcmp0(dep, "COMMON-LISP") != 0) {
+  if (self->project) {
+    guint n = 0;
+    gchar **names = project_get_package_names(self->project, &n);
+    for (guint i = 0; i < n; i++) {
+      const gchar *name = names[i];
       gtk_tree_store_append(self->store, &child, &iter);
       gtk_tree_store_set(self->store, &child,
-          PROJECT_VIEW_COL_TEXT, dep,
-          PROJECT_VIEW_COL_KIND, PROJECT_VIEW_KIND_LIBRARY,
-          PROJECT_VIEW_COL_OBJECT, dep,
+          PROJECT_VIEW_COL_TEXT, name,
+          PROJECT_VIEW_COL_KIND, PROJECT_VIEW_KIND_PACKAGE,
+          PROJECT_VIEW_COL_OBJECT,
+          project_get_package(self->project, name),
           -1);
     }
+    g_free(names);
   }
 
   gtk_tree_view_expand_all(GTK_TREE_VIEW(self));

--- a/src/project_view.h
+++ b/src/project_view.h
@@ -21,8 +21,8 @@ typedef enum {
   PROJECT_VIEW_KIND_ROOT,
   PROJECT_VIEW_KIND_SRC,
   PROJECT_VIEW_KIND_COMPONENT,
-  PROJECT_VIEW_KIND_LIBRARIES,
-  PROJECT_VIEW_KIND_LIBRARY
+  PROJECT_VIEW_KIND_PACKAGES,
+  PROJECT_VIEW_KIND_PACKAGE
 } ProjectViewKind;
 GtkWidget *project_view_new(Asdf *asdf, App *app);
 void project_view_select_file(ProjectView *self, const gchar *file);


### PR DESCRIPTION
## Summary
- Show project packages in ProjectView instead of hardcoded libraries
- Add API to fetch package names from Project

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68b59567b5d483289be8797900fe8b8a