### PR TITLE
Handle empty output in ReplProcess

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -185,3 +185,11 @@ the text unchanged.
 Packages fetched from the REPL were added to `Project` but `ProjectView` never
 repopulated, so the packages list stayed empty. `Project` now notifies listeners
 when packages are added and `ProjectView` refreshes its store in response.
+
+## repl_process_test hung on empty output
+
+`ReplProcess` stripped leading newlines without verifying that the buffer
+contained any characters. When the process emitted only newlines, the trimming
+loop examined the first byte of an empty string, triggering undefined behavior
+and leaving tests blocked. The loop now guards the check with the buffer's
+length so empty output exits cleanly and the test completes.

--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -19,7 +19,7 @@ static void on_proc_out(GString *data, gpointer user_data) {
   g_string_append_len(self->buffer, data->str, data->len);
   g_debug_160("ReplProcess.on_proc_out added: ", data->str);
   while(TRUE) {
-    while (self->buffer->str[0] == '\n') {
+    while (self->buffer->len > 0 && self->buffer->str[0] == '\n') {
       g_string_erase(self->buffer, 0, 1);
     }
     gsize i;


### PR DESCRIPTION
## Summary
- guard ReplProcess newline stripping against empty buffers to avoid undefined behavior on pure newline output
- document the empty-output hang in BUGS.md

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b5e84d91088328b668537f939155bc