### PR TITLE
Show package and function name in tooltip

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -133,9 +133,18 @@ gchar *project_function_tooltip(Function *function) {
   g_return_val_if_fail(function != NULL, NULL);
   GString *tt = g_string_new(NULL);
   const Node *lambda = function_get_lambda_list(function);
-  if (lambda) {
+  const gchar *pkg = function_get_package(function);
+  const gchar *name = function_get_name(function);
+  if (lambda && name) {
     gchar *ls = node_to_string(lambda);
-    g_string_append_printf(tt, "Lambda: %s\n", ls);
+    g_string_append_printf(tt, "(%s%s%s", pkg ? pkg : "",
+        pkg ? ":" : "", name);
+    gsize len = strlen(ls);
+    if (len > 2 && ls[0] == '(' && ls[len - 1] == ')') {
+      g_string_append_c(tt, ' ');
+      g_string_append_len(tt, ls + 1, len - 2);
+    }
+    g_string_append(tt, ")\n");
     g_free(ls);
   }
   const Node *sym = function_get_symbol(function);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -144,6 +144,21 @@ static void test_functions_table(void)
   project_unref(project);
 }
 
+static void test_function_tooltip(void)
+{
+  Project *project = project_new(NULL);
+  TextProvider *provider = string_text_provider_new("(defun foo (x y) \"doc\")");
+  ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
+  text_provider_unref(provider);
+  project_file_changed(project, file);
+  Function *fn = project_get_function(project, "FOO");
+  gchar *tooltip = project_function_tooltip(fn);
+  g_assert_nonnull(tooltip);
+  g_assert_cmpstr(tooltip, ==, "(CL-USER:FOO x y)\n\ndoc");
+  g_free(tooltip);
+  project_unref(project);
+}
+
 static void test_incremental_index(void)
 {
   Project *project = project_new(NULL);
@@ -248,6 +263,7 @@ int main(int argc, char *argv[])
   g_test_add_func("/project/function_analysis", test_function_analysis);
   g_test_add_func("/project/index", test_index);
   g_test_add_func("/project/functions_table", test_functions_table);
+  g_test_add_func("/project/function_tooltip", test_function_tooltip);
   g_test_add_func("/project/incremental_index", test_incremental_index);
   g_test_add_func("/project/relative_path", test_relative_path);
   g_test_add_func("/project/remove_file", test_remove_file);


### PR DESCRIPTION
## Summary
- display package and function name with arguments in tooltips
- cover function tooltip formatting with a unit test

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c6bdaeec4483289bb3c58a3c683798