### PR TITLE
Fix toplevel analysis of file root

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -397,3 +397,12 @@ child, yielding correct ASTs.
 package declarations, so comma expressions within them were ignored. The
 analyser now treats `DEFPACKAGE` and `IN-PACKAGE` inside backquotes as regular
 function calls, ensuring that comma subforms are interpreted as code.
+
+## Toplevel analysis treated file as a list form
+
+Analysing a file walked the artificial toplevel list as if it were code. The
+file node's helper children represent each top-level form, but the analyser
+tagged later children as variable uses because it treated them as arguments to
+the first expression. The analyser now iterates over the toplevel children
+directly, so each form is analysed independently and top-level symbols keep
+their correct roles.

--- a/src/analyse.c
+++ b/src/analyse.c
@@ -65,8 +65,13 @@ void analyse_node(Project *project, Node *node, AnalyseContext *context) {
 }
 
 void analyse_ast(Project *project, Node *root) {
+  g_return_if_fail(root != NULL);
+
   AnalyseContext context = { g_strdup("CL-USER"), FALSE };
-  analyse_node(project, root, &context);
+  if (root->children) {
+    for (guint i = 0; i < root->children->len; i++)
+      analyse_node(project, g_array_index(root->children, Node*, i), &context);
+  }
   g_free(context.package);
 }
 


### PR DESCRIPTION
## Summary
- avoid treating the synthetic toplevel list as a regular form and analyse each child expression instead
- guard analyse_ast against null roots while skipping empty toplevels
- record the regression in BUGS.md

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68c84768b23883288f4bd627bc6b983c