### PR TITLE
Use GString for component name generation

### DIFF
--- a/src/file_new.c
+++ b/src/file_new.c
@@ -1,5 +1,4 @@
 #include <gtk/gtk.h>
-#include <string.h>
 #include "file_new.h"
 #include "app.h"
 #include "project.h"
@@ -41,13 +40,13 @@ void file_new(GtkWidget */*widget*/, gpointer data) {
           app_connect_editor(app, view);
         Asdf *asdf = project_get_asdf(project);
         const gchar *rel = project_file_get_relative_path(file);
-        gchar *comp = g_strdup(rel);
-        if (g_str_has_suffix(comp, ".lisp"))
-          comp[strlen(comp) - 5] = '\0';
-        asdf_add_component(asdf, comp);
+        GString *comp = g_string_new(rel);
+        if (g_str_has_suffix(comp->str, ".lisp"))
+          g_string_truncate(comp, comp->len - 5);
+        asdf_add_component(asdf, comp->str);
         asdf_save(asdf, asdf_get_filename(asdf));
         app_update_project_view(app);
-        g_free(comp);
+        g_string_free(comp, TRUE);
       }
       g_free(path);
       g_free(fname);


### PR DESCRIPTION
## Summary
- replace manual strlen-based truncation with GString in file_new
- survey all uses of strlen; convert component creation to GLib style

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68bfeca7aa248328be36175397f6972f