### PR TITLE
Ensure ProjectView repopulates packages on UI thread

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -193,3 +193,11 @@ contained any characters. When the process emitted only newlines, the trimming
 loop examined the first byte of an empty string, triggering undefined behavior
 and leaving tests blocked. The loop now guards the check with the buffer's
 length so empty output exits cleanly and the test completes.
+
+## Package list updated from background thread
+
+`ProjectView` refreshed its tree store directly from the package-added callback,
+which may run outside the main GTK thread. GTK requires UI updates on the main
+context, so repopulating from a background thread could lead to race conditions
+and warnings. The callback now dispatches the refresh via `g_main_context_invoke`,
+ensuring the tree store updates on the UI thread.


### PR DESCRIPTION
## Summary
- dispatch package list refreshes via `g_main_context_invoke`
- document background-thread package update issue

## Testing
- `make app-full`
- `make run` *(fails: `ERROR:repl_session_test.c:39:test_eval: assertion failed (status == INTERACTION_OK): (1 == 2)`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e0c531048328a4c46e422cc2fc18