### PR TITLE
Implement recursive node stringification and tests

### DIFF
--- a/src/lisp_parser_view.c
+++ b/src/lisp_parser_view.c
@@ -104,7 +104,7 @@ add_ast_node(LispParserView *self, const Node *node, GtkTreeIter *parent) {
   }
 
   if (node->sd_type)
-    info = node_to_string(node);
+    info = node_debug_string(node);
 
   gtk_tree_store_append(self->store, &iter, parent);
   gtk_tree_store_set(self->store, &iter,

--- a/src/node.h
+++ b/src/node.h
@@ -48,6 +48,7 @@ void node_unref(Node *node);
 gboolean node_is(const Node *node, StringDesignatorType t);
 gboolean node_is_toplevel(const Node *node);
 const gchar *node_sd_type_to_string(StringDesignatorType sd_type);
+gchar *node_debug_string(const Node *node);
 gchar *node_to_string(const Node *node);
 const gchar *node_get_name(const Node *node);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,8 @@ endif
 
 VPATH = ../src
 INCLUDES = -I$(VPATH) -I..
-CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
+VERBOSITY = -DVERBOSITY=0
+CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4` $(VERBOSITY)
 COMMON = verbosity.c
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
 TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test \

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -1,6 +1,7 @@
 #include "lisp_lexer.h"
 #include "lisp_parser.h"
 #include "string_text_provider.h"
+#include "node.h"
 #include <glib.h>
 
 typedef struct {
@@ -210,6 +211,18 @@ static void test_comment(void) {
   parser_fixture_free(&fixture);
 }
 
+static void test_node_to_string(void) {
+  const gchar *text = " (  + 1 ; comment\n   (- 2 3) ) ; trailing\n";
+  ParserFixture fixture = parser_fixture_from_text(text);
+  const Node *ast = lisp_parser_get_ast(fixture.parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const Node *list = g_array_index(ast->children, Node*, 0);
+  gchar *s = node_to_string(list);
+  g_assert_cmpstr(s, ==, "(+ 1 (- 2 3))");
+  g_free(s);
+  parser_fixture_free(&fixture);
+}
+
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/lisp_parser/empty_file", test_empty_file);
@@ -222,6 +235,7 @@ int main(int argc, char *argv[]) {
   g_test_add_func("/lisp_parser/symbol_with_package", test_symbol_with_package);
   g_test_add_func("/lisp_parser/extra_closing_paren", test_extra_closing_paren);
   g_test_add_func("/lisp_parser/comment", test_comment);
+  g_test_add_func("/lisp_parser/node_to_string", test_node_to_string);
   return g_test_run();
 }
 


### PR DESCRIPTION
## Summary
- Add `node_debug_string` and implement new recursive `node_to_string`
- Use `node_debug_string` in parser view
- Test `node_to_string` handles nested lists with whitespace and comments
- Enable verbosity macro in test builds

## Testing
- `make app-full`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68c6b843302483289768af0338ae7f48