### PR TITLE
Parse lambda list in describe output

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -354,3 +354,10 @@ returned "nothing to evaluate". `editor_get_toplevel_range` broke out of its
 search loop before recording the full-buffer range, leaving start and end equal
 to the cursor offset. The function now updates the range prior to checking for
 the buffer bounds so end-of-file expressions evaluate correctly.
+
+## Describe omitted lambda list
+
+`project_on_describe` created `Function` objects without a lambda list when
+reading the `describe` output for compiled functions. Tooltips therefore
+lacked argument lists. The handler now parses the `Lambda-list:` section and
+attaches the resulting AST to the `Function`.

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -251,8 +251,36 @@ static void project_handle_compiled_function(Project *project,
   LOG(1, "describe %s compiled function lambda=%s", symbol,
       lambda_list ? lambda_list : "(unknown)");
   LOG_LONG(1, "↳ doc: ", doc ? doc->str : "");
-  Function *function = function_new(NULL, NULL, doc ? doc->str : NULL,
+  Node *lambda_node = NULL;
+  TextProvider *provider = NULL;
+  LispLexer *lexer = NULL;
+  LispParser *parser = NULL;
+  if (lambda_list) {
+    provider = string_text_provider_new(lambda_list);
+    lexer = lisp_lexer_new(provider);
+    lisp_lexer_lex(lexer);
+    GArray *tokens = lisp_lexer_get_tokens(lexer);
+    parser = lisp_parser_new();
+    lisp_parser_parse(parser, tokens, NULL);
+    const Node *ast = lisp_parser_get_ast(parser);
+    if (ast && ast->children && ast->children->len > 0) {
+      lambda_node = g_array_index(ast->children, Node*, 0);
+      g_array_remove_index(ast->children, 0);
+      lambda_node->parent = NULL;
+    }
+  }
+  Function *function = function_new(NULL, lambda_node, doc ? doc->str : NULL,
       NULL, FUNCTION_KIND_FUNCTION, symbol, package);
+  if (lambda_node) {
+    /* Drop parser reference; Function keeps its own. */
+    node_unref(lambda_node);
+  }
+  if (parser)
+    lisp_parser_free(parser);
+  if (lexer)
+    lisp_lexer_free(lexer);
+  if (provider)
+    text_provider_unref(provider);
   FunctionData *fd = g_new0(FunctionData, 1);
   fd->project = project;
   fd->function = function;

--- a/tests/project_repl_test.c
+++ b/tests/project_repl_test.c
@@ -28,6 +28,9 @@ static void test_describe(void) {
   }
   g_assert_nonnull(fn);
   g_assert_cmpstr(function_get_doc_string(fn), ==, "foo doc");
+  const Node *lambda = function_get_lambda_list(fn);
+  g_assert_nonnull(lambda);
+  g_assert_cmpint(lambda->type, ==, LISP_AST_NODE_TYPE_LIST);
   g_assert_nonnull(var_doc);
   g_assert_cmpstr(var_doc, ==, "bar doc");
 


### PR DESCRIPTION
## Summary
- parse `Lambda-list` sections from `describe` output and attach the AST to `Function`
- ensure lambda nodes survive parser cleanup without redundant ref/unref operations
- document missing lambda list bug in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c6d52b5cd48328a5aa60959755de79