### PR TITLE
Ensure project mutations run on UI thread

### DIFF
--- a/src/project_file.c
+++ b/src/project_file.c
@@ -23,6 +23,7 @@ ProjectFile *project_file_new(Project *project, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state) {
   g_return_val_if_fail(project != NULL, NULL);
   g_return_val_if_fail(provider, NULL);
+  g_return_val_if_fail(glide_is_ui_thread(), NULL);
 
   ProjectFile *file = g_new0(ProjectFile, 1);
   file->project = project;
@@ -52,6 +53,7 @@ ProjectFileState project_file_get_state(ProjectFile *file) {
 
 void project_file_set_state(ProjectFile *file, ProjectFileState state) {
   g_return_if_fail(file != NULL);
+  g_return_if_fail(glide_is_ui_thread());
   file->state = state;
 }
 
@@ -59,6 +61,7 @@ void project_file_set_provider(ProjectFile *file, TextProvider *provider,
     GtkTextBuffer *buffer) {
   g_return_if_fail(file != NULL);
   g_return_if_fail(provider);
+  g_return_if_fail(glide_is_ui_thread());
   if (file->parser)
     lisp_parser_free(file->parser);
   if (file->lexer)
@@ -100,12 +103,14 @@ const gchar *project_file_get_path(ProjectFile *file) {
 
 void project_file_set_path(ProjectFile *file, const gchar *path) {
   g_return_if_fail(file != NULL);
+  g_return_if_fail(glide_is_ui_thread());
   g_free(file->path);
   file->path = path ? g_strdup(path) : NULL;
 }
 
 gboolean project_file_load(ProjectFile *file) {
   g_return_val_if_fail(file != NULL, FALSE);
+  g_return_val_if_fail(glide_is_ui_thread(), FALSE);
 
   const gchar *path = project_file_get_path(file);
   LOG(1, "project_file_load path=%s", path ? path : "(null)");

--- a/src/project_index.c
+++ b/src/project_index.c
@@ -44,6 +44,7 @@ ProjectIndex *project_index_new(void) {
 
 void project_index_free(ProjectIndex *self) {
   if (!self) return;
+  g_return_if_fail(glide_is_ui_thread());
   project_index_clear(self);
   g_clear_pointer(&self->function_defs, g_hash_table_unref);
   g_clear_pointer(&self->function_uses, g_hash_table_unref);
@@ -90,6 +91,7 @@ static void project_index_node(ProjectIndex *self, const Node *node) {
 }
 
 void project_index_walk(ProjectIndex *self, const Node *node) {
+  g_return_if_fail(glide_is_ui_thread());
   if (!node) return;
   project_index_node(self, node);
   if (node->children)
@@ -102,6 +104,7 @@ GHashTable *project_index_get(ProjectIndex *self, StringDesignatorType sd_type) 
 }
 
 void project_index_clear(ProjectIndex *self) {
+  g_return_if_fail(glide_is_ui_thread());
   GHashTable *tables[] = { self->function_defs, self->function_uses,
     self->variable_defs, self->variable_uses, self->package_defs,
     self->package_uses };
@@ -158,6 +161,7 @@ static void project_index_remove_from_table(GHashTable *table, ProjectFile *file
 }
 
 void project_index_remove_file(ProjectIndex *self, ProjectFile *file) {
+  g_return_if_fail(glide_is_ui_thread());
   GHashTable *tables[] = { self->function_defs, self->function_uses,
     self->variable_defs, self->variable_uses, self->package_defs,
     self->package_uses };
@@ -225,6 +229,7 @@ void project_index_remove_file(ProjectIndex *self, ProjectFile *file) {
 void project_index_add_package(ProjectIndex *self, Package *package) {
   g_return_if_fail(self != NULL);
   g_return_if_fail(package != NULL);
+  g_return_if_fail(glide_is_ui_thread());
   const gchar *name = package_get_name(package);
   if (!name) return;
   g_hash_table_replace(self->packages, g_strdup(name), package_ref(package));
@@ -245,6 +250,7 @@ gchar **project_index_get_package_names(ProjectIndex *self, guint *length) {
 void project_index_add_function(ProjectIndex *self, Function *function) {
   g_return_if_fail(self != NULL);
   g_return_if_fail(function != NULL);
+  g_return_if_fail(glide_is_ui_thread());
   const gchar *name = function_get_name(function);
   if (!name) return;
   g_hash_table_replace(self->functions, g_strdup(name), function_ref(function));
@@ -283,6 +289,7 @@ void project_index_add_variable(ProjectIndex *self, const gchar *package,
   g_return_if_fail(self != NULL);
   g_return_if_fail(package != NULL);
   g_return_if_fail(name != NULL);
+  g_return_if_fail(glide_is_ui_thread());
   g_hash_table_replace(self->variables, g_strdup(name),
       doc ? g_strdup(doc) : NULL);
   LOG(1, "Index: added variable %s", name);

--- a/src/project_view.c
+++ b/src/project_view.c
@@ -307,7 +307,7 @@ on_button_press(GtkWidget *widget, GdkEventButton *event, gpointer data)
 static gboolean
 dispatch_project_changed(gpointer data)
 {
-  g_assert(g_main_context_is_owner(g_main_context_default()));
+  g_assert(glide_is_ui_thread());
   ProjectView *self = PROJECT_VIEW(data);
   self->project_changed_source = 0;
   LOG(1, "ProjectView.dispatch_project_changed update started");
@@ -319,7 +319,7 @@ dispatch_project_changed(gpointer data)
 static gboolean
 schedule_project_changed(gpointer data)
 {
-  g_assert(g_main_context_is_owner(g_main_context_default()));
+  g_assert(glide_is_ui_thread());
   ProjectView *self = PROJECT_VIEW(data);
   if (!self->project_changed_source) {
     LOG(1, "ProjectView.schedule_project_changed armed");

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,11 @@
 
 #include <glib.h>
 
+static inline gboolean glide_is_ui_thread(void)
+{
+  return g_main_context_is_owner(g_main_context_default());
+}
+
 static inline void g_debug_long(const char *string, const char *msg)
 {
   char *escaped = g_strescape(msg, NULL);

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -108,8 +108,12 @@ static void test_nested_defun(void) {
 
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
+  GMainContext *ctx = g_main_context_default();
+  g_main_context_push_thread_default(ctx);
   g_test_add_func("/analyse/basic", test_analyse);
   g_test_add_func("/analyse/nested-defpackage", test_nested_defpackage);
   g_test_add_func("/analyse/nested-defun", test_nested_defun);
-  return g_test_run();
+  int ret = g_test_run();
+  g_main_context_pop_thread_default(ctx);
+  return ret;
 }

--- a/tests/editor_test.c
+++ b/tests/editor_test.c
@@ -29,7 +29,11 @@ int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
   have_display = gtk_init_check(&argc, &argv);
+  GMainContext *ctx = g_main_context_default();
+  g_main_context_push_thread_default(ctx);
   g_test_add_func("/editor/undo_pristine", test_undo_pristine);
-  return g_test_run();
+  int ret = g_test_run();
+  g_main_context_pop_thread_default(ctx);
+  return ret;
 }
 

--- a/tests/project_repl_test.c
+++ b/tests/project_repl_test.c
@@ -19,6 +19,7 @@ static void test_describe(void) {
   Function *fn = NULL;
   const gchar *var_doc = NULL;
   for (int i = 0; i < 200; i++) {
+    g_main_context_iteration(NULL, FALSE);
     fn = project_get_function(project, "FOO");
     var_doc = project_get_variable(project, "*BAR*");
     if (fn && var_doc)
@@ -38,6 +39,10 @@ static void test_describe(void) {
 
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
+  GMainContext *ctx = g_main_context_default();
+  g_main_context_push_thread_default(ctx);
   g_test_add_func("/project_repl/describe", test_describe);
-  return g_test_run();
+  int ret = g_test_run();
+  g_main_context_pop_thread_default(ctx);
+  return ret;
 }

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -240,6 +240,8 @@ static void test_project_changed_cb(void)
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
+  GMainContext *ctx = g_main_context_default();
+  g_main_context_push_thread_default(ctx);
   g_test_add_func("/project/default_file", test_default_file);
   g_test_add_func("/project/parse_on_change", test_parse_on_change);
   g_test_add_func("/project/file_load", test_file_load);
@@ -250,5 +252,7 @@ int main(int argc, char *argv[])
   g_test_add_func("/project/relative_path", test_relative_path);
   g_test_add_func("/project/remove_file", test_remove_file);
   g_test_add_func("/project/project_changed_cb", test_project_changed_cb);
-  return g_test_run();
+  int ret = g_test_run();
+  g_main_context_pop_thread_default(ctx);
+  return ret;
 }


### PR DESCRIPTION
## Summary
- centralize UI-thread ownership check in a new `glide_is_ui_thread` helper
- replace explicit `g_main_context_is_owner` checks across project modules
- dispatch REPL-driven project mutations to the UI thread instead of moving entire callbacks

## Testing
- `make -C src app-full`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_68c016c6a6fc8328b1d4594e0d7c3c0d