### PR TITLE
Use generic project change callback

### DIFF
--- a/src/project.h
+++ b/src/project.h
@@ -14,14 +14,14 @@ typedef struct _ReplSession ReplSession;
 
 typedef void (*ProjectFileLoadedCb)(Project *self, ProjectFile *file, gpointer user_data);
 typedef void (*ProjectFileRemovedCb)(Project *self, ProjectFile *file, gpointer user_data);
-typedef void (*ProjectPackageAddedCb)(Project *self, Package *package, gpointer user_data);
+typedef void (*ProjectChangedCb)(Project *self, gpointer user_data);
 
 Project       *project_new(ReplSession *repl);
 Project       *project_ref(Project *self);
 void           project_unref(Project *self);
 void           project_set_file_loaded_cb(Project *self, ProjectFileLoadedCb cb, gpointer user_data);
 void           project_set_file_removed_cb(Project *self, ProjectFileRemovedCb cb, gpointer user_data);
-void           project_set_package_added_cb(Project *self, ProjectPackageAddedCb cb, gpointer user_data);
+void           project_set_changed_cb(Project *self, ProjectChangedCb cb, gpointer user_data);
 ProjectFile   *project_get_file(Project *self, guint index);
 guint          project_get_file_count(Project *self);
 ProjectFile   *project_add_file(Project *self, TextProvider *provider,
@@ -48,4 +48,5 @@ void           project_add_variable(Project *self, const gchar *package,
 const gchar   *project_get_variable(Project *self, const gchar *name);
 gchar        **project_get_variable_names(Project *self, const gchar *package,
     guint *length);
+void           project_changed(Project *self);
 

--- a/src/project_priv.h
+++ b/src/project_priv.h
@@ -12,8 +12,8 @@ struct _Project {
   gpointer file_loaded_data;
   ProjectFileRemovedCb file_removed_cb;
   gpointer file_removed_data;
-  ProjectPackageAddedCb package_added_cb;
-  gpointer package_added_data;
+  ProjectChangedCb changed_cb;
+  gpointer changed_data;
   Asdf *asdf; /* owned, nullable */
   ReplSession *repl;
   gchar *path;

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -217,17 +217,17 @@ static void test_remove_file(void)
   project_unref(project);
 }
 
-static void on_pkg_added(Project * /*project*/, Package * /*package*/, gpointer user_data)
+static void on_project_changed(Project * /*project*/, gpointer user_data)
 {
   int *count = user_data;
   (*count)++;
 }
 
-static void test_package_added_cb(void)
+static void test_project_changed_cb(void)
 {
   Project *project = project_new(NULL);
   int count = 0;
-  project_set_package_added_cb(project, on_pkg_added, &count);
+  project_set_changed_cb(project, on_project_changed, &count);
   Package *pkg = package_new("FOO");
   project_add_package(project, pkg);
   package_unref(pkg);
@@ -249,6 +249,6 @@ int main(int argc, char *argv[])
   g_test_add_func("/project/incremental_index", test_incremental_index);
   g_test_add_func("/project/relative_path", test_relative_path);
   g_test_add_func("/project/remove_file", test_remove_file);
-  g_test_add_func("/project/package_added_cb", test_package_added_cb);
+  g_test_add_func("/project/project_changed_cb", test_project_changed_cb);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- Replace package-specific callback with generic `ProjectChangedCb`
- Notify project view via `project_set_changed_cb` and repopulate on any change
- Test generic project change notifications

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68bda053a83483288360214c54f9d975