### PR TITLE
Uppercase leaf symbols in node_to_string

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -261,6 +261,13 @@ still tagging their symbols.
 expressions. Functions are now added only when the `defun` is at the top level,
 while nested definitions are still analysed but not recorded in the project.
 
+## node_to_string returned lowercase symbols
+
+`node_to_string` duplicated the text of leaf symbol nodes without normalizing case.
+Parsing `aaa` therefore produced `aaa`, while other parts of the system expected
+`AAA`. The function now uppercases leaf symbol and package nodes so its output
+matches `node_get_name`.
+
 ## Package definition parsing only logged errors
 
 `project_on_package_definition` treated invalid REPL output as debug messages,

--- a/src/node.c
+++ b/src/node.c
@@ -87,6 +87,10 @@ gchar *node_to_string(const Node *node) {
   if (!node)
     return NULL;
   if (!node->children || node->children->len == 0) {
+    if (node->type == LISP_AST_NODE_TYPE_SYMBOL_NAME ||
+        node->type == LISP_AST_NODE_TYPE_SYMBOL_PACKAGE) {
+      return node->start_token ? g_ascii_strup(node->start_token->text, -1) : NULL;
+    }
     return node->start_token ? g_strdup(node->start_token->text) : NULL;
   }
   if (node->type == LISP_AST_NODE_TYPE_LIST) {

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -223,6 +223,17 @@ static void test_node_to_string(void) {
   parser_fixture_free(&fixture);
 }
 
+static void test_node_to_string_symbol_uppercase(void) {
+  ParserFixture fixture = parser_fixture_from_text("aaa");
+  const Node *ast = lisp_parser_get_ast(fixture.parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const Node *sym = g_array_index(ast->children, Node*, 0);
+  gchar *s = node_to_string(sym);
+  g_assert_cmpstr(s, ==, "AAA");
+  g_free(s);
+  parser_fixture_free(&fixture);
+}
+
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/lisp_parser/empty_file", test_empty_file);
@@ -236,6 +247,7 @@ int main(int argc, char *argv[]) {
   g_test_add_func("/lisp_parser/extra_closing_paren", test_extra_closing_paren);
   g_test_add_func("/lisp_parser/comment", test_comment);
   g_test_add_func("/lisp_parser/node_to_string", test_node_to_string);
+  g_test_add_func("/lisp_parser/node_to_string_symbol", test_node_to_string_symbol_uppercase);
   return g_test_run();
 }
 


### PR DESCRIPTION
## Summary
- normalize node_to_string so leaf symbol and package nodes are uppercased
- add regression test for symbol name case folding
- document the bug in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c6be35e2e88328b7b37ba1bfd5676c