### PR TITLE
Handle file-local index updates

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -212,3 +212,9 @@ empty, so pristine buffers no longer crash.
 
 Loading preferences invoked the setter functions, which saved the configuration file for each key.
 Initialization now disables auto-saving while preferences are loaded, avoiding unnecessary writes.
+
+## project_file_changed cleared all indexes
+
+Editing a file reindexed the whole project and wiped out symbol information from other files.
+`project_file_changed` now scans existing indexes and removes only entries originating from the
+modified file, keeping definitions from untouched files intact.

--- a/src/asdf.c
+++ b/src/asdf.c
@@ -147,7 +147,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
   lisp_lexer_lex(lexer);
   LispParser *parser = lisp_parser_new();
   GArray *tokens = lisp_lexer_get_tokens(lexer);
-  lisp_parser_parse(parser, tokens);
+  lisp_parser_parse(parser, tokens, NULL);
 
   const Node *ast = lisp_parser_get_ast(parser);
   if (!ast)

--- a/src/lisp_parser.h
+++ b/src/lisp_parser.h
@@ -7,10 +7,11 @@
 G_BEGIN_DECLS
 
 typedef struct _LispParser LispParser;
+typedef struct _ProjectFile ProjectFile;
 
 LispParser *lisp_parser_new(void);
 void lisp_parser_free(LispParser *parser);
-void lisp_parser_parse(LispParser *parser, GArray *tokens);
+void lisp_parser_parse(LispParser *parser, GArray *tokens, ProjectFile *file);
 const Node *lisp_parser_get_ast(LispParser *parser);
 
 G_END_DECLS

--- a/src/node.c
+++ b/src/node.c
@@ -14,6 +14,14 @@ static void node_finalize(Node *node) {
   g_clear_pointer(&node->name, g_free);
 }
 
+Node *node_new(LispAstNodeType type, ProjectFile *file) {
+  Node *node = g_new0(Node, 1);
+  g_atomic_int_set(&node->ref, 1);
+  node->type = type;
+  node->file = file;
+  return node;
+}
+
 Node *node_ref(Node *node) {
   if (!node) return NULL;
   g_atomic_int_inc(&node->ref);

--- a/src/node.h
+++ b/src/node.h
@@ -25,6 +25,7 @@ typedef enum {
 } StringDesignatorType;
 
 typedef struct Node Node;
+typedef struct _ProjectFile ProjectFile;
 
 struct Node {
   LispAstNodeType type;
@@ -32,6 +33,7 @@ struct Node {
   const LispToken *end_token;
   Node *parent;
   GArray *children; /* Node* */
+  ProjectFile *file;
 
   StringDesignatorType sd_type;
   gint ref;
@@ -40,6 +42,7 @@ struct Node {
 };
 void node_set_sd_type(Node *node, StringDesignatorType sd_type, const gchar *package_context);
 
+Node *node_new(LispAstNodeType type, ProjectFile *file);
 Node *node_ref(Node *node);
 void node_unref(Node *node);
 gboolean node_is(const Node *node, StringDesignatorType t);

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -18,7 +18,7 @@ static void test_analyse(void) {
   lisp_lexer_lex(lexer);
   LispParser *parser = lisp_parser_new();
   GArray *tokens = lisp_lexer_get_tokens(lexer);
-  lisp_parser_parse(parser, tokens);
+  lisp_parser_parse(parser, tokens, NULL);
   Node *ast = (Node*)lisp_parser_get_ast(parser);
 
   Project *project = project_new(NULL);

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -15,7 +15,7 @@ static ParserFixture parser_fixture_from_text(const gchar *text) {
   lisp_lexer_lex(fixture.lexer);
   fixture.parser = lisp_parser_new();
   GArray *tokens = lisp_lexer_get_tokens(fixture.lexer);
-  lisp_parser_parse(fixture.parser, tokens);
+  lisp_parser_parse(fixture.parser, tokens, NULL);
   text_provider_unref(provider);
   return fixture;
 }


### PR DESCRIPTION
## Summary
- embed source ProjectFile on each AST node and provide constructor
- update parser to set node file and adjust parsing API
- prune project indexes by comparing node->file instead of scanning tokens

## Testing
- `make app-full`
- `make run` *(fails: repl_session_test.c assertion)*
- `tests/project_test`


------
https://chatgpt.com/codex/tasks/task_e_68b71aeea7c48328b61f8babc237aa18