### PR TITLE
Assert package definition parsing

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -260,3 +260,10 @@ still tagging their symbols.
 `analyse_defun` registered functions even when the form appeared inside other
 expressions. Functions are now added only when the `defun` is at the top level,
 while nested definitions are still analysed but not recorded in the project.
+
+## Package definition parsing only logged errors
+
+`project_on_package_definition` treated invalid REPL output as debug messages,
+making protocol bugs easy to miss. The handler now asserts that a result,
+parsable AST and package name are always returned, turning these conditions
+into detectable failures during development.


### PR DESCRIPTION
## Summary
- assert that package-definition replies always return a result, AST and name
- log entry to project_on_package_definition for easier tracing
- document package-definition assertion fix

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68b8562971f08328a56664946278208c