### PR TITLE
Use GLib test harness for package and analyser tests

### DIFF
--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -6,7 +6,7 @@
 #include "project.h"
 #include <glib.h>
 
-int main(void) {
+static void test_analyse(void) {
   const gchar *text =
     "(defpackage :my-pack (:nicknames :mp) (:use :cl))\n"
     "(defun foo ())\n"
@@ -25,9 +25,9 @@ int main(void) {
   analyse_ast(project, ast);
 
   Package *pkg = project_get_package(project, "MY-PACK");
-  g_assert(pkg);
-  g_assert(g_hash_table_contains(package_get_nicknames(pkg), "MP"));
-  g_assert(g_hash_table_contains(package_get_uses(pkg), "CL"));
+  g_assert_nonnull(pkg);
+  g_assert_true(g_hash_table_contains(package_get_nicknames(pkg), "MP"));
+  g_assert_true(g_hash_table_contains(package_get_uses(pkg), "CL"));
 
   Node *foo_expr = g_array_index(ast->children, Node*, 1);
   Node *foo_name = g_array_index(foo_expr->children, Node*, 1);
@@ -46,5 +46,10 @@ int main(void) {
   lisp_lexer_free(lexer);
   text_provider_unref(provider);
   project_unref(project);
-  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/analyse/basic", test_analyse);
+  return g_test_run();
 }

--- a/tests/package_test.c
+++ b/tests/package_test.c
@@ -1,8 +1,10 @@
+// This test verifies the basic package API and ensures it integrates
+// with Node's package context helpers.
 #include "package.h"
 #include "node.h"
-#include <assert.h>
+#include <glib.h>
 
-int main(void) {
+static void test_package(void) {
   Package *package = package_new("CL-USER");
   package_set_description(package, "desc");
   package_add_nickname(package, "USER");
@@ -11,21 +13,26 @@ int main(void) {
   package_add_shadow(package, "BAR");
   package_add_import_from(package, "BAZ", "OTHER");
 
-  assert(g_strcmp0(package_get_name(package), "CL-USER") == 0);
-  assert(g_strcmp0(package_get_description(package), "desc") == 0);
-  assert(g_hash_table_contains(package_get_nicknames(package), "USER"));
-  assert(g_hash_table_contains(package_get_uses(package), "COMMON-LISP"));
-  assert(g_hash_table_contains(package_get_exports(package), "FOO"));
-  assert(g_hash_table_contains(package_get_shadows(package), "BAR"));
-  assert(g_strcmp0(g_hash_table_lookup(package_get_import_from(package), "BAZ"), "OTHER") == 0);
+  g_assert_cmpstr(package_get_name(package), ==, "CL-USER");
+  g_assert_cmpstr(package_get_description(package), ==, "desc");
+  g_assert_true(g_hash_table_contains(package_get_nicknames(package), "USER"));
+  g_assert_true(g_hash_table_contains(package_get_uses(package), "COMMON-LISP"));
+  g_assert_true(g_hash_table_contains(package_get_exports(package), "FOO"));
+  g_assert_true(g_hash_table_contains(package_get_shadows(package), "BAR"));
+  g_assert_cmpstr(g_hash_table_lookup(package_get_import_from(package), "BAZ"), ==, "OTHER");
 
   Node *node = g_new0(Node, 1);
   g_atomic_int_set(&node->ref, 1);
   node_set_sd_type(node, SDT_PACKAGE_DEF, "COMMON-LISP-USER");
-  assert(node_is(node, SDT_PACKAGE_DEF));
-  assert(g_strcmp0(node->package_context, "COMMON-LISP-USER") == 0);
+  g_assert(node_is(node, SDT_PACKAGE_DEF));
+  g_assert_cmpstr(node->package_context, ==, "COMMON-LISP-USER");
 
   node_unref(node);
   package_unref(package);
-  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/package/basic", test_package);
+  return g_test_run();
 }


### PR DESCRIPTION
## Summary
- rewrite `package_test` to use GLib's g_test framework so it emits TAP logs
- switch `analyser_test` to g_test to show logs and success output

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68b6f2a6af1c8328a2581ffe768792f1