### PR TITLE
Make repl_session_test independent of working directory

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -231,3 +231,11 @@ sorted alphabetically so entries appear in order.
 also removed packages known to the project but defined elsewhere like
 `COMMON-LISP`. The fix removes packages defined by the file being unindexed
 before clearing its package definitions so external packages remain.
+
+## `repl_session_test` required running from tests directory
+
+Executing `repl_session_test` from the repository root failed because the test
+added only `../src/` to ASDF's registry. Running the binary outside the `tests`
+directory left ASDF unable to find `glide.asd`. The test now checks both
+`../src/` and `src/`, registering whichever exists so it works from any
+directory.

--- a/tests/repl_session_test.c
+++ b/tests/repl_session_test.c
@@ -9,7 +9,9 @@ static void test_eval(void) {
   const gchar *argv[] = {
     "sbcl", "--noinform",
     "--eval", "(require :asdf)",
-    "--eval", "(pushnew (truename \"../src/\") asdf:*central-registry*)",
+    "--eval", "(let ((p (probe-file \"../src/\"))) (when p (pushnew p asdf:*central-registry*)))",
+    "--eval", "(let ((p (probe-file \"src/\"))) (when p (pushnew p asdf:*central-registry*)))",
+    "--eval", "(setf *load-verbose* nil *compile-verbose* nil)",
     "--eval", "(require :glide)",
     "--eval", "(glide:start-server)",
     NULL


### PR DESCRIPTION
## Summary
- ensure repl_session_test locates the `src` tree whether run from repo root or tests folder
- silence SBCL load/compile output so the test parses REPL messages reliably
- document the previous working-directory dependence in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`
- `./tests/repl_session_test`
- `cd tests && ./repl_session_test`


------
https://chatgpt.com/codex/tasks/task_e_68b778fa32048328982f16fc871489d4