### PR TITLE
Remember last open file between sessions

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -375,3 +375,11 @@ The AST range search function relied on token offsets and lived in `editor.c`,
 so nodes without explicit tokens were skipped and the code was misplaced.
 `node_find_containing_range` now resides in `node.c` and computes bounds using
 `node_get_start_offset` and `node_get_end_offset` to handle all nodes.
+
+## Last open file not restored
+
+Glide failed to reopen the previously active file on startup. The application
+only saved the current file when quitting, so unexpected termination left the
+preferences without the last file and cursor position. The page switch handler
+now updates both values whenever the user changes tabs, ensuring the last open
+file and cursor are restored at launch.

--- a/src/app.c
+++ b/src/app.c
@@ -350,9 +350,20 @@ on_notebook_switch_page(GtkNotebook * /*notebook*/, GtkWidget *page, guint /*pag
   if (!file)
     return;
   const gchar *rel = project_file_get_relative_path(file);
-  if (!rel)
-    return;
-  project_view_select_file(PROJECT_VIEW(view), rel);
+  if (rel)
+    project_view_select_file(PROJECT_VIEW(view), rel);
+
+  Preferences *prefs = app_get_preferences(self);
+  if (prefs) {
+    preferences_set_last_file(prefs, project_file_get_path(file));
+    GtkTextBuffer *buffer = project_file_get_buffer(file);
+    g_return_if_fail(buffer);
+    GtkTextMark *mark = gtk_text_buffer_get_insert(buffer);
+    GtkTextIter iter;
+    gtk_text_buffer_get_iter_at_mark(buffer, &iter, mark);
+    gint pos = gtk_text_iter_get_offset(&iter);
+    preferences_set_cursor_position(prefs, pos);
+  }
 }
 
 STATIC void


### PR DESCRIPTION
## Summary
- persist last opened file and cursor on tab changes
- assert editor buffers exist when saving cursor
- document fix for last file not being restored

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c7f4f2c058832892e95b1e590469d7