### PR TITLE
Treat DEFPACKAGE in backquote as normal code

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -390,3 +390,10 @@ Reader macros `'`, `` ` ``, `,` and `,@` were tokenized as part of the following
 parser produced leaf symbol nodes instead of wrapping the next expression. The lexer now emits
 dedicated tokens for these macros, and the parser attaches the following s-expression as their
 child, yielding correct ASTs.
+
+## DEFPACKAGE in backquote skipped code analysis
+
+`DEFPACKAGE` forms appearing inside a backquoted expression were analysed as
+package declarations, so comma expressions within them were ignored. The
+analyser now treats `DEFPACKAGE` and `IN-PACKAGE` inside backquotes as regular
+function calls, ensuring that comma subforms are interpreted as code.

--- a/src/analyse.c
+++ b/src/analyse.c
@@ -35,20 +35,22 @@ void analyse_node(Project *project, Node *node, AnalyseContext *context) {
         if (name) {
           if (!first->sd_type)
             node_set_sd_type(first, SDT_FUNCTION_USE, context->package);
-          if (strcmp(name, "DEFUN") == 0) {
-            analyse_defun(project, node, context);
-            return;
-          } else if (strcmp(name, "IN-PACKAGE") == 0 && node->children->len > 1) {
-            Node *pkg_node = g_array_index(node->children, Node*, 1);
-            analyse_node(project, pkg_node, context);
-            const gchar *pkg_name = node_get_name(pkg_node);
-            if (pkg_name) {
-              g_free(context->package);
-              context->package = g_strdup(pkg_name);
+          if (!context->backquote) {
+            if (strcmp(name, "DEFUN") == 0) {
+              analyse_defun(project, node, context);
+              return;
+            } else if (strcmp(name, "IN-PACKAGE") == 0 && node->children->len > 1) {
+              Node *pkg_node = g_array_index(node->children, Node*, 1);
+              analyse_node(project, pkg_node, context);
+              const gchar *pkg_name = node_get_name(pkg_node);
+              if (pkg_name) {
+                g_free(context->package);
+                context->package = g_strdup(pkg_name);
+              }
+            } else if (strcmp(name, "DEFPACKAGE") == 0) {
+              analyse_defpackage(project, node, context);
+              return;
             }
-          } else if (strcmp(name, "DEFPACKAGE") == 0) {
-            analyse_defpackage(project, node, context);
-            return;
           }
         }
       }

--- a/src/analyse_defpackage.c
+++ b/src/analyse_defpackage.c
@@ -102,7 +102,7 @@ void analyse_defpackage(Project *project, Node *expr, AnalyseContext *context) {
     }
   }
 
-  if (node_is_toplevel(expr) && pkg && !context->backquote) {
+  if (node_is_toplevel(expr) && pkg) {
     AddPackageData *data = g_new0(AddPackageData, 1);
     data->project = project;
     data->package = package_ref(pkg);

--- a/src/analyse_defun.c
+++ b/src/analyse_defun.c
@@ -28,7 +28,7 @@ void analyse_defun(Project *project, Node *expr, AnalyseContext *context) {
   Function *function = function_new(name_node, args,
       doc_node ? node_get_name(doc_node) : NULL, NULL,
       FUNCTION_KIND_FUNCTION, node_get_name(name_node), context->package, NULL);
-  if (node_is_toplevel(expr) && !context->backquote)
+  if (node_is_toplevel(expr))
     project_add_function(project, function);
   function_unref(function);
 


### PR DESCRIPTION
## Summary
- Avoid special-case analysis for IN-PACKAGE and DEFPACKAGE when inside a backquote
- Remove backquote guards from DEFUN and DEFPACKAGE analyzers

## Testing
- `cd src && make app-full`
- `cd tests && make run`


------
https://chatgpt.com/codex/tasks/task_e_68c832092e60832891022f90ee511f9a