### PR TITLE
Move range search to node

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -368,3 +368,10 @@ Function tooltips always appended a newline after each section, leaving a blank
 line at the bottom when no further content followed. Newlines are now inserted
 only when another section is added, so tooltips no longer include trailing
 empty lines.
+
+## find_node_containing_range used token offsets
+
+The AST range search function relied on token offsets and lived in `editor.c`,
+so nodes without explicit tokens were skipped and the code was misplaced.
+`node_find_containing_range` now resides in `node.c` and computes bounds using
+`node_get_start_offset` and `node_get_end_offset` to handle all nodes.

--- a/src/node.c
+++ b/src/node.c
@@ -64,6 +64,23 @@ gsize node_get_end_offset(const Node *node) {
   return node_get_end_offset(child);
 }
 
+const Node *node_find_containing_range(const Node *node, gsize start, gsize end) {
+  g_return_val_if_fail(node, NULL);
+  gsize node_start = node_get_start_offset(node);
+  gsize node_end = node_get_end_offset(node);
+  if (start < node_start || end > node_end)
+    return NULL;
+  if (node->children) {
+    for (guint i = 0; i < node->children->len; i++) {
+      const Node *child = g_array_index(node->children, Node*, i);
+      const Node *found = node_find_containing_range(child, start, end);
+      if (found)
+        return found;
+    }
+  }
+  return node;
+}
+
 const gchar *node_sd_type_to_string(StringDesignatorType sd_type) {
   switch(sd_type) {
     case SDT_VAR_DEF: return "VarDef";

--- a/src/node.h
+++ b/src/node.h
@@ -49,6 +49,7 @@ gboolean node_is(const Node *node, StringDesignatorType t);
 gboolean node_is_toplevel(const Node *node);
 gsize node_get_start_offset(const Node *node);
 gsize node_get_end_offset(const Node *node);
+const Node *node_find_containing_range(const Node *node, gsize start, gsize end);
 const gchar *node_sd_type_to_string(StringDesignatorType sd_type);
 gchar *node_debug_string(const Node *node);
 gchar *node_to_string(const Node *node);


### PR DESCRIPTION
## Summary
- Move range lookup helper from editor to node module
- Use start and end offset helpers to find the enclosing node
- Document prior bug about token-based node ranges

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c7f0bb4a408328bfea8b8c762a8a54