### PR TITLE
Style tooltips with light gray background

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -151,6 +151,17 @@ app_startup (GApplication *app)
   App *self = GLIDE_APP(app);
   self->project = project_new(self->glide);
   actions_init(self);
+
+  // Load tooltip CSS
+  GtkCssProvider *provider = gtk_css_provider_new();
+  gtk_css_provider_load_from_data(provider,
+      "tooltip { color: #000; background-color: #eee; }",
+      -1, NULL);
+  gtk_style_context_add_provider_for_screen(
+      gdk_screen_get_default(),
+      GTK_STYLE_PROVIDER(provider),
+      GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  g_object_unref(provider);
 }
 
 static void


### PR DESCRIPTION
## Summary
- style tooltips using CSS to render black text on a light gray background

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c6e5ffdfb483288e7d56ddf883638d