### PR TITLE
Add Node offset accessors

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -46,6 +46,24 @@ gboolean node_is_toplevel(const Node *node) {
   return node->parent->parent == NULL;
 }
 
+gsize node_get_start_offset(const Node *node) {
+  g_return_val_if_fail(node, 0);
+  if (node->start_token)
+    return node->start_token->start_offset;
+  g_return_val_if_fail(node->children && node->children->len > 0, 0);
+  Node *child = g_array_index(node->children, Node*, 0);
+  return node_get_start_offset(child);
+}
+
+gsize node_get_end_offset(const Node *node) {
+  g_return_val_if_fail(node, 0);
+  if (node->end_token)
+    return node->end_token->end_offset;
+  g_return_val_if_fail(node->children && node->children->len > 0, 0);
+  Node *child = g_array_index(node->children, Node*, node->children->len - 1);
+  return node_get_end_offset(child);
+}
+
 const gchar *node_sd_type_to_string(StringDesignatorType sd_type) {
   switch(sd_type) {
     case SDT_VAR_DEF: return "VarDef";

--- a/src/node.h
+++ b/src/node.h
@@ -47,6 +47,8 @@ Node *node_ref(Node *node);
 void node_unref(Node *node);
 gboolean node_is(const Node *node, StringDesignatorType t);
 gboolean node_is_toplevel(const Node *node);
+gsize node_get_start_offset(const Node *node);
+gsize node_get_end_offset(const Node *node);
 const gchar *node_sd_type_to_string(StringDesignatorType sd_type);
 gchar *node_debug_string(const Node *node);
 gchar *node_to_string(const Node *node);


### PR DESCRIPTION
## Summary
- add helper functions to compute a node's start and end offsets

## Testing
- `make app-full`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec4428ac832882d1d2fdf3d7684f