### PR TITLE
Handle macros and special operators in describe output

### DIFF
--- a/tests/project_repl_test.c
+++ b/tests/project_repl_test.c
@@ -15,14 +15,20 @@ static void test_describe(void) {
 
   project_request_describe(project, "COMMON-LISP-USER", "FOO");
   project_request_describe(project, "COMMON-LISP-USER", "*BAR*");
+  project_request_describe(project, "COMMON-LISP", "WHEN");
+  project_request_describe(project, "COMMON-LISP", "IF");
 
   Function *fn = NULL;
+  Function *macro_fn = NULL;
+  Function *special_fn = NULL;
   const gchar *var_doc = NULL;
   for (int i = 0; i < 200; i++) {
     g_main_context_iteration(NULL, FALSE);
     fn = project_get_function(project, "FOO");
+    macro_fn = project_get_function(project, "WHEN");
+    special_fn = project_get_function(project, "IF");
     var_doc = project_get_variable(project, "*BAR*");
-    if (fn && var_doc)
+    if (fn && macro_fn && special_fn && var_doc)
       break;
     g_usleep(100000);
   }
@@ -32,6 +38,24 @@ static void test_describe(void) {
   const Node *lambda = function_get_lambda_list(fn);
   g_assert_nonnull(lambda);
   g_assert_cmpint(lambda->type, ==, LISP_AST_NODE_TYPE_LIST);
+  g_assert_nonnull(macro_fn);
+  g_assert_cmpint(function_get_kind(macro_fn), ==, FUNCTION_KIND_MACRO);
+  const Node *macro_lambda = function_get_lambda_list(macro_fn);
+  g_assert_nonnull(macro_lambda);
+  g_assert_cmpint(macro_lambda->type, ==, LISP_AST_NODE_TYPE_LIST);
+  const gchar *macro_doc = function_get_doc_string(macro_fn);
+  g_assert_nonnull(macro_doc);
+  g_assert_nonnull(g_strrstr(macro_doc, "rest of the forms"));
+  g_assert_nonnull(special_fn);
+  g_assert_cmpint(function_get_kind(special_fn), ==,
+      FUNCTION_KIND_SPECIAL_OPERATOR);
+  const Node *special_lambda = function_get_lambda_list(special_fn);
+  g_assert_nonnull(special_lambda);
+  g_assert_cmpint(special_lambda->type, ==, LISP_AST_NODE_TYPE_LIST);
+  const gchar *special_doc = function_get_doc_string(special_fn);
+  g_assert_nonnull(special_doc);
+  g_assert_nonnull(g_strrstr(special_doc, "IF predicate then [else]"));
+  g_assert_nonnull(g_strrstr(special_doc, "otherwise evaluate ELSE"));
   g_assert_nonnull(var_doc);
   g_assert_cmpstr(var_doc, ==, "bar doc");
 


### PR DESCRIPTION
## Summary
- share the describe section parsing so macros and special operators populate project data like compiled functions
- collect multi-paragraph documentation when parsing describe output
- extend the project REPL test to cover macros and special operators from COMMON-LISP

## Testing
- make app-full (from src)
- make run (from tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9cec25f9c8328857b933ebd6468eb