### PR TITLE
Accept GString in process_write

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -122,13 +122,14 @@ void process_start(Process *process) {
     process->err_thread = g_thread_new("process-stderr", stderr_thread, process);
 }
 
-gboolean process_write(Process *process, const gchar *data, gssize len) {
+gboolean process_write(Process *process, const GString *data) {
   g_return_val_if_fail(process, FALSE);
-  if (len < 0)
-    len = strlen(data);
+  g_return_val_if_fail(data, FALSE);
+  gssize len = data->len;
   gssize written = 0;
   while (written < len) {
-    ssize_t r = sys_write(process->in_fd, data + written, len - written);
+    ssize_t r = sys_write(process->in_fd,
+        data->str + written, len - written);
     if (r <= 0)
       return FALSE;
     written += r;

--- a/src/process.h
+++ b/src/process.h
@@ -11,6 +11,6 @@ Process *process_new_from_argv(const gchar *const *argv);
 void     process_set_stdout_cb(Process *self, ProcessCallback cb, gpointer user_data);
 void     process_set_stderr_cb(Process *self, ProcessCallback cb, gpointer user_data);
 void     process_start(Process *self);
-gboolean process_write(Process *self, const gchar *data, gssize len);
+gboolean process_write(Process *self, const GString *data);
 Process *process_ref(Process *self);
 void     process_unref(Process *self);

--- a/src/repl_process.c
+++ b/src/repl_process.c
@@ -123,7 +123,7 @@ gboolean repl_process_send(ReplProcess *self, const GString *payload) {
   g_return_val_if_fail(self, FALSE);
   g_return_val_if_fail(payload, FALSE);
   LOG_LONG(1, "ReplProcess.send: ", payload->str);
-  gboolean success = process_write(self->proc, payload->str, payload->len);
+  gboolean success = process_write(self->proc, payload);
   if (!success) {
     g_warning("ReplProcess.send failed to write to process");
   }

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -47,10 +47,14 @@ static void test_bc(void) {
   output = g_string_new(NULL);
   process_set_stdout_cb(p, on_out, NULL);
   process_start(p);
-  process_write(p, "1+2\n", -1);
+  GString *cmd = g_string_new("1+2\n");
+  process_write(p, cmd);
+  g_string_free(cmd, TRUE);
   g_usleep(100000);
   g_assert_nonnull(strstr(output->str, "3"));
-  process_write(p, "quit\n", -1);
+  cmd = g_string_new("quit\n");
+  process_write(p, cmd);
+  g_string_free(cmd, TRUE);
   process_unref(p);
   g_string_free(output, TRUE);
 }
@@ -59,9 +63,13 @@ static void test_no_callbacks(void) {
   Process *p = process_new("/usr/bin/bc");
   g_assert_nonnull(p);
   process_start(p);
-  process_write(p, "1+2\n", -1);
+  GString *cmd = g_string_new("1+2\n");
+  process_write(p, cmd);
+  g_string_free(cmd, TRUE);
   g_usleep(100000);
-  process_write(p, "quit\n", -1);
+  cmd = g_string_new("quit\n");
+  process_write(p, cmd);
+  g_string_free(cmd, TRUE);
   process_unref(p);
 }
 
@@ -76,11 +84,14 @@ static void test_lisp_no_padding(void) {
   output = g_string_new(NULL);
   process_set_stdout_cb(p, on_out, NULL);
   process_start(p);
-  process_write(p,
-      "(glide:eval-and-capture 1 \"(format t \"ok\")\")\n", -1);
+  GString *cmd = g_string_new("(glide:eval-and-capture 1 \"(format t \"ok\")\")\n");
+  process_write(p, cmd);
+  g_string_free(cmd, TRUE);
   g_usleep(300000);
   g_assert_null(memchr(output->str, '\0', output->len));
-  process_write(p, "(sb-ext:quit)\n", -1);
+  cmd = g_string_new("(sb-ext:quit)\n");
+  process_write(p, cmd);
+  g_string_free(cmd, TRUE);
   process_unref(p);
   g_string_free(output, TRUE);
 }
@@ -90,7 +101,9 @@ static void test_partial_write(void) {
   intercept_fd = 99;
   p.in_fd = intercept_fd;
   write_calls = 0;
-  gboolean ok = process_write(&p, "abcdef", 6);
+  GString *cmd = g_string_new_len("abcdef", 6);
+  gboolean ok = process_write(&p, cmd);
+  g_string_free(cmd, TRUE);
   g_assert_true(ok);
   g_assert_cmpint(write_calls, ==, 2);
   g_assert_cmpint(write_sizes[0], ==, 6);


### PR DESCRIPTION
## Summary
- allow `process_write` to accept a `GString` directly
- forward `GString` payload from `repl_process_send` without converting
- adjust process tests to send commands as `GString`

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68bfe6b8f02c8328ae36e5c12ed2a050