### PR TITLE
Fix leak in project view selection handler

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -276,3 +276,11 @@ the entire buffer back to Glide. SBCL supplied fixed-size strings padded with
 of output filled with NUL characters. The method now respects the slice before
 forwarding, preventing padded NULs from ever reaching `Process` or
 `ReplProcess`.
+
+## Project view selection leaked strings
+
+Selecting rows in the project viewer leaked memory because the selection handler
+retrieved the object's value before verifying the row type. `gtk_tree_model_get`
+duplicated the underlying data for non-component rows, and the copies were never
+freed. The handler now queries the row kind first and only fetches the object
+for component rows, closing the leak.

--- a/src/app.c
+++ b/src/app.c
@@ -299,15 +299,20 @@ on_project_view_selection_changed(GtkTreeSelection *selection, gpointer data)
   GtkTreeIter iter;
   if (!gtk_tree_selection_get_selected(selection, &model, &iter))
     return;
+
   gint kind = 0;
-  gpointer obj = NULL;
   gtk_tree_model_get(model, &iter,
       PROJECT_VIEW_COL_KIND, &kind,
-      PROJECT_VIEW_COL_OBJECT, &obj,
       -1);
-  if (kind != PROJECT_VIEW_KIND_COMPONENT || !obj)
+  if (kind != PROJECT_VIEW_KIND_COMPONENT)
     return;
-  ProjectFile *file = obj;
+
+  ProjectFile *file = NULL;
+  gtk_tree_model_get(model, &iter,
+      PROJECT_VIEW_COL_OBJECT, &file,
+      -1);
+  if (!file)
+    return;
   guint count = project_get_file_count(self->project);
   for (guint i = 0; i < count; i++) {
     if (project_get_file(self->project, i) == file) {


### PR DESCRIPTION
## Summary
- avoid leaking memory when selecting project view rows by querying kind before fetching object
- document the project view selection leak

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68bd8c26e48c83289364d9a3b8acc746