### PR TITLE
Offload project file analysis to background thread

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -314,3 +314,9 @@ the callback is dispatched to the main loop. The UI thread then blocked in
 `dispatch_interaction_added` trying to take the same lock. The handler now
 ignores non‑user interactions so only UI‑visible interactions schedule a
 dispatch, preventing the deadlock.
+
+## Synchronous project file analysis blocked startup
+
+`project_file_changed` performed lexing and parsing on the UI thread, delaying
+application startup when loading projects. The heavy work now happens on a
+worker thread and applies results through the main loop.

--- a/src/project.c
+++ b/src/project.c
@@ -206,6 +206,39 @@ void project_clear(Project *self) {
   project_changed(self);
 }
 
+typedef struct {
+  Project *project;
+  ProjectFile *file;
+} ProjectFileChangedData;
+
+static gboolean project_file_changed_finish(gpointer user_data) {
+  ProjectFileChangedData *data = user_data;
+  Project *self = data->project;
+  ProjectFile *file = data->file;
+  LispParser *parser = project_file_get_parser(file);
+  const Node *ast = lisp_parser_get_ast(parser);
+  if (ast)
+    analyse_ast(self, (Node*)ast);
+  if (ast)
+    project_index_walk(self->index, ast);
+  project_changed(self);
+  project_unref(self);
+  g_free(data);
+  return FALSE;
+}
+
+static gpointer project_file_changed_thread(gpointer user_data) {
+  ProjectFileChangedData *data = user_data;
+  ProjectFile *file = data->file;
+  LispLexer *lexer = project_file_get_lexer(file);
+  LispParser *parser = project_file_get_parser(file);
+  lisp_lexer_lex(lexer);
+  GArray *tokens = lisp_lexer_get_tokens(lexer);
+  lisp_parser_parse(parser, tokens, file);
+  g_main_context_invoke(NULL, project_file_changed_finish, data);
+  return NULL;
+}
+
 void project_file_changed(Project *self, ProjectFile *file) {
   g_return_if_fail(self != NULL);
   g_return_if_fail(file != NULL);
@@ -214,17 +247,11 @@ void project_file_changed(Project *self, ProjectFile *file) {
   if (!project_file_get_lexer(file) || !project_file_get_parser(file))
     return;
   project_index_remove_file(self->index, file);
-  LispLexer *lexer = project_file_get_lexer(file);
-  LispParser *parser = project_file_get_parser(file);
-  lisp_lexer_lex(lexer);
-  GArray *tokens = lisp_lexer_get_tokens(lexer);
-  lisp_parser_parse(parser, tokens, file);
-  const Node *ast = lisp_parser_get_ast(parser);
-  if (ast)
-    analyse_ast(self, (Node*)ast);
-  if (ast)
-    project_index_walk(self->index, ast);
-  project_changed(self);
+  ProjectFileChangedData *data = g_new(ProjectFileChangedData, 1);
+  data->project = project_ref(self);
+  data->file = file;
+  GThread *thread = g_thread_new("project-file-changed", project_file_changed_thread, data);
+  g_thread_unref(thread);
 }
 
 Project *project_ref(Project *self) {

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -22,6 +22,7 @@ static void test_parse_on_change(void)
   ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
+  g_main_context_iteration(NULL, TRUE);
   LispParser *parser = project_file_get_parser(file);
   LispLexer *lexer = project_file_get_lexer(file);
   GArray *tokens = lisp_lexer_get_tokens(lexer);
@@ -29,9 +30,11 @@ static void test_parse_on_change(void)
   const LispToken *token = &g_array_index(tokens, LispToken, 0);
   g_assert_cmpint(token->type, ==, LISP_TOKEN_TYPE_LIST_START);
   project_file_changed(project, file); /* should still parse without error */
+  g_main_context_iteration(NULL, TRUE);
   const Node *ast = lisp_parser_get_ast(parser);
   g_assert_cmpint(ast->children->len, ==, 1);
   project_file_changed(project, file);
+  g_main_context_iteration(NULL, TRUE);
   project_unref(project);
 }
 
@@ -82,6 +85,7 @@ static void test_function_analysis(void)
   ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
+  g_main_context_iteration(NULL, TRUE);
   LispParser *parser = project_file_get_parser(file);
   const Node *ast = lisp_parser_get_ast(parser);
   const Node *form = g_array_index(ast->children, Node*, 0);
@@ -103,6 +107,7 @@ static void test_index(void)
       PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
+  g_main_context_iteration(NULL, TRUE);
   LispParser *parser = project_file_get_parser(file);
   const Node *ast = lisp_parser_get_ast(parser);
   const Node *form = g_array_index(ast->children, Node*, 0);
@@ -134,6 +139,7 @@ static void test_functions_table(void)
   ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
+  g_main_context_iteration(NULL, TRUE);
   Function *fn = project_get_function(project, "FOO");
   g_assert_nonnull(fn);
   const gchar *doc = function_get_doc_string(fn);
@@ -151,11 +157,13 @@ static void test_incremental_index(void)
   ProjectFile *f1 = project_add_file(project, p1, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(p1);
   project_file_changed(project, f1);
+  g_main_context_iteration(NULL, TRUE);
 
   TextProvider *p2 = string_text_provider_new("(defun bar () nil)");
   ProjectFile *f2 = project_add_file(project, p2, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(p2);
   project_file_changed(project, f2);
+  g_main_context_iteration(NULL, TRUE);
 
   GHashTable *defs = project_get_index(project, SDT_FUNCTION_DEF);
   g_assert_nonnull(g_hash_table_lookup(defs, "FOO"));
@@ -165,6 +173,7 @@ static void test_incremental_index(void)
   g_free(stp2->text);
   stp2->text = g_strdup("(defun baz () nil)");
   project_file_changed(project, f2);
+  g_main_context_iteration(NULL, TRUE);
 
   g_assert_nonnull(g_hash_table_lookup(defs, "FOO"));
   g_assert_null(g_hash_table_lookup(defs, "BAR"));


### PR DESCRIPTION
## Summary
- parse and index project files on a worker thread
- wait for async parsing in project tests
- document startup stall from synchronous project file analysis

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68c173494f248328b88871a6e6d1a5eb