### PR TITLE
Rename tooltip query callbacks

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -23,7 +23,7 @@ G_DEFINE_TYPE (Editor, editor, GTK_TYPE_SCROLLED_WINDOW)
 
 // Forward declaration for the callback
 static void on_buffer_changed (GtkTextBuffer *buffer, gpointer user_data);
-static gboolean on_query_tooltip (GtkWidget *widget, gint x, gint y,
+static gboolean editor_on_query_tooltip (GtkWidget *widget, gint x, gint y,
     gboolean /*keyboard_mode*/, GtkTooltip *tooltip, gpointer user_data);
 
 static void
@@ -41,7 +41,7 @@ editor_init (Editor *self)
   gtk_container_add (GTK_CONTAINER (self), GTK_WIDGET (self->view));
   gtk_widget_set_has_tooltip (GTK_WIDGET (self->view), TRUE);
   g_signal_connect (self->view, "query-tooltip",
-      G_CALLBACK (on_query_tooltip), self);
+      G_CALLBACK (editor_on_query_tooltip), self);
 
   self->project = NULL;
   self->file = NULL;
@@ -196,7 +196,7 @@ find_node_containing_range (const Node *node, gsize start, gsize end, gsize len)
 }
 
 static gboolean
-on_query_tooltip (GtkWidget *widget, gint x, gint y, gboolean /*keyboard_mode*/,
+editor_on_query_tooltip (GtkWidget *widget, gint x, gint y, gboolean /*keyboard_mode*/,
     GtkTooltip *tooltip, gpointer user_data)
 {
   Editor *self = GLIDE_EDITOR (user_data);

--- a/src/project_view.c
+++ b/src/project_view.c
@@ -36,7 +36,7 @@ static gboolean schedule_project_changed(gpointer data);
 static void on_project_changed(Project *project, gpointer user_data);
 static gint compare_names(gconstpointer a, gconstpointer b, gpointer user_data);
 static GdkPixbuf *load_icon(const gchar *filename);
-static gboolean on_query_tooltip(GtkWidget *widget, gint x, gint y,
+static gboolean project_view_on_query_tooltip(GtkWidget *widget, gint x, gint y,
     gboolean keyboard_mode, GtkTooltip *tooltip, gpointer /*user_data*/);
 
 static void
@@ -53,7 +53,7 @@ project_view_init(ProjectView *self)
       GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_INT, G_TYPE_POINTER);
   gtk_tree_view_set_model(GTK_TREE_VIEW(self), GTK_TREE_MODEL(self->store));
   gtk_widget_set_has_tooltip(GTK_WIDGET(self), TRUE);
-  g_signal_connect(self, "query-tooltip", G_CALLBACK(on_query_tooltip), self);
+  g_signal_connect(self, "query-tooltip", G_CALLBACK(project_view_on_query_tooltip), self);
 
   column = gtk_tree_view_column_new();
   /* Use a single column with icon and text renderers so the icon
@@ -327,7 +327,7 @@ on_button_press(GtkWidget *widget, GdkEventButton *event, gpointer data)
 }
 
 static gboolean
-on_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
+project_view_on_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
     GtkTooltip *tooltip, gpointer /*user_data*/)
 {
   GtkTreeModel *model;


### PR DESCRIPTION
## Summary
- Rename editor tooltip callback to `editor_on_query_tooltip`
- Rename project view tooltip callback to `project_view_on_query_tooltip`

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3840f2c8328a5dc444e5808f4b8