### PR TITLE
Use GString for interaction fields

### DIFF
--- a/src/interaction.h
+++ b/src/interaction.h
@@ -20,13 +20,13 @@ typedef enum {
 
 struct _Interaction {
   GMutex lock;
-  gchar *expression;
+  GString *expression;
   guint32 tag;
   InteractionStatus status;
   InteractionType type;
-  gchar *result;
-  gchar *output;
-  gchar *error;
+  GString *result;
+  GString *output;
+  GString *error;
   InteractionCallback done_cb;
   gpointer done_cb_data;
 };
@@ -34,7 +34,7 @@ struct _Interaction {
 static inline void interaction_init(Interaction *self, const gchar *expr) {
   g_mutex_init(&self->lock);
   g_mutex_lock(&self->lock);
-  self->expression = g_strdup(expr);
+  self->expression = g_string_new(expr);
   self->tag = 0;
   self->status = INTERACTION_CREATED;
   self->type = INTERACTION_USER;
@@ -48,10 +48,14 @@ static inline void interaction_init(Interaction *self, const gchar *expr) {
 
 static inline void interaction_clear(Interaction *self) {
   g_mutex_lock(&self->lock);
-  g_free(self->expression);
-  g_free(self->result);
-  g_free(self->output);
-  g_free(self->error);
+  if (self->expression)
+    g_string_free(self->expression, TRUE);
+  if (self->result)
+    g_string_free(self->result, TRUE);
+  if (self->output)
+    g_string_free(self->output, TRUE);
+  if (self->error)
+    g_string_free(self->error, TRUE);
   self->done_cb = NULL;
   self->done_cb_data = NULL;
   g_mutex_unlock(&self->lock);

--- a/src/interactions_view.c
+++ b/src/interactions_view.c
@@ -85,10 +85,10 @@ interaction_row_update(InteractionRow *row, Interaction *interaction)
   gchar *error;
   gchar *result;
   g_mutex_lock(&interaction->lock);
-  expression = g_strdup(interaction->expression);
-  output = g_strdup(interaction->output);
-  error = g_strdup(interaction->error);
-  result = g_strdup(interaction->result);
+  expression = interaction->expression ? g_strdup(interaction->expression->str) : NULL;
+  output = interaction->output ? g_strdup(interaction->output->str) : NULL;
+  error = interaction->error ? g_strdup(interaction->error->str) : NULL;
+  result = interaction->result ? g_strdup(interaction->result->str) : NULL;
   g_mutex_unlock(&interaction->lock);
   LOG(1, "InteractionsView.row_update %s", expression);
   set_text_view(GTK_BOX(row->box), &row->expression,
@@ -114,7 +114,7 @@ interaction_row_ensure(InteractionsView *self, Interaction *interaction)
   if (!row) {
     gchar *expr;
     g_mutex_lock(&interaction->lock);
-    expr = g_strdup(interaction->expression);
+    expr = interaction->expression ? g_strdup(interaction->expression->str) : NULL;
     g_mutex_unlock(&interaction->lock);
     LOG(1, "InteractionsView.interaction_row_ensure creating row for %s", expr);
     row = g_new0(InteractionRow, 1);
@@ -153,7 +153,7 @@ dispatch_interaction_added(gpointer data)
   gchar *expr;
   InteractionType type;
   g_mutex_lock(&interaction->lock);
-  expr = g_strdup(interaction->expression);
+  expr = interaction->expression ? g_strdup(interaction->expression->str) : NULL;
   type = interaction->type;
   g_mutex_unlock(&interaction->lock);
   LOG(1, "InteractionsView.on_interaction_added %s", expr);
@@ -177,7 +177,7 @@ dispatch_interaction_updated(gpointer data)
   Interaction *interaction = d->interaction;
   gchar *expr;
   g_mutex_lock(&interaction->lock);
-  expr = g_strdup(interaction->expression);
+  expr = interaction->expression ? g_strdup(interaction->expression->str) : NULL;
   g_mutex_unlock(&interaction->lock);
   LOG(1, "InteractionsView.on_interaction_updated %s", expr);
   InteractionRow *row = interaction_row_ensure(self, interaction);

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -66,7 +66,7 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
   gchar *res = NULL;
   g_mutex_lock(&interaction->lock);
   if (interaction->result)
-    res = g_strdup(interaction->result);
+    res = g_strdup(interaction->result->str);
   g_mutex_unlock(&interaction->lock);
   g_assert(res);
   TextProvider *provider = string_text_provider_new(res);
@@ -190,7 +190,7 @@ static void project_on_describe(Interaction *interaction, gpointer user_data) {
   gchar *out = NULL;
   g_mutex_lock(&interaction->lock);
   if (interaction->output)
-    out = g_strdup(interaction->output);
+    out = g_strdup(interaction->output->str);
   g_mutex_unlock(&interaction->lock);
   g_return_if_fail(out);
   gchar **lines = g_strsplit(out, "\n", -1);

--- a/tests/repl_session_test.c
+++ b/tests/repl_session_test.c
@@ -36,7 +36,7 @@ static void test_eval(void) {
   }
   g_mutex_lock(&interaction.lock);
   InteractionStatus status = interaction.status;
-  gchar *result = g_strdup(interaction.result);
+  gchar *result = interaction.result ? g_strdup(interaction.result->str) : NULL;
   g_mutex_unlock(&interaction.lock);
   g_assert_cmpint(status, ==, INTERACTION_OK);
   g_assert_cmpstr(result, ==, "3");
@@ -76,7 +76,8 @@ static void test_ignore_compilation_comment(void) {
   g_string_free(msg, TRUE);
   g_mutex_lock(&interaction.lock);
   g_assert_cmpint(interaction.status, ==, INTERACTION_OK);
-  g_assert_cmpstr(interaction.result, ==, "42");
+  g_assert(interaction.result);
+  g_assert_cmpstr(interaction.result->str, ==, "42");
   g_mutex_unlock(&interaction.lock);
   interaction_clear(&interaction);
   repl_session_unref(sess);


### PR DESCRIPTION
## Summary
- Replace raw `char*` fields in `Interaction` with `GString` for expression, result, output, and error.
- Update `ReplSession` and related components to build and append to these `GString` buffers.
- Adjust unit tests for the new `GString`-based API.

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68bfe2d4b33c832883aee122f821d654