### PR TITLE
Ensure process_write handles partial writes

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -291,3 +291,10 @@ for component rows, closing the leak.
 signalled a change. Rapid successive signals therefore triggered redundant
 updates. The callback now starts a 10 ms timer and performs the refresh once it
 fires, coalescing intermediate signals.
+
+## Process write could drop data
+
+`process_write` performed a single `write` call and considered any short write
+an error. Pipes may legally return fewer bytes than requested, truncating data
+sent to child processes. The function now loops until the entire buffer is
+written so partial writes no longer lose input.

--- a/src/process.c
+++ b/src/process.c
@@ -126,7 +126,14 @@ gboolean process_write(Process *process, const gchar *data, gssize len) {
   g_return_val_if_fail(process, FALSE);
   if (len < 0)
     len = strlen(data);
-  return sys_write(process->in_fd, data, len) == len;
+  gssize written = 0;
+  while (written < len) {
+    ssize_t r = sys_write(process->in_fd, data + written, len - written);
+    if (r <= 0)
+      return FALSE;
+    written += r;
+  }
+  return TRUE;
 }
 
 Process *process_new_from_argv(const gchar *const *argv) {

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -1,6 +1,39 @@
 #include "process.h"
 #include <glib.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+struct _Process {
+  GPid pid;
+  int refcnt;
+  int in_fd;
+  int out_fd;
+  int err_fd;
+  GThread *out_thread;
+  GThread *err_thread;
+  ProcessCallback out_cb;
+  gpointer out_user;
+  ProcessCallback err_cb;
+  gpointer err_user;
+  gchar **argv;
+  gboolean started;
+};
+
+static int intercept_fd = -1;
+static int write_calls;
+static gssize write_sizes[2];
+
+ssize_t write(int fd, const void *buf, size_t count) {
+  if (fd == intercept_fd) {
+    write_sizes[write_calls] = count;
+    write_calls++;
+    if (write_calls == 1)
+      return count / 2;
+    return count;
+  }
+  return syscall(SYS_write, fd, buf, count);
+}
 
 static GString *output;
 
@@ -52,10 +85,24 @@ static void test_lisp_no_padding(void) {
   g_string_free(output, TRUE);
 }
 
+static void test_partial_write(void) {
+  struct _Process p = {0};
+  intercept_fd = 99;
+  p.in_fd = intercept_fd;
+  write_calls = 0;
+  gboolean ok = process_write(&p, "abcdef", 6);
+  g_assert_true(ok);
+  g_assert_cmpint(write_calls, ==, 2);
+  g_assert_cmpint(write_sizes[0], ==, 6);
+  g_assert_cmpint(write_sizes[1], ==, 3);
+  intercept_fd = -1;
+}
+
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/process/bc", test_bc);
   g_test_add_func("/process/no_callbacks", test_no_callbacks);
   g_test_add_func("/process/lisp_no_padding", test_lisp_no_padding);
+  g_test_add_func("/process/partial_write", test_partial_write);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- Fix `process_write` to retry until all bytes are written
- Test partial writes via a stubbed `write`
- Document the bug in `BUGS.md`

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68bf4fd36dd08328baf8012f100d887f