### PR TITLE
Use debug logging instead of message

### DIFF
--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -138,9 +138,10 @@ static void project_handle_special_variable(Project *project,
       }
     }
   }
-  g_message("describe %s special variable type=%s value=%s doc=%s",
-      symbol, declared_type ? declared_type : "(unknown)",
-      value ? value : "(unknown)", doc ? doc->str : "");
+  g_debug("describe %s special variable type=%s value=%s", symbol,
+      declared_type ? declared_type : "(unknown)",
+      value ? value : "(unknown)");
+  g_debug_160(1, "↳ doc: ", doc ? doc->str : "");
   project_add_variable(project, package, symbol, doc ? doc->str : NULL);
   g_free(declared_type);
   g_free(value);
@@ -173,8 +174,9 @@ static void project_handle_compiled_function(Project *project,
       }
     }
   }
-  g_message("describe %s compiled function lambda=%s doc=%s", symbol,
-      lambda_list ? lambda_list : "(unknown)", doc ? doc->str : "");
+  g_debug("describe %s compiled function lambda=%s", symbol,
+      lambda_list ? lambda_list : "(unknown)");
+  g_debug_160(1, "↳ doc: ", doc ? doc->str : "");
   Function *function = function_new(NULL, NULL, doc ? doc->str : NULL,
       NULL, FUNCTION_KIND_FUNCTION, symbol, package);
   project_add_function(project, function);
@@ -210,7 +212,7 @@ static void project_on_describe(Interaction *interaction, gpointer user_data) {
     if (section->len == 0)
       continue;
     const gchar *first_line = g_ptr_array_index(section, 0);
-    g_message("describe %s section: %s", data->symbol, first_line);
+    g_debug("describe %s section: %s", data->symbol, first_line);
     if (g_str_has_suffix(first_line, "names a special variable:")) {
       project_handle_special_variable(data->project, data->package_name,
           data->symbol, section);

--- a/src/repl_session.c
+++ b/src/repl_session.c
@@ -266,7 +266,7 @@ void repl_session_on_message(GString *msg, gpointer user_data) {
       }
     }
   } else {
-    g_message("ReplSession.on_message unknown message: %s", str);
+    g_debug_160(1, "ReplSession.on_message unknown message: ", str);
   }
   g_mutex_unlock(&self->lock);
   if (updated_cb)


### PR DESCRIPTION
## Summary
- use `g_debug_160` for describe outputs to avoid flooding logs with long documentation
- switch remaining `g_message` calls to `g_debug`
- log documentation strings in separate messages to avoid temporary buffers
- prefix documentation logs with `↳` to mark them as continuations

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68bd94bfb5a48328bec91adbbb9a53f5