### PR TITLE
Update function tooltip header text

### DIFF
--- a/src/function.c
+++ b/src/function.c
@@ -100,6 +100,21 @@ function_get_kind(const Function *function)
   return function ? function->kind : FUNCTION_KIND_FUNCTION;
 }
 
+static const gchar *
+function_get_kind_name(FunctionKind kind)
+{
+  switch (kind) {
+    case FUNCTION_KIND_COMPILED_FUNCTION:
+      return "compiled function";
+    case FUNCTION_KIND_MACRO:
+      return "macro";
+    case FUNCTION_KIND_SPECIAL_OPERATOR:
+      return "special operator";
+    default:
+      return "function";
+  }
+}
+
 const gchar *
 function_get_name(const Function *function)
 {
@@ -123,11 +138,20 @@ function_tooltip(Function *function)
   if (lambda && name) {
     gchar *ls = node_to_string(lambda);
     gsize len = strlen(ls);
+    FunctionKind kind = function_get_kind(function);
+    const gchar *kind_name = function_get_kind_name(kind);
     gchar *pkg_esc = pkg ? g_markup_escape_text(pkg, -1) : NULL;
     gchar *name_esc = g_markup_escape_text(name, -1);
-    if (pkg_esc)
-      g_string_append_printf(tt,
-          "In <span foreground=\"darkgreen\">%s</span>:\n", pkg_esc);
+    if (name_esc) {
+      if (pkg_esc)
+        g_string_append_printf(tt,
+            "<span foreground=\"brown\"><b>%s</b></span> is a %s in <span foreground=\"darkgreen\">%s</span>:\n",
+            name_esc, kind_name, pkg_esc);
+      else
+        g_string_append_printf(tt,
+            "<span foreground=\"brown\"><b>%s</b></span> is a %s:\n", name_esc,
+            kind_name);
+    }
     g_string_append_printf(tt, "(<span foreground=\"brown\"><b>%s</b></span>",
         name_esc);
     if (len > 2 && ls[0] == '(' && ls[len - 1] == ')') {

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -168,7 +168,7 @@ static void test_function_tooltip(void)
   gchar *tooltip = function_tooltip(fn);
   g_assert_nonnull(tooltip);
   g_assert_cmpstr(tooltip, ==,
-      "In <span foreground=\"darkgreen\">CL-USER</span>:\n"
+      "<span foreground=\"brown\"><b>FOO</b></span> is a function in <span foreground=\"darkgreen\">CL-USER</span>:\n"
       "(<span foreground=\"brown\"><b>FOO</b></span> X <span foreground=\"darkgreen\">&amp;REST</span> REST)\n\n"
       "doc");
   g_free(tooltip);


### PR DESCRIPTION
## Summary
- show each function tooltip as "name is a <kind> in <package>" and escape markup accordingly
- adjust the project tooltip test expectation for the new introductory line
- factor converting `FunctionKind` values into tooltip labels into a helper

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68c9d676bbf883288d962499d1f1ab3b