### PR TITLE
Introduce verbosity-based logging

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -12,6 +12,7 @@
 #include "project_file.h"
 #include "lisp_source_notebook.h"
 #include "editor.h"
+#include "util.h"
 
 static gboolean app_maybe_save_all(App *self);
 static void show_parser(App *self);

--- a/src/app.c
+++ b/src/app.c
@@ -10,6 +10,7 @@
 #include "project_view.h"
 #include "menu_bar.h"
 #include "actions.h"
+#include "util.h"
 
 /* Signal handlers */
 STATIC void     on_notebook_paned_position(GObject *object, GParamSpec *pspec, gpointer data);

--- a/src/editor.c
+++ b/src/editor.c
@@ -1,6 +1,7 @@
 #include "editor.h"
 #include "gtk_text_provider.h"
 #include "project.h"
+#include "util.h"
 
 typedef struct {
   gsize start;

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -12,6 +12,7 @@
 #include "evaluate.h"
 #include "editor.h"
 #include "app.h"
+#include "util.h"
 
 /* ------------------------------------------------------------------------- */
 /* Callback triggered when the user requests evaluation of the current form. */

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -16,6 +16,7 @@
 #include "preferences.h"
 #include "asdf.h"
 #include "file_utilities.h"
+#include "util.h"
 
 static gboolean save_if_modified(App *app) {
   Project *project = app_get_project(app);

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -1,6 +1,7 @@
 #include "interactions_view.h"
 #include "interaction.h"
 #include "repl_session.h"
+#include "util.h"
 
 #define CSS_CLASS_OUTPUT "interaction-output"
 #define CSS_CLASS_ERROR  "interaction-error"

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,15 @@
 #include "repl_session.h"
 #include "project.h"
 #include "status_service.h"
+#include "util.h"
+
+static int verbosity = 1;
+
+int
+get_verbosity(void)
+{
+  return verbosity;
+}
 
 int
 main (int argc, char *argv[])

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -2,6 +2,7 @@
 #include "preferences.h"
 #include <glib/gstdio.h>
 #include <errno.h>
+#include "util.h"
 
 struct _Preferences {
   gchar   *filename;

--- a/src/project.c
+++ b/src/project.c
@@ -98,10 +98,10 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
         analyse_defpackage(project, expr, NULL);
         g_debug("project_on_package_definition built package %s", pkg_name);
       } else {
-        g_debug_160("project_on_package_definition failed, missing name in ", res);
+        g_debug_160(1, "project_on_package_definition failed, missing name in ", res);
       }
     } else {
-      g_debug_160("project_on_package_definition failed to parse ", res);
+      g_debug_160(1, "project_on_package_definition failed to parse ", res);
     }
     lisp_parser_free(parser);
     lisp_lexer_free(lexer);

--- a/src/project_file.c
+++ b/src/project_file.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <glib-object.h>
 #include "syscalls.h"
+#include "util.h"
 
 struct _ProjectFile {
   ProjectFileState state;

--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -5,6 +5,7 @@
 #include "asdf.h"
 #include "file_open.h"
 #include <glib/gstdio.h>
+#include "util.h"
 
 typedef struct {
   GtkEntry *name_entry;

--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -17,7 +17,7 @@ static void on_proc_out(GString *data, gpointer user_data) {
   ReplProcess *self = user_data;
   g_mutex_lock(&self->mutex);
   g_string_append_len(self->buffer, data->str, data->len);
-  g_debug_160("ReplProcess.on_proc_out added: ", data->str);
+  g_debug_160(2, "ReplProcess.on_proc_out added: ", data->str);
   while(TRUE) {
     while (self->buffer->len > 0 && self->buffer->str[0] == '\n') {
       g_string_erase(self->buffer, 0, 1);
@@ -52,14 +52,14 @@ static void on_proc_out(GString *data, gpointer user_data) {
       }
     }
     if (!complete) {
-      g_debug_160("ReplProcess.on_proc_out incomplete: ", self->buffer->str);
+      g_debug_160(2, "ReplProcess.on_proc_out incomplete: ", self->buffer->str);
       g_mutex_unlock(&self->mutex);
       return;
     }
     GString *line = g_string_new_len(self->buffer->str, i + 1);
     g_string_erase(self->buffer, 0, i + 1);
-    g_debug_160("ReplProcess.on_proc_out forwarding: ", line->str);
-    g_debug_160("ReplProcess.on_proc_out still in buffer: ", self->buffer->str);
+    g_debug_160(1, "ReplProcess.on_proc_out forwarding: ", line->str);
+    g_debug_160(1, "ReplProcess.on_proc_out still in buffer: ", self->buffer->str);
     g_mutex_unlock(&self->mutex);
     if (self->msg_cb)
       self->msg_cb(line, self->msg_cb_data);
@@ -122,7 +122,7 @@ void repl_process_start(ReplProcess *self) {
 gboolean repl_process_send(ReplProcess *self, const GString *payload) {
   g_return_val_if_fail(self, FALSE);
   g_return_val_if_fail(payload, FALSE);
-  g_debug_160("ReplProcess.send: ", payload->str);
+  g_debug_160(1, "ReplProcess.send: ", payload->str);
   gboolean success = process_write(self->proc, payload->str, payload->len);
   if (!success) {
     g_warning("ReplProcess.send failed to write to process");

--- a/src/repl_session.c
+++ b/src/repl_session.c
@@ -94,7 +94,7 @@ static gpointer repl_session_thread(gpointer data) {
     g_mutex_lock(&interaction->lock);
     expr = g_strdup(interaction->expression);
     g_mutex_unlock(&interaction->lock);
-    g_debug_160("ReplSession.thread eval ", expr);
+    g_debug_160(1, "ReplSession.thread eval ", expr);
     g_mutex_lock(&self->lock);
     if (!self->started) {
       repl_process_start(self->proc);
@@ -120,7 +120,7 @@ static gpointer repl_session_thread(gpointer data) {
     g_free(escaped);
     g_free(expr);
     g_free(cmd);
-    g_debug_160("ReplSession.thread send ", payload->str);
+    g_debug_160(1, "ReplSession.thread send ", payload->str);
     repl_process_send(self->proc, payload);
     g_string_free(payload, TRUE);
   }
@@ -134,7 +134,7 @@ void repl_session_eval(ReplSession *self, Interaction *interaction) {
     interaction->tag = g_atomic_int_add(&next_tag, 1);
     gchar *expr = g_strdup(interaction->expression);
     g_mutex_unlock(&interaction->lock);
-    g_debug_160("ReplSession.eval queue ", expr);
+    g_debug_160(1, "ReplSession.eval queue ", expr);
     g_async_queue_push(self->queue, interaction);
     g_free(expr);
   }
@@ -155,7 +155,7 @@ void repl_session_set_interaction_updated_cb(ReplSession *self, ReplSessionCallb
 void repl_session_on_message(GString *msg, gpointer user_data) {
   ReplSession *self = user_data ? (ReplSession*)user_data : NULL;
   const char *str = msg->str;
-  g_debug_160("ReplSession.on_message ", str);
+  g_debug_160(1, "ReplSession.on_message ", str);
   ReplSessionCallback updated_cb = NULL;
   gpointer updated_cb_data = NULL;
   InteractionCallback done_cb = NULL;
@@ -173,7 +173,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strstr(start, "\")");
       if (end) {
         gchar *text = g_strndup(start, end - start);
-        g_debug_160("ReplSession.on_message stdout: ", text);
+        g_debug_160(1, "ReplSession.on_message stdout: ", text);
         gchar *old = NULL;
         g_mutex_lock(&interaction->lock);
         old = interaction->output;
@@ -195,7 +195,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strstr(start, "\")");
       if (end) {
         gchar *text = g_strndup(start, end - start);
-        g_debug_160("ReplSession.on_message stderr: ", text);
+        g_debug_160(1, "ReplSession.on_message stderr: ", text);
         gchar *old = NULL;
         g_mutex_lock(&interaction->lock);
         old = interaction->output;
@@ -217,7 +217,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strrchr(start, ')');
       if (end) {
         gchar *res = g_strndup(start, end - start);
-        g_debug_160("ReplSession.on_message result: ", res);
+        g_debug_160(1, "ReplSession.on_message result: ", res);
         g_mutex_lock(&interaction->lock);
         interaction->result = g_strdup(res);
         interaction->status = INTERACTION_OK;
@@ -240,7 +240,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strrchr(start, '"');
       if (end) {
         gchar *err = g_strndup(start, end - start);
-        g_debug_160("ReplSession.on_message error: ", err);
+        g_debug_160(1, "ReplSession.on_message error: ", err);
         g_mutex_lock(&interaction->lock);
         interaction->error = g_strdup(err);
         interaction->status = INTERACTION_ERROR;

--- a/src/util.h
+++ b/src/util.h
@@ -2,14 +2,26 @@
 
 #include <glib.h>
 
-static inline void g_debug_160(const char *string, const char *msg)
+int get_verbosity(void);
+
+#undef g_debug
+#define LOG(level, ...) \
+    do { if (get_verbosity() >= (level)) \
+      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __VA_ARGS__); } while (0)
+
+#define g_debug(...) LOG(1, __VA_ARGS__)
+
+static inline void g_debug_160(int level, const char *string, const char *msg)
 {
-  char *escaped = g_strescape(msg, NULL);
-  size_t len = strlen(escaped);
-  if (len > 160)
-    g_debug("%s%.80s...%s", string, escaped, escaped + len - 80);
-  else
-    g_debug("%s%s", string, escaped);
-  g_free(escaped);
+  if (get_verbosity() >= level) {
+    char *escaped = g_strescape(msg, NULL);
+    size_t len = strlen(escaped);
+    if (len > 160)
+      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, "%s%.80s...%s", string,
+          escaped, escaped + len - 80);
+    else
+      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, "%s%s", string, escaped);
+    g_free(escaped);
+  }
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,43 +6,44 @@ endif
 VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
+COMMON = verbosity.c
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
 TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test project_test asdf_test analyser_test package_test status_service_test editor_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
 
-preferences_test: preferences_test.c preferences.c
+preferences_test: preferences_test.c preferences.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-process_test: process_test.c process.c
+process_test: process_test.c process.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-repl_process_test: repl_process_test.c process.c
+repl_process_test: repl_process_test.c process.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
+repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c
+lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c string_text_provider.c text_provider.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project.c asdf.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c
+project_test: project_test.c project.c asdf.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c repl_session.c repl_process.c process.c status_service.c
+asdf_test: asdf_test.c asdf.c string_text_provider.c text_provider.c lisp_lexer.c lisp_parser.c node.c package.c project.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c project.c asdf.c project_file.c repl_session.c repl_process.c process.c status_service.c
+analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c project.c asdf.c project_file.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-package_test: package_test.c package.c node.c
+package_test: package_test.c package.c node.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-status_service_test: status_service_test.c status_service.c
+status_service_test: status_service_test.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_test: editor_test.c editor.c gtk_text_provider.c project.c asdf.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c
+editor_test: editor_test.c editor.c gtk_text_provider.c project.c asdf.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all

--- a/tests/verbosity.c
+++ b/tests/verbosity.c
@@ -1,0 +1,7 @@
+#include "util.h"
+
+int
+get_verbosity(void)
+{
+  return 1;
+}


### PR DESCRIPTION
## Summary
- centralize logging with a LOG macro using an adjustable verbosity level
- gate long debug messages with g_debug_160 and per-call log levels
- ensure tests link by stubbing verbosity helper

## Testing
- `make app-full`
- `make run` *(fails: `ERROR:repl_session_test.c:39:test_eval: assertion failed (status == INTERACTION_OK): (1 == 2)`)*

------
https://chatgpt.com/codex/tasks/task_e_68b721494a3483288d48c6d71cdbf29e