### PR TITLE
Rename REPL add_package_cb to avoid inline build conflict

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -333,3 +333,9 @@ queuing the callback and frees the copy after use.
 
 `project_file_changed` parsed files on a worker thread while the UI could modify the buffer, producing
 inconsistent ASTs and indexes. The analysis now runs synchronously on the UI thread to avoid races.
+
+## Duplicate add_package_cb broke inline build
+
+The INLINE build includes every source file in a single translation unit. Two static functions were both named
+`add_package_cb`, so the compiler reported a redefinition error. Renaming the REPL callback to
+`analyse_defpackage_cb` restored unique names and allowed the inline version to compile.

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -42,7 +42,7 @@ typedef struct {
   Function *function;
 } FunctionData;
 
-static gboolean add_package_cb(gpointer data) {
+static gboolean analyse_defpackage_cb(gpointer data) {
   PackageDefinitionData *pd = data;
   analyse_defpackage(pd->project, pd->expr, NULL);
   lisp_parser_free(pd->parser);
@@ -165,7 +165,7 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
   pd->parser = parser;
   pd->lexer = lexer;
   pd->provider = provider;
-  g_main_context_invoke(NULL, add_package_cb, pd);
+  g_main_context_invoke(NULL, analyse_defpackage_cb, pd);
   for (guint i = 0; i < exports->len; i++) {
     const gchar *sym = g_ptr_array_index(exports, i);
     project_request_describe(project, pkg_name, sym);


### PR DESCRIPTION
## Summary
- Rename REPL callback `add_package_cb` to `analyse_defpackage_cb` to avoid name clash in inline build
- Document duplicate callback issue in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run` *(fails: `VERBOSITY` undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68c6929acb048328a2a01c8dc3afd7bb