### PR TITLE
format function tooltip

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -143,7 +143,7 @@ gchar *project_function_tooltip(Function *function) {
     if (pkg_esc)
       g_string_append_printf(tt,
           "In <span foreground=\"darkgreen\">%s</span>:\n", pkg_esc);
-    g_string_append_printf(tt, "(<span foreground=\"brown\">%s</span>",
+    g_string_append_printf(tt, "(<span foreground=\"brown\"><b>%s</b></span>",
         name_esc);
     if (len > 2 && ls[0] == '(' && ls[len - 1] == ')') {
       gchar *args = g_strndup(ls + 1, len - 2);
@@ -186,7 +186,7 @@ gchar *project_function_tooltip(Function *function) {
   const gchar *doc = function_get_doc_string(function);
   if (doc && *doc) {
     if (tt->len)
-      g_string_append_c(tt, '\n');
+      g_string_append(tt, "\n\n");
     gchar *doc_esc = g_markup_escape_text(doc, -1);
     g_string_append(tt, doc_esc);
     g_free(doc_esc);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -156,7 +156,8 @@ static void test_function_tooltip(void)
   g_assert_nonnull(tooltip);
   g_assert_cmpstr(tooltip, ==,
       "In <span foreground=\"darkgreen\">CL-USER</span>:\n"
-      "(<span foreground=\"brown\">FOO</span> X <span foreground=\"darkgreen\">&amp;REST</span> REST)\ndoc");
+      "(<span foreground=\"brown\"><b>FOO</b></span> X <span foreground=\"darkgreen\">&amp;REST</span> REST)\n\n"
+      "doc");
   g_free(tooltip);
   project_unref(project);
 }


### PR DESCRIPTION
## Summary
- show function names in bold in tooltips
- add a blank line between signature and docstring
- update tooltip test

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68c7c40242648328b286b1a9cf5ce2cd