### PR TITLE
Handle evaluating EOF form without newline

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -339,3 +339,11 @@ inconsistent ASTs and indexes. The analysis now runs synchronously on the UI thr
 The INLINE build includes every source file in a single translation unit. Two static functions were both named
 `add_package_cb`, so the compiler reported a redefinition error. Renaming the REPL callback to
 `analyse_defpackage_cb` restored unique names and allowed the inline version to compile.
+
+## Eval toplevel ignored form without trailing newline
+
+Evaluating a buffer containing a single form without a terminating newline
+returned "nothing to evaluate". `editor_get_toplevel_range` broke out of its
+search loop before recording the full-buffer range, leaving start and end equal
+to the cursor offset. The function now updates the range prior to checking for
+the buffer bounds so end-of-file expressions evaluate correctly.

--- a/src/editor.c
+++ b/src/editor.c
@@ -158,10 +158,10 @@ editor_get_toplevel_range (Editor *self, gsize offset,
 
   while (find_parent_range(buffer, self->file, cur_start, cur_end,
       &new_start, &new_end)) {
-    if (new_start == 0 && new_end == len)
-      break;
     cur_start = new_start;
     cur_end = new_end;
+    if (cur_start == 0 && cur_end == len)
+      break;
   }
 
   if (cur_start == offset && cur_end == offset)

--- a/tests/editor_test.c
+++ b/tests/editor_test.c
@@ -25,6 +25,31 @@ static void test_undo_pristine(void)
   project_unref(project);
 }
 
+static void test_toplevel_range_eof_without_newline(void)
+{
+  if (!have_display) {
+    g_test_skip("no display");
+    return;
+  }
+  Project *project = project_new(NULL);
+  TextProvider *provider = string_text_provider_new("(+ 1 2)");
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL,
+      PROJECT_FILE_LIVE);
+  text_provider_unref(provider);
+
+  GtkWidget *widget = editor_new_for_file(project, file);
+  Editor *editor = GLIDE_EDITOR(widget);
+
+  gsize start;
+  gsize end;
+  g_assert_true(editor_get_toplevel_range(editor, 7, &start, &end));
+  g_assert_cmpint(start, ==, 0);
+  g_assert_cmpint(end, ==, 7);
+
+  g_object_unref(widget);
+  project_unref(project);
+}
+
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
@@ -32,6 +57,8 @@ int main(int argc, char *argv[])
   GMainContext *ctx = g_main_context_default();
   g_main_context_push_thread_default(ctx);
   g_test_add_func("/editor/undo_pristine", test_undo_pristine);
+  g_test_add_func("/editor/toplevel_range_eof_without_newline",
+      test_toplevel_range_eof_without_newline);
   int ret = g_test_run();
   g_main_context_pop_thread_default(ctx);
   return ret;


### PR DESCRIPTION
## Summary
- record buffer-wide range before breaking out of search in `editor_get_toplevel_range`
- cover end-of-file evaluation without trailing newline in `editor_test`
- document fix for missing eval at EOF

## Testing
- `make app-full`
- `make run` *(tests skipped: editor requires a display)*

------
https://chatgpt.com/codex/tasks/task_e_68c6999f4e748328a664123f567008f1