### PR TITLE
Emit defpackage in package-definition

### DIFF
--- a/src/package-definition.lisp
+++ b/src/package-definition.lisp
@@ -1,17 +1,36 @@
 (in-package :glide)
 
 (defun package-definition (package-name)
-  (let ((pkg (find-package package-name)))
-    (when pkg
-      (list :name (package-name pkg)
-            :description (documentation pkg t)
-            :nicknames (package-nicknames pkg)
-            :uses (mapcar #'package-name (package-use-list pkg))
-            :exports (loop for sym being the external-symbols of pkg
-                           collect (symbol-name sym))
-            :shadows (mapcar #'symbol-name (package-shadowing-symbols pkg))
-            :import-from (loop for sym being the present-symbols of pkg
-                               for home = (symbol-package sym)
-                               unless (eq pkg home)
-                               collect (list (symbol-name sym)
-                                             (package-name home)))))))
+  (let ((package (find-package package-name)))
+    (when package
+      (let ((imports (make-hash-table :test 'equal)))
+        (loop for symbol being the present-symbols of package
+              for home-package = (symbol-package symbol)
+              unless (eq package home-package)
+                do (push (symbol-name symbol)
+                         (gethash (package-name home-package) imports)))
+        `(defpackage ,(package-name package)
+           ,@(let ((nicknames (package-nicknames package)))
+               (when nicknames
+                 `((:nicknames ,@nicknames))))
+           ,@(let ((uses (package-use-list package)))
+               (when uses
+                 `((:use ,@(mapcar #'package-name uses)))))
+           ,@(let ((shadows (package-shadowing-symbols package)))
+               (when shadows
+                 `((:shadow ,@(mapcar #'symbol-name shadows)))))
+           ,@(let ((forms '()))
+               (maphash (lambda (from-package symbols)
+                          (push (list* :import-from from-package
+                                       (nreverse symbols))
+                                forms))
+                        imports)
+               (nreverse forms))
+           ,@(let ((exports
+                    (loop for symbol being the external-symbols of package
+                          collect (symbol-name symbol))))
+               (when exports
+                 `((:export ,@exports))))
+           ,@(let ((description (documentation package t)))
+               (when description
+                 `((:documentation ,description)))))))))

--- a/src/project.c
+++ b/src/project.c
@@ -97,11 +97,11 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
     const Node *ast = lisp_parser_get_ast(parser);
     if (ast && ast->children && ast->children->len > 0) {
       Node *expr = g_array_index(ast->children, Node*, 0);
+      analyse_defpackage(project, expr, NULL);
       Node *name_node = (expr->children && expr->children->len > 1) ?
         g_array_index(expr->children, Node*, 1) : NULL;
       const gchar *pkg_name = node_get_name(name_node);
       if (pkg_name) {
-        analyse_defpackage(project, expr, NULL);
         g_debug("project_on_package_definition built package %s", pkg_name);
         Package *pkg = project_get_package(project, pkg_name);
         if (pkg && project->repl) {


### PR DESCRIPTION
## Summary
- generate proper `defpackage` form in `package-definition`
- parse package info using `analyse_defpackage` instead of ad-hoc logic

## Testing
- `make app-full`
- `make run` *(fails: ERROR:repl_session_test.c:39:test_eval: assertion failed (status == INTERACTION_OK): (1 == 2))*

------
https://chatgpt.com/codex/tasks/task_e_68b7f985ea888328b2f176ed166b9e30