### PR TITLE
Create Project on UI thread

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -298,3 +298,10 @@ fires, coalescing intermediate signals.
 an error. Pipes may legally return fewer bytes than requested, truncating data
 sent to child processes. The function now loops until the entire buffer is
 written so partial writes no longer lose input.
+
+## Project created off UI thread
+
+`Project` was instantiated in `main.c` before the GTK main loop owned the
+default context, causing `project_new` to fail its UI thread assertion.
+Creation now happens in `App.startup`, ensuring the project is constructed on
+the main thread.

--- a/src/app.c
+++ b/src/app.c
@@ -147,7 +147,10 @@ app_startup (GApplication *app)
   LOG(1, "App.startup");
   /* Chain up first */
   G_APPLICATION_CLASS (app_parent_class)->startup (app);
-  actions_init(GLIDE_APP(app));
+  g_return_if_fail(glide_is_ui_thread());
+  App *self = GLIDE_APP(app);
+  self->project = project_new(self->glide);
+  actions_init(self);
 }
 
 static void
@@ -202,7 +205,7 @@ app_init (App *self)
 }
 
 STATIC App *
-app_new (Preferences *prefs, ReplSession *glide, Project *project, StatusService *status_service)
+app_new (Preferences *prefs, ReplSession *glide, StatusService *status_service)
 {
   LOG(1, "App.new");
   g_return_val_if_fail (glide, NULL);
@@ -215,7 +218,6 @@ app_new (Preferences *prefs, ReplSession *glide, Project *project, StatusService
 
   self->preferences    = preferences_ref(prefs);
   self->glide          = repl_session_ref(glide);
-  self->project        = project_ref(project);
   self->status_service = status_service;
   return self;
 }

--- a/src/app.h
+++ b/src/app.h
@@ -18,7 +18,7 @@ G_BEGIN_DECLS
 #define GLIDE_TYPE (app_get_type())
 G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 
-STATIC App *app_new (Preferences *prefs, ReplSession *glide, Project *project, StatusService *status_service);
+STATIC App *app_new (Preferences *prefs, ReplSession *glide, StatusService *status_service);
 STATIC Editor *app_get_editor(App *self);
 STATIC LispSourceNotebook *app_get_notebook(App *self);
 STATIC Project *app_get_project(App *self);

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,6 @@
 #include "process.h"
 #include "repl_process.h"
 #include "repl_session.h"
-#include "project.h"
 #include "status_service.h"
 #include "util.h"
 
@@ -75,15 +74,13 @@ main (int argc, char *argv[])
   ReplProcess *repl_proc = repl_process_new(proc);
   StatusService *status_service = status_service_new();
   ReplSession *repl = repl_session_new(repl_proc, status_service);
-  Project *project = project_new(repl);
-  App *app     = app_new (prefs, repl, project, status_service);
+  App *app     = app_new (prefs, repl, status_service);
 
   int status = g_application_run (G_APPLICATION (app), argc, argv);
   g_object_unref(app);
   repl_session_unref(repl);
   repl_process_unref(repl_proc);
   process_unref(proc);
-  project_unref(project);
   status_service_free(status_service);
   preferences_unref(prefs);
   exit(status);


### PR DESCRIPTION
## Summary
- create `Project` during `App.startup` to ensure UI thread ownership
- simplify `app_new` API now that project is built internally
- note bug about project being created off UI thread

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c057ce702883289a31f7ff1931c6bd