### PR TITLE
Convert Asdf strings to GString

### DIFF
--- a/src/asdf.c
+++ b/src/asdf.c
@@ -6,14 +6,15 @@
 
 struct _Asdf {
   GObject parent_instance;
-  gchar *filename;
-  gchar *description;
+  GString *filename;
+  GString *description;
   gboolean serial;
-  GPtrArray *components; /* gchar* */
-  GPtrArray *depends_on; /* gchar* */
+  GPtrArray *components; /* GString* */
+  GPtrArray *depends_on; /* GString* */
 };
 
 static void asdf_finalize(GObject *object);
+static void g_string_free_full(gpointer data);
 
 G_DEFINE_TYPE(Asdf, asdf, G_TYPE_OBJECT)
 
@@ -26,14 +27,16 @@ static void asdf_init(Asdf *self) {
   self->filename = NULL;
   self->description = NULL;
   self->serial = FALSE;
-  self->components = g_ptr_array_new_with_free_func(g_free);
-  self->depends_on = g_ptr_array_new_with_free_func(g_free);
+  self->components = g_ptr_array_new_with_free_func(g_string_free_full);
+  self->depends_on = g_ptr_array_new_with_free_func(g_string_free_full);
 }
 
 static void asdf_finalize(GObject *object) {
   Asdf *self = GLIDE_ASDF(object);
-  g_free(self->filename);
-  g_free(self->description);
+  if (self->filename)
+    g_string_free(self->filename, TRUE);
+  if (self->description)
+    g_string_free(self->description, TRUE);
   if (self->components)
     g_ptr_array_free(self->components, TRUE);
   if (self->depends_on)
@@ -47,29 +50,30 @@ Asdf *asdf_new(void) {
 
 static void parse_file_contents(Asdf *self, const gchar *contents);
 
-Asdf *asdf_new_from_file(const gchar *filename) {
+Asdf *asdf_new_from_file(GString *filename) {
   Asdf *self = asdf_new();
-  self->filename = g_strdup(filename);
+  self->filename = filename;
   gchar *contents = NULL;
-  if (g_file_get_contents(filename, &contents, NULL, NULL)) {
+  if (g_file_get_contents(filename->str, &contents, NULL, NULL)) {
     parse_file_contents(self, contents);
     g_free(contents);
   }
   return self;
 }
 
-const gchar *asdf_get_filename(Asdf *self) {
+const GString *asdf_get_filename(Asdf *self) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
   return self->filename;
 }
 
-void asdf_set_description(Asdf *self, const gchar *description) {
+void asdf_set_description(Asdf *self, GString *description) {
   g_return_if_fail(GLIDE_IS_ASDF(self));
-  g_free(self->description);
-  self->description = g_strdup(description);
+  if (self->description)
+    g_string_free(self->description, TRUE);
+  self->description = description;
 }
 
-const gchar *asdf_get_description(Asdf *self) {
+const GString *asdf_get_description(Asdf *self) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
   return self->description;
 }
@@ -84,12 +88,12 @@ gboolean asdf_get_serial(Asdf *self) {
   return self->serial;
 }
 
-void asdf_add_component(Asdf *self, const gchar *file) {
+void asdf_add_component(Asdf *self, GString *file) {
   g_return_if_fail(GLIDE_IS_ASDF(self));
-  g_ptr_array_add(self->components, g_strdup(file));
+  g_ptr_array_add(self->components, file);
 }
 
-const gchar *asdf_get_component(Asdf *self, guint index) {
+const GString *asdf_get_component(Asdf *self, guint index) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
   if (index >= self->components->len)
     return NULL;
@@ -101,35 +105,35 @@ uint asdf_get_component_count(Asdf *self) {
   return self->components->len;
 }
 
-void asdf_remove_component(Asdf *self, const gchar *file) {
+void asdf_remove_component(Asdf *self, const GString *file) {
   g_return_if_fail(GLIDE_IS_ASDF(self));
   for (guint i = 0; i < self->components->len; i++) {
-    gchar *comp = g_ptr_array_index(self->components, i);
-    if (g_strcmp0(comp, file) == 0) {
+    GString *comp = g_ptr_array_index(self->components, i);
+    if (g_strcmp0(comp->str, file->str) == 0) {
       g_ptr_array_remove_index(self->components, i);
       break;
     }
   }
 }
 
-void asdf_rename_component(Asdf *self, const gchar *old_file, const gchar *new_file) {
+void asdf_rename_component(Asdf *self, const GString *old_file, GString *new_file) {
   g_return_if_fail(GLIDE_IS_ASDF(self));
   for (guint i = 0; i < self->components->len; i++) {
-    gchar *comp = g_ptr_array_index(self->components, i);
-    if (g_strcmp0(comp, old_file) == 0) {
-      g_free(comp);
-      g_ptr_array_index(self->components, i) = g_strdup(new_file);
+    GString *comp = g_ptr_array_index(self->components, i);
+    if (g_strcmp0(comp->str, old_file->str) == 0) {
+      g_string_free(comp, TRUE);
+      g_ptr_array_index(self->components, i) = new_file;
       break;
     }
   }
 }
 
-void asdf_add_dependency(Asdf *self, const gchar *dep) {
+void asdf_add_dependency(Asdf *self, GString *dep) {
   g_return_if_fail(GLIDE_IS_ASDF(self));
-  g_ptr_array_add(self->depends_on, g_strdup(dep));
+  g_ptr_array_add(self->depends_on, dep);
 }
 
-const gchar *asdf_get_dependency(Asdf *self, guint index) {
+const GString *asdf_get_dependency(Asdf *self, guint index) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
   if (index >= self->depends_on->len)
     return NULL;
@@ -177,7 +181,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
     const gchar *kw = node_get_name(key);
     if (g_strcmp0(kw, "DESCRIPTION") == 0) {
       if (val->type == LISP_AST_NODE_TYPE_STRING)
-        asdf_set_description(self, node_get_name(val));
+        asdf_set_description(self, g_string_new(node_get_name(val)));
     } else if (g_strcmp0(kw, "SERIAL") == 0) {
       if (val->type == LISP_AST_NODE_TYPE_SYMBOL || val->type == LISP_AST_NODE_TYPE_NUMBER) {
         const gchar *v = val->type == LISP_AST_NODE_TYPE_SYMBOL ?
@@ -194,7 +198,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
           const Node *fname = g_array_index(comp->children, Node*, 1);
           if (sym->type == LISP_AST_NODE_TYPE_SYMBOL &&
               g_strcmp0(node_get_name(sym), "FILE") == 0) {
-            asdf_add_component(self, node_get_name(fname));
+            asdf_add_component(self, g_string_new(node_get_name(fname)));
           }
         }
       }
@@ -202,7 +206,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
       if (val->type == LISP_AST_NODE_TYPE_LIST) {
         for (guint j = 0; j < val->children->len; j++) {
           const Node *dep = g_array_index(val->children, Node*, j);
-          asdf_add_dependency(self, node_get_name(dep));
+          asdf_add_dependency(self, g_string_new(node_get_name(dep)));
         }
       }
     }
@@ -214,30 +218,32 @@ cleanup:
   text_provider_unref(provider);
 }
 
-static char *get_system_name(Asdf *self) {
+static GString *get_system_name(Asdf *self) {
   if (!self->filename)
-    return g_strdup("system");
-  gchar *base = g_path_get_basename(self->filename);
+    return g_string_new("system");
+  gchar *base = g_path_get_basename(self->filename->str);
   gchar *dot = g_strrstr(base, ".");
   if (dot)
     *dot = '\0';
-  return base;
+  GString *name = g_string_new(base);
+  g_free(base);
+  return name;
 }
 
 GString *asdf_to_string(Asdf *self) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), NULL);
   GString *out = g_string_new(NULL);
-  gchar *name = get_system_name(self);
-  g_string_append_printf(out, "(defsystem \"%s\"\n", name);
-  g_free(name);
+  GString *name = get_system_name(self);
+  g_string_append_printf(out, "(defsystem \"%s\"\n", name->str);
+  g_string_free(name, TRUE);
   if (self->description)
-    g_string_append_printf(out, "  :description \"%s\"\n", self->description);
+    g_string_append_printf(out, "  :description \"%s\"\n", self->description->str);
   g_string_append_printf(out, "  :serial %s\n", self->serial ? "t" : "nil");
   if (self->components->len > 0) {
     g_string_append(out, "  :components (");
     for (guint i = 0; i < self->components->len; i++) {
-      const gchar *comp = g_ptr_array_index(self->components, i);
-      g_string_append_printf(out, "(:file \"%s\")", comp);
+      const GString *comp = g_ptr_array_index(self->components, i);
+      g_string_append_printf(out, "(:file \"%s\")", comp->str);
       if (i + 1 < self->components->len)
         g_string_append(out, " ");
     }
@@ -246,8 +252,8 @@ GString *asdf_to_string(Asdf *self) {
   if (self->depends_on->len > 0) {
     g_string_append(out, "  :depends-on (");
     for (guint i = 0; i < self->depends_on->len; i++) {
-      const gchar *dep = g_ptr_array_index(self->depends_on, i);
-      g_string_append_printf(out, "\"%s\"", dep);
+      const GString *dep = g_ptr_array_index(self->depends_on, i);
+      g_string_append_printf(out, "\"%s\"", dep->str);
       if (i + 1 < self->depends_on->len)
         g_string_append(out, " ");
     }
@@ -257,11 +263,16 @@ GString *asdf_to_string(Asdf *self) {
   return out;
 }
 
-gboolean asdf_save(Asdf *self, const gchar *filename) {
+gboolean asdf_save(Asdf *self, const GString *filename) {
   g_return_val_if_fail(GLIDE_IS_ASDF(self), FALSE);
   GString *text = asdf_to_string(self);
-  gboolean ok = g_file_set_contents(filename, text->str, text->len, NULL);
+  gboolean ok = g_file_set_contents(filename->str, text->str, text->len, NULL);
   g_string_free(text, TRUE);
   return ok;
+}
+
+static void g_string_free_full(gpointer data) {
+  if (data)
+    g_string_free(data, TRUE);
 }
 

--- a/src/asdf.h
+++ b/src/asdf.h
@@ -8,21 +8,21 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(Asdf, asdf, GLIDE, ASDF, GObject)
 
 Asdf *asdf_new(void);
-Asdf *asdf_new_from_file(const gchar *filename);
-const gchar *asdf_get_filename(Asdf *self);
-void asdf_set_description(Asdf *self, const gchar *description);
-const gchar *asdf_get_description(Asdf *self);
+Asdf *asdf_new_from_file(GString *filename);
+const GString *asdf_get_filename(Asdf *self);
+void asdf_set_description(Asdf *self, GString *description);
+const GString *asdf_get_description(Asdf *self);
 void asdf_set_serial(Asdf *self, gboolean serial);
 gboolean asdf_get_serial(Asdf *self);
-void asdf_add_component(Asdf *self, const gchar *file);
-const gchar *asdf_get_component(Asdf *self, guint index);
+void asdf_add_component(Asdf *self, GString *file);
+const GString *asdf_get_component(Asdf *self, guint index);
 guint asdf_get_component_count(Asdf *self);
-void asdf_remove_component(Asdf *self, const gchar *file);
-void asdf_rename_component(Asdf *self, const gchar *old_file, const gchar *new_file);
-void asdf_add_dependency(Asdf *self, const gchar *dep);
-const gchar *asdf_get_dependency(Asdf *self, guint index);
+void asdf_remove_component(Asdf *self, const GString *file);
+void asdf_rename_component(Asdf *self, const GString *old_file, GString *new_file);
+void asdf_add_dependency(Asdf *self, GString *dep);
+const GString *asdf_get_dependency(Asdf *self, guint index);
 guint asdf_get_dependency_count(Asdf *self);
 GString *asdf_to_string(Asdf *self);
-gboolean asdf_save(Asdf *self, const gchar *filename);
+gboolean asdf_save(Asdf *self, const GString *filename);
 
 G_END_DECLS

--- a/src/file_add.c
+++ b/src/file_add.c
@@ -35,10 +35,9 @@ void file_add(GtkWidget */*widget*/, gpointer data) {
       GString *comp = g_string_new(rel);
       if (g_str_has_suffix(comp->str, ".lisp"))
         g_string_truncate(comp, comp->len - 5);
-      asdf_add_component(asdf, comp->str);
+      asdf_add_component(asdf, comp);
       asdf_save(asdf, asdf_get_filename(asdf));
       app_update_project_view(app);
-      g_string_free(comp, TRUE);
     }
     g_free(filename);
   }

--- a/src/file_delete.c
+++ b/src/file_delete.c
@@ -34,7 +34,9 @@ void file_delete(GtkWidget */*widget*/, gpointer data) {
     g_remove(path);
     Asdf *asdf = project_get_asdf(app_get_project(app));
     if (comp) {
-      asdf_remove_component(asdf, comp);
+      GString *comp_str = g_string_new(comp);
+      asdf_remove_component(asdf, comp_str);
+      g_string_free(comp_str, TRUE);
       asdf_save(asdf, asdf_get_filename(asdf));
       app_update_project_view(app);
     }

--- a/src/file_new.c
+++ b/src/file_new.c
@@ -43,10 +43,9 @@ void file_new(GtkWidget */*widget*/, gpointer data) {
         GString *comp = g_string_new(rel);
         if (g_str_has_suffix(comp->str, ".lisp"))
           g_string_truncate(comp, comp->len - 5);
-        asdf_add_component(asdf, comp->str);
+        asdf_add_component(asdf, comp);
         asdf_save(asdf, asdf_get_filename(asdf));
         app_update_project_view(app);
-        g_string_free(comp, TRUE);
       }
       g_free(path);
       g_free(fname);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -53,15 +53,16 @@ gboolean file_open_path(App *app, const gchar *filename) {
 
   gboolean is_asdf = g_str_has_suffix(filename, ".asd");
   if (is_asdf) {
-    Asdf *asdf = asdf_new_from_file(filename);
+    GString *fn = g_string_new(filename);
+    Asdf *asdf = asdf_new_from_file(fn);
     project_set_asdf(project, asdf);
     g_object_unref(asdf);
     gchar *base = g_path_get_dirname(filename);
     project_set_path(project, base);
     gchar *dir = g_strdup(base);
     for (guint i = 0; i < asdf_get_component_count(project_get_asdf(project)); i++) {
-      const gchar *comp = asdf_get_component(project_get_asdf(project), i);
-      gchar *path = g_build_filename(dir, comp, NULL);
+      const GString *comp = asdf_get_component(project_get_asdf(project), i);
+      gchar *path = g_build_filename(dir, comp->str, NULL);
       gchar *full = ensure_lisp_extension(path);
       g_free(path);
       TextProvider *provider = string_text_provider_new("");

--- a/src/file_rename.c
+++ b/src/file_rename.c
@@ -48,7 +48,10 @@ void file_rename(GtkWidget */*widget*/, gpointer data) {
         if (dot)
           *dot = '\0';
         Asdf *asdf = project_get_asdf(app_get_project(app));
-        asdf_rename_component(asdf, old_comp, new_comp);
+        GString *old_str = g_string_new(old_comp);
+        GString *new_str = g_string_new(new_comp);
+        asdf_rename_component(asdf, old_str, new_str);
+        g_string_free(old_str, TRUE);
         asdf_save(asdf, asdf_get_filename(asdf));
         app_update_project_view(app);
         LispSourceNotebook *notebook = app_get_notebook(app);

--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -129,9 +129,10 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
     g_file_set_contents(unnamed, "", -1, NULL);
     gchar *name_asd = g_strdup_printf("%s.asd", name);
     gchar *asd_path = g_build_filename(dir, name_asd, NULL);
-    Asdf *asdf = asdf_new_from_file(asd_path);
-    asdf_add_component(asdf, "unnamed");
-    asdf_save(asdf, asd_path);
+    GString *asd_path_str = g_string_new(asd_path);
+    Asdf *asdf = asdf_new_from_file(asd_path_str);
+    asdf_add_component(asdf, g_string_new("unnamed"));
+    asdf_save(asdf, asdf_get_filename(asdf));
     g_object_unref(asdf);
     file_open_path(app, asd_path);
     g_free(unnamed);

--- a/src/project_view.c
+++ b/src/project_view.c
@@ -139,8 +139,8 @@ project_view_populate_store(ProjectView *self)
   GtkTreeIter root;
   GtkTreeIter iter;
   GtkTreeIter child;
-  const gchar *filename = asdf_get_filename(self->asdf);
-  gchar *basename = filename ? g_path_get_basename(filename) : g_strdup("");
+  const GString *filename = asdf_get_filename(self->asdf);
+  gchar *basename = filename ? g_path_get_basename(filename->str) : g_strdup("");
   gtk_tree_store_clear(self->store);
 
   gtk_tree_store_append(self->store, &root, NULL);
@@ -160,13 +160,13 @@ project_view_populate_store(ProjectView *self)
       PROJECT_VIEW_COL_OBJECT, self->project,
       -1);
   for (guint i = 0; i < asdf_get_component_count(self->asdf); i++) {
-    const gchar *comp = asdf_get_component(self->asdf, i);
+    const GString *comp = asdf_get_component(self->asdf, i);
     ProjectFile *pf = NULL;
     if (self->project) {
       for (guint j = 0; j < project_get_file_count(self->project); j++) {
         ProjectFile *f = project_get_file(self->project, j);
         const gchar *rel = project_file_get_relative_path(f);
-        if (filename_matches(comp, rel)) {
+        if (filename_matches(comp->str, rel)) {
           pf = f;
           break;
         }
@@ -175,7 +175,7 @@ project_view_populate_store(ProjectView *self)
     gtk_tree_store_append(self->store, &child, &iter);
     gtk_tree_store_set(self->store, &child,
         PROJECT_VIEW_COL_ICON, self->icon_lisp,
-        PROJECT_VIEW_COL_TEXT, comp,
+        PROJECT_VIEW_COL_TEXT, comp->str,
         PROJECT_VIEW_COL_KIND, PROJECT_VIEW_KIND_SRC,
         PROJECT_VIEW_COL_OBJECT, pf,
         -1);

--- a/tests/asdf_test.c
+++ b/tests/asdf_test.c
@@ -9,15 +9,16 @@ static void test_parse(void)
   const gchar *contents = "(defsystem \"foo\"\n  :description \"desc\"\n  :serial t\n  :components ((:file \"a\") (:file \"b\"))\n  :depends-on (\"dep1\" \"dep2\"))";
   g_file_set_contents(file, contents, -1, NULL);
 
-  Asdf *asdf = asdf_new_from_file(file);
-  g_assert_cmpstr(asdf_get_description(asdf), ==, "desc");
+  GString *file_str = g_string_new(file);
+  Asdf *asdf = asdf_new_from_file(file_str);
+  g_assert_cmpstr(asdf_get_description(asdf)->str, ==, "desc");
   g_assert_true(asdf_get_serial(asdf));
   g_assert_cmpuint(asdf_get_component_count(asdf), ==, 2);
-  g_assert_cmpstr(asdf_get_component(asdf, 0), ==, "a");
-  g_assert_cmpstr(asdf_get_component(asdf, 1), ==, "b");
+  g_assert_cmpstr(asdf_get_component(asdf, 0)->str, ==, "a");
+  g_assert_cmpstr(asdf_get_component(asdf, 1)->str, ==, "b");
   g_assert_cmpuint(asdf_get_dependency_count(asdf), ==, 2);
-  g_assert_cmpstr(asdf_get_dependency(asdf, 0), ==, "dep1");
-  g_assert_cmpstr(asdf_get_dependency(asdf, 1), ==, "dep2");
+  g_assert_cmpstr(asdf_get_dependency(asdf, 0)->str, ==, "dep1");
+  g_assert_cmpstr(asdf_get_dependency(asdf, 1)->str, ==, "dep2");
 
   GString *str = asdf_to_string(asdf);
   g_assert_nonnull(strstr(str->str, "(:file \"a\")"));
@@ -37,13 +38,15 @@ static void test_save(void)
 
   Asdf *asdf = asdf_new();
   asdf_set_serial(asdf, TRUE);
-  asdf_add_component(asdf, "a");
-  asdf_add_component(asdf, "b");
-  asdf_add_dependency(asdf, "dep1");
-  asdf_add_dependency(asdf, "dep2");
-  asdf_set_description(asdf, "desc");
+  asdf_add_component(asdf, g_string_new("a"));
+  asdf_add_component(asdf, g_string_new("b"));
+  asdf_add_dependency(asdf, g_string_new("dep1"));
+  asdf_add_dependency(asdf, g_string_new("dep2"));
+  asdf_set_description(asdf, g_string_new("desc"));
 
-  g_assert_true(asdf_save(asdf, out));
+  GString *out_str = g_string_new(out);
+  g_assert_true(asdf_save(asdf, out_str));
+  g_string_free(out_str, TRUE);
   g_assert_true(g_file_test(out, G_FILE_TEST_EXISTS));
 
   gchar *contents = NULL;
@@ -63,20 +66,25 @@ static void test_save(void)
 static void test_rename(void)
 {
   Asdf *asdf = asdf_new();
-  asdf_add_component(asdf, "old");
-  asdf_rename_component(asdf, "old", "new");
-  g_assert_cmpstr(asdf_get_component(asdf, 0), ==, "new");
+  asdf_add_component(asdf, g_string_new("old"));
+  GString *old = g_string_new("old");
+  GString *new = g_string_new("new");
+  asdf_rename_component(asdf, old, new);
+  g_string_free(old, TRUE);
+  g_assert_cmpstr(asdf_get_component(asdf, 0)->str, ==, "new");
   g_object_unref(asdf);
 }
 
 static void test_remove(void)
 {
   Asdf *asdf = asdf_new();
-  asdf_add_component(asdf, "a");
-  asdf_add_component(asdf, "b");
-  asdf_remove_component(asdf, "a");
+  asdf_add_component(asdf, g_string_new("a"));
+  asdf_add_component(asdf, g_string_new("b"));
+  GString *a = g_string_new("a");
+  asdf_remove_component(asdf, a);
+  g_string_free(a, TRUE);
   g_assert_cmpuint(asdf_get_component_count(asdf), ==, 1);
-  g_assert_cmpstr(asdf_get_component(asdf, 0), ==, "b");
+  g_assert_cmpstr(asdf_get_component(asdf, 0)->str, ==, "b");
   g_object_unref(asdf);
 }
 


### PR DESCRIPTION
## Summary
- Refactor Asdf to store strings with `GString`, updating object fields and API signatures accordingly
- Adjust all callers and tests for the new `GString`-based API

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68bff03575648328868db38f94bb0eba