### PR TITLE
Suspend auto-save during preferences load

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -207,3 +207,8 @@ ensuring the tree store updates on the UI thread.
 `editor_test` invoked `gtk_source_buffer_undo` on a new buffer even though the undo manager had no actions, causing a
 GtkSourceView assertion. The test now avoids calling `gtk_source_buffer_undo` and simply verifies the undo stack is
 empty, so pristine buffers no longer crash.
+
+## Preferences saved during load
+
+Loading preferences invoked the setter functions, which saved the configuration file for each key.
+Initialization now disables auto-saving while preferences are loaded, avoiding unnecessary writes.

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -14,11 +14,13 @@ struct _Preferences {
   gchar   *last_file;
   gint     cursor_position;
   GList   *recent_projects;
+  gboolean auto_save;
   gint     refcnt;
 };
 
 static void preferences_load(Preferences *self) {
   g_debug("preferences_load %s", self->filename);
+  self->auto_save = FALSE;
   GKeyFile *key_file = g_key_file_new();
   if (g_key_file_load_from_file(key_file, self->filename, G_KEY_FILE_NONE, NULL)) {
     char *sdk = g_key_file_get_string(key_file, "General", "sdk", NULL);
@@ -71,9 +73,12 @@ static void preferences_load(Preferences *self) {
   }
 
   g_key_file_free(key_file);
+  self->auto_save = TRUE;
 }
 
 static void preferences_save(Preferences *self) {
+  if (!self->auto_save)
+    return;
   g_debug("preferences_save project_file=%s", self->project_file);
   /* Ensure that the configuration directory exists */
   char *dir = g_path_get_dirname(self->filename);
@@ -141,6 +146,7 @@ preferences_new(const gchar *config_dir)
   self->window_height = 600;
   self->project_view_width = 200;
   self->cursor_position = 0;
+  self->auto_save = TRUE;
   preferences_load(self);
   return self;
 }

--- a/tests/preferences_test.c
+++ b/tests/preferences_test.c
@@ -140,6 +140,31 @@ test_set_window_size(void)
 }
 
 static void
+test_load_does_not_save(void)
+{
+  gchar *tmpdir = g_dir_make_tmp("prefs-test-XXXXXX", NULL);
+  gchar *cfgdir = g_build_filename(tmpdir, "glide", NULL);
+  g_mkdir_with_parents(cfgdir, 0700);
+  gchar *file = g_build_filename(cfgdir, "preferences.ini", NULL);
+  g_file_set_contents(file, "[General]\nsdk=foo\n", -1, NULL);
+  GStatBuf before;
+  GStatBuf after;
+  g_stat(file, &before);
+  g_usleep(1000000);
+  Preferences *prefs = preferences_new(tmpdir);
+  g_stat(file, &after);
+  g_assert_cmpint(before.st_mtime, ==, after.st_mtime);
+  g_assert_cmpstr(preferences_get_sdk(prefs), ==, "foo");
+  preferences_unref(prefs);
+  g_remove(file);
+  g_rmdir(cfgdir);
+  g_rmdir(tmpdir);
+  g_free(file);
+  g_free(cfgdir);
+  g_free(tmpdir);
+}
+
+static void
 test_recent_projects(void)
 {
   gchar *tmpdir = g_dir_make_tmp("prefs-test-XXXXXX", NULL);
@@ -181,15 +206,16 @@ test_recent_projects(void)
 int
 main(int argc, char *argv[])
 {
-    g_test_init(&argc, &argv, NULL);
+  g_test_init(&argc, &argv, NULL);
 
-    g_test_add_func("/preferences/defaults", test_defaults);
-    g_test_add_func("/preferences/set_sdk", test_set_sdk);
-    g_test_add_func("/preferences/set_project_dir", test_set_project_dir);
-    g_test_add_func("/preferences/set_project_view_width", test_set_project_view_width);
-    g_test_add_func("/preferences/set_window_size", test_set_window_size);
-    g_test_add_func("/preferences/recent_projects", test_recent_projects);
+  g_test_add_func("/preferences/defaults", test_defaults);
+  g_test_add_func("/preferences/set_sdk", test_set_sdk);
+  g_test_add_func("/preferences/set_project_dir", test_set_project_dir);
+  g_test_add_func("/preferences/set_project_view_width", test_set_project_view_width);
+  g_test_add_func("/preferences/set_window_size", test_set_window_size);
+  g_test_add_func("/preferences/load_does_not_save", test_load_does_not_save);
+  g_test_add_func("/preferences/recent_projects", test_recent_projects);
 
-    return g_test_run();
+  return g_test_run();
 }
 


### PR DESCRIPTION
## Summary
- prevent preference writes during initialization by adding an `auto_save` flag
- test that loading preferences leaves the config file untouched
- document the previous unnecessary save behavior

## Testing
- `cd src && make app-full`
- `cd tests && make run` *(fails: assertion in repl_session_test)*
- `./preferences_test`


------
https://chatgpt.com/codex/tasks/task_e_68b7036ae1f08328993111c7c12173f9