### PR TITLE
Format function tooltip

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -140,17 +140,32 @@ gchar *project_function_tooltip(Function *function) {
     gsize len = strlen(ls);
     gchar *pkg_esc = pkg ? g_markup_escape_text(pkg, -1) : NULL;
     gchar *name_esc = g_markup_escape_text(name, -1);
-    g_string_append_c(tt, '(');
     if (pkg_esc)
-      g_string_append_printf(tt, "<span foreground=\"gray\">%s</span>:", pkg_esc);
-    g_string_append(tt, name_esc);
+      g_string_append_printf(tt,
+          "In <span foreground=\"darkgreen\">%s</span>:\n", pkg_esc);
+    g_string_append_printf(tt, "(<span foreground=\"brown\">%s</span>",
+        name_esc);
     if (len > 2 && ls[0] == '(' && ls[len - 1] == ')') {
       gchar *args = g_strndup(ls + 1, len - 2);
-      gchar *args_esc = g_markup_escape_text(args, -1);
       g_string_append_c(tt, ' ');
-      g_string_append(tt, args_esc);
+      gchar **tokens = g_strsplit_set(args, " \t\n", 0);
+      gboolean first = TRUE;
+      for (guint i = 0; tokens[i]; i++) {
+        if (!tokens[i][0])
+          continue;
+        if (!first)
+          g_string_append_c(tt, ' ');
+        gchar *tok_esc = g_markup_escape_text(tokens[i], -1);
+        if (tokens[i][0] == '&')
+          g_string_append_printf(tt,
+              "<span foreground=\"darkgreen\">%s</span>", tok_esc);
+        else
+          g_string_append(tt, tok_esc);
+        g_free(tok_esc);
+        first = FALSE;
+      }
+      g_strfreev(tokens);
       g_free(args);
-      g_free(args_esc);
     }
     g_string_append_c(tt, ')');
     g_free(pkg_esc);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -147,7 +147,7 @@ static void test_functions_table(void)
 static void test_function_tooltip(void)
 {
   Project *project = project_new(NULL);
-  TextProvider *provider = string_text_provider_new("(defun foo (x y) \"doc\")");
+  TextProvider *provider = string_text_provider_new("(defun foo (x &rest rest) \"doc\")");
   ProjectFile *file = project_add_file(project, provider, NULL, NULL, PROJECT_FILE_LIVE);
   text_provider_unref(provider);
   project_file_changed(project, file);
@@ -155,7 +155,8 @@ static void test_function_tooltip(void)
   gchar *tooltip = project_function_tooltip(fn);
   g_assert_nonnull(tooltip);
   g_assert_cmpstr(tooltip, ==,
-      "(<span foreground=\"gray\">CL-USER</span>:FOO X Y)\ndoc");
+      "In <span foreground=\"darkgreen\">CL-USER</span>:\n"
+      "(<span foreground=\"brown\">FOO</span> X <span foreground=\"darkgreen\">&amp;REST</span> REST)\ndoc");
   g_free(tooltip);
   project_unref(project);
 }


### PR DESCRIPTION
## Summary
- Reformat function tooltips to show package on separate line and color-code package and function names
- Highlight keyword parameters in dark green within tooltips
- Adjust tests for new keyword highlighting

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7f7b108832886d520697daa0c78