### PR TITLE
Raise default logging verbosity to level 2

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@
 #include "status_service.h"
 #include "util.h"
 
-static int verbosity = 1;
+static int verbosity = 2;
 
 int
 get_verbosity(void)

--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -17,7 +17,7 @@ static void on_proc_out(GString *data, gpointer user_data) {
   ReplProcess *self = user_data;
   g_mutex_lock(&self->mutex);
   g_string_append_len(self->buffer, data->str, data->len);
-  g_debug_160(2, "ReplProcess.on_proc_out added: ", data->str);
+  g_debug_160(3, "ReplProcess.on_proc_out added: ", data->str);
   while(TRUE) {
     while (self->buffer->len > 0 && self->buffer->str[0] == '\n') {
       g_string_erase(self->buffer, 0, 1);
@@ -52,14 +52,14 @@ static void on_proc_out(GString *data, gpointer user_data) {
       }
     }
     if (!complete) {
-      g_debug_160(2, "ReplProcess.on_proc_out incomplete: ", self->buffer->str);
+      g_debug_160(3, "ReplProcess.on_proc_out incomplete: ", self->buffer->str);
       g_mutex_unlock(&self->mutex);
       return;
     }
     GString *line = g_string_new_len(self->buffer->str, i + 1);
     g_string_erase(self->buffer, 0, i + 1);
-    g_debug_160(1, "ReplProcess.on_proc_out forwarding: ", line->str);
-    g_debug_160(1, "ReplProcess.on_proc_out still in buffer: ", self->buffer->str);
+    g_debug_160(2, "ReplProcess.on_proc_out forwarding: ", line->str);
+    g_debug_160(2, "ReplProcess.on_proc_out still in buffer: ", self->buffer->str);
     g_mutex_unlock(&self->mutex);
     if (self->msg_cb)
       self->msg_cb(line, self->msg_cb_data);

--- a/src/repl_session.c
+++ b/src/repl_session.c
@@ -155,7 +155,7 @@ void repl_session_set_interaction_updated_cb(ReplSession *self, ReplSessionCallb
 void repl_session_on_message(GString *msg, gpointer user_data) {
   ReplSession *self = user_data ? (ReplSession*)user_data : NULL;
   const char *str = msg->str;
-  g_debug_160(1, "ReplSession.on_message ", str);
+  g_debug_160(2, "ReplSession.on_message ", str);
   while (*str && *str != '(') {
     if (*str == ';') {
       const char *nl = strchr(str, '\n');
@@ -185,7 +185,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strstr(start, "\")");
       if (end) {
         gchar *text = g_strndup(start, end - start);
-        g_debug_160(1, "ReplSession.on_message stdout: ", text);
+        g_debug_160(2, "ReplSession.on_message stdout: ", text);
         gchar *old = NULL;
         g_mutex_lock(&interaction->lock);
         old = interaction->output;
@@ -207,7 +207,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strstr(start, "\")");
       if (end) {
         gchar *text = g_strndup(start, end - start);
-        g_debug_160(1, "ReplSession.on_message stderr: ", text);
+        g_debug_160(2, "ReplSession.on_message stderr: ", text);
         gchar *old = NULL;
         g_mutex_lock(&interaction->lock);
         old = interaction->output;
@@ -229,7 +229,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strrchr(start, ')');
       if (end) {
         gchar *res = g_strndup(start, end - start);
-        g_debug_160(1, "ReplSession.on_message result: ", res);
+        g_debug_160(2, "ReplSession.on_message result: ", res);
         g_mutex_lock(&interaction->lock);
         interaction->result = g_strdup(res);
         interaction->status = INTERACTION_OK;
@@ -252,7 +252,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       const char *end = strrchr(start, '"');
       if (end) {
         gchar *err = g_strndup(start, end - start);
-        g_debug_160(1, "ReplSession.on_message error: ", err);
+        g_debug_160(2, "ReplSession.on_message error: ", err);
         g_mutex_lock(&interaction->lock);
         interaction->error = g_strdup(err);
         interaction->status = INTERACTION_ERROR;

--- a/tests/verbosity.c
+++ b/tests/verbosity.c
@@ -3,5 +3,5 @@
 int
 get_verbosity(void)
 {
-  return 1;
+  return 2;
 }


### PR DESCRIPTION
## Summary
- Promote REPL session message logs to level 2 for better visibility
- Reduce noise from REPL process output by shifting detailed logs to level 3
- Default application verbosity bumped to level 2 and tests updated accordingly

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b8766bd5048328b7edfe306f1c1061