### PR TITLE
Call describe directly from worker

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -256,7 +256,6 @@ void project_file_changed(Project *self, ProjectFile *file) {
 
 Project *project_ref(Project *self) {
   g_return_val_if_fail(self != NULL, NULL);
-  g_return_val_if_fail(glide_is_ui_thread(), NULL);
   g_atomic_int_inc(&self->refcnt);
   return self;
 }
@@ -264,7 +263,6 @@ Project *project_ref(Project *self) {
 void project_unref(Project *self) {
   if (!self)
     return;
-  g_return_if_fail(glide_is_ui_thread());
   if (g_atomic_int_dec_and_test(&self->refcnt))
     project_free(self);
 }

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -42,12 +42,6 @@ typedef struct {
   Function *function;
 } FunctionData;
 
-typedef struct {
-  Project *project;
-  gchar *package_name;
-  gchar *symbol;
-} DescribeRequestData;
-
 static gboolean add_package_cb(gpointer data) {
   PackageDefinitionData *pd = data;
   analyse_defpackage(pd->project, pd->expr, NULL);
@@ -78,15 +72,6 @@ static gboolean add_function_cb(gpointer data) {
 
 static gboolean project_unref_cb(gpointer data) {
   project_unref(data);
-  return G_SOURCE_REMOVE;
-}
-
-static gboolean request_describe_cb(gpointer data) {
-  DescribeRequestData *dd = data;
-  project_request_describe(dd->project, dd->package_name, dd->symbol);
-  g_free(dd->package_name);
-  g_free(dd->symbol);
-  g_free(dd);
   return G_SOURCE_REMOVE;
 }
 
@@ -183,11 +168,7 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
   g_main_context_invoke(NULL, add_package_cb, pd);
   for (guint i = 0; i < exports->len; i++) {
     const gchar *sym = g_ptr_array_index(exports, i);
-    DescribeRequestData *dd = g_new0(DescribeRequestData, 1);
-    dd->project = project;
-    dd->package_name = g_strdup(pkg_name);
-    dd->symbol = g_strdup(sym);
-    g_main_context_invoke(NULL, request_describe_cb, dd);
+    project_request_describe(project, pkg_name, sym);
   }
   g_main_context_invoke(NULL, project_unref_cb, project);
   g_ptr_array_free(exports, TRUE);


### PR DESCRIPTION
## Summary
- invoke `project_request_describe` directly from the worker thread
- allow `project_ref`/`project_unref` to run off the UI thread

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68c281a29e608328bbedc52b8929eb43