### PR TITLE
fix: avoid trailing newline in function tooltips

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -361,3 +361,10 @@ the buffer bounds so end-of-file expressions evaluate correctly.
 reading the `describe` output for compiled functions. Tooltips therefore
 lacked argument lists. The handler now parses the `Lambda-list:` section and
 attaches the resulting AST to the `Function`.
+
+## project_function_tooltip added trailing newline
+
+Function tooltips always appended a newline after each section, leaving a blank
+line at the bottom when no further content followed. Newlines are now inserted
+only when another section is added, so tooltips no longer include trailing
+empty lines.

--- a/src/project.c
+++ b/src/project.c
@@ -152,7 +152,7 @@ gchar *project_function_tooltip(Function *function) {
       g_free(args);
       g_free(args_esc);
     }
-    g_string_append(tt, ")\n");
+    g_string_append_c(tt, ')');
     g_free(pkg_esc);
     g_free(name_esc);
     g_free(ls);
@@ -162,7 +162,9 @@ gchar *project_function_tooltip(Function *function) {
     const gchar *rel = project_file_get_relative_path(sym->file);
     if (rel) {
       gchar *rel_esc = g_markup_escape_text(rel, -1);
-      g_string_append_printf(tt, "File: %s\n", rel_esc);
+      if (tt->len)
+        g_string_append_c(tt, '\n');
+      g_string_append_printf(tt, "File: %s", rel_esc);
       g_free(rel_esc);
     }
   }

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -155,7 +155,7 @@ static void test_function_tooltip(void)
   gchar *tooltip = project_function_tooltip(fn);
   g_assert_nonnull(tooltip);
   g_assert_cmpstr(tooltip, ==,
-      "(<span foreground=\"gray\">CL-USER</span>:FOO X Y)\n\ndoc");
+      "(<span foreground=\"gray\">CL-USER</span>:FOO X Y)\ndoc");
   g_free(tooltip);
   project_unref(project);
 }


### PR DESCRIPTION
## Summary
- ensure `project_function_tooltip` only inserts newlines before additional sections
- adjust tooltip unit test accordingly
- document the trailing newline bug in BUGS.md

## Testing
- `cd src && make app-full`
- `cd tests && make run`

------
https://chatgpt.com/codex/tasks/task_e_68c6e4c8143c8328a541a4e821f6d151