### PR TITLE
Own parsed lambdas with virtual project file

### DIFF
--- a/src/analyse_defun.c
+++ b/src/analyse_defun.c
@@ -27,7 +27,7 @@ void analyse_defun(Project *project, Node *expr, gchar **context) {
   }
   Function *function = function_new(name_node, args,
       doc_node ? node_get_name(doc_node) : NULL, NULL,
-      FUNCTION_KIND_FUNCTION, node_get_name(name_node), *context);
+      FUNCTION_KIND_FUNCTION, node_get_name(name_node), *context, NULL);
   if (node_is_toplevel(expr))
     project_add_function(project, function);
   function_unref(function);

--- a/src/function.c
+++ b/src/function.c
@@ -1,4 +1,5 @@
 #include "function.h"
+#include "project_file.h"
 
 struct Function {
   gint ref;
@@ -9,11 +10,13 @@ struct Function {
   gchar *name;
   gchar *package;
   FunctionKind kind;
+  ProjectFile *file;
 };
 
 Function *
 function_new(Node *symbol, Node *lambda_list, const gchar *doc_string,
-    Node *type, FunctionKind kind, const gchar *name, const gchar *package)
+    Node *type, FunctionKind kind, const gchar *name, const gchar *package,
+    ProjectFile *file)
 {
   Function *function = g_new0(Function, 1);
   g_atomic_int_set(&function->ref, 1);
@@ -26,6 +29,7 @@ function_new(Node *symbol, Node *lambda_list, const gchar *doc_string,
   function->package = package ? g_strdup(package) :
     (symbol ? g_strdup(symbol->package_context) : NULL);
   function->kind = kind;
+  function->file = file;
   return function;
 }
 
@@ -49,6 +53,8 @@ function_finalize(Function *function)
   g_clear_pointer(&function->doc_string, g_free);
   g_clear_pointer(&function->name, g_free);
   g_clear_pointer(&function->package, g_free);
+  if (function->file)
+    project_file_free(function->file);
 }
 
 void

--- a/src/function.h
+++ b/src/function.h
@@ -12,7 +12,7 @@ typedef struct Function Function;
 
 Function *function_new(Node *symbol, Node *lambda_list,
     const gchar *doc_string, Node *type, FunctionKind kind,
-    const gchar *name, const gchar *package);
+    const gchar *name, const gchar *package, ProjectFile *file);
 Function *function_ref(Function *function);
 void function_unref(Function *function);
 

--- a/src/project_file.c
+++ b/src/project_file.c
@@ -36,6 +36,16 @@ ProjectFile *project_file_new(Project *project, TextProvider *provider,
   return file;
 }
 
+ProjectFile *project_file_new_virtual(TextProvider *provider) {
+  g_return_val_if_fail(provider, NULL);
+  ProjectFile *file = g_new0(ProjectFile, 1);
+  file->state = PROJECT_FILE_LIVE;
+  file->provider = text_provider_ref(provider);
+  file->lexer = lisp_lexer_new(file->provider);
+  file->parser = lisp_parser_new();
+  return file;
+}
+
 void project_file_free(ProjectFile *file) {
   if (!file) return;
   if (file->parser) lisp_parser_free(file->parser);

--- a/src/project_file.h
+++ b/src/project_file.h
@@ -17,6 +17,7 @@ typedef struct _ProjectFile ProjectFile;
 
 ProjectFile *project_file_new(Project *project, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
+ProjectFile *project_file_new_virtual(TextProvider *provider);
 void        project_file_free(ProjectFile *file);
 ProjectFileState project_file_get_state(ProjectFile *file);
 void        project_file_set_state(ProjectFile *file, ProjectFileState state);


### PR DESCRIPTION
## Summary
- Allocate a virtual ProjectFile when describing compiled functions and let Function own it
- Extend Function to hold and free an optional ProjectFile
- Add `project_file_new_virtual` to build parser/lexer without UI-thread constraints

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68c6e15621b08328b17b4bcde7b1e459