### PR TITLE
Refactor asdf_to_string to return GString

### DIFF
--- a/src/asdf.c
+++ b/src/asdf.c
@@ -224,7 +224,7 @@ static char *get_system_name(Asdf *self) {
   return base;
 }
 
-char *asdf_to_string(Asdf *self) {
+GString *asdf_to_string(Asdf *self) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
   GString *out = g_string_new(NULL);
   gchar *name = get_system_name(self);
@@ -254,14 +254,14 @@ char *asdf_to_string(Asdf *self) {
     g_string_append(out, ")\n");
   }
   g_string_append(out, ")\n");
-  return g_string_free(out, FALSE);
+  return out;
 }
 
 gboolean asdf_save(Asdf *self, const gchar *filename) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), FALSE);
-  gchar *text = asdf_to_string(self);
-  gboolean ok = g_file_set_contents(filename, text, -1, NULL);
-  g_free(text);
+  GString *text = asdf_to_string(self);
+  gboolean ok = g_file_set_contents(filename, text->str, text->len, NULL);
+  g_string_free(text, TRUE);
   return ok;
 }
 

--- a/src/asdf.h
+++ b/src/asdf.h
@@ -22,7 +22,7 @@ void asdf_rename_component(Asdf *self, const gchar *old_file, const gchar *new_f
 void asdf_add_dependency(Asdf *self, const gchar *dep);
 const gchar *asdf_get_dependency(Asdf *self, guint index);
 guint asdf_get_dependency_count(Asdf *self);
-char *asdf_to_string(Asdf *self);
+GString *asdf_to_string(Asdf *self);
 gboolean asdf_save(Asdf *self, const gchar *filename);
 
 G_END_DECLS

--- a/tests/asdf_test.c
+++ b/tests/asdf_test.c
@@ -19,9 +19,9 @@ static void test_parse(void)
   g_assert_cmpstr(asdf_get_dependency(asdf, 0), ==, "dep1");
   g_assert_cmpstr(asdf_get_dependency(asdf, 1), ==, "dep2");
 
-  gchar *str = asdf_to_string(asdf);
-  g_assert_nonnull(strstr(str, "(:file \"a\")"));
-  g_free(str);
+  GString *str = asdf_to_string(asdf);
+  g_assert_nonnull(strstr(str->str, "(:file \"a\")"));
+  g_string_free(str, TRUE);
 
   g_object_unref(asdf);
   g_remove(file);


### PR DESCRIPTION
## Summary
- refactor asdf_to_string to return a GString instead of a char*
- update asdf_save and tests to work with GString without extra conversion

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68bfe6b8f02c8328ae36e5c12ed2a050