### PR TITLE
project_repl: copy package name before freeing parser

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -320,3 +320,11 @@ dispatch, preventing the deadlock.
 `project_file_changed` performed lexing and parsing on the UI thread, delaying
 application startup when loading projects. The heavy work now happens on a
 worker thread and applies results through the main loop.
+
+## Use-after-free in project_on_package_definition
+
+`project_on_package_definition` stored the package name pointer from the AST and
+scheduled `add_package_cb`, which destroyed the parser and its nodes. The loop
+describing exported symbols then dereferenced the freed pointer, corrupting the
+package name and crashing. The handler now duplicates the package name before
+queuing the callback and frees the copy after use.

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -154,7 +154,7 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
   Node *expr = g_array_index(ast->children, Node*, 0);
   Node *name_node = (expr->children && expr->children->len > 1) ?
     g_array_index(expr->children, Node*, 1) : NULL;
-  const gchar *pkg_name = node_get_name(name_node);
+  gchar *pkg_name = g_strdup(node_get_name(name_node));
   g_assert(pkg_name);
   LOG(1, "project_on_package_definition built package %s", pkg_name);
   GPtrArray *exports = g_ptr_array_new_with_free_func(g_free);
@@ -170,6 +170,7 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
     const gchar *sym = g_ptr_array_index(exports, i);
     project_request_describe(project, pkg_name, sym);
   }
+  g_free(pkg_name);
   g_main_context_invoke(NULL, project_unref_cb, project);
   g_ptr_array_free(exports, TRUE);
   interaction_clear(interaction);


### PR DESCRIPTION
## Summary
- Duplicate the package name in `project_on_package_definition` so callbacks use a valid string
- Document the use-after-free bug in `BUGS.md`

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c2a5eaa7ac8328b80d3d4ad7702495