### PR TITLE
Request core packages whenever clearing a project

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -415,3 +415,11 @@ tagged later children as variable uses because it treated them as arguments to
 the first expression. The analyser now iterates over the toplevel children
 directly, so each form is analysed independently and top-level symbols keep
 their correct roles.
+
+## COMMON-LISP package not refreshed after switching projects
+
+Loading another project cleared the index but never asked the REPL to describe
+`COMMON-LISP` again. Only the first project populated the core packages, so
+standard symbols were missing afterwards. Package bootstrap now happens inside
+`project_clear()`, ensuring both startup and later project loads request
+`COMMON-LISP` and `COMMON-LISP-USER` from the REPL.

--- a/src/project.c
+++ b/src/project.c
@@ -35,13 +35,10 @@ Project *project_new(ReplSession *repl) {
   LOG(1, "project_new");
   Project *self = project_init();
   self->repl = repl ? repl_session_ref(repl) : NULL;
+  project_clear(self);
   TextProvider *provider = string_text_provider_new("");
   project_add_file(self, provider, NULL, "unnamed.lisp", PROJECT_FILE_LIVE);
   text_provider_unref(provider);
-  if (self->repl) {
-    project_request_package(self, "COMMON-LISP");
-    project_request_package(self, "COMMON-LISP-USER");
-  }
   return self;
 }
 
@@ -203,6 +200,10 @@ void project_clear(Project *self) {
   Asdf *asdf = asdf_new();
   project_set_asdf(self, asdf);
   g_object_unref(asdf);
+  if (self->repl) {
+    project_request_package(self, "COMMON-LISP");
+    project_request_package(self, "COMMON-LISP-USER");
+  }
   project_changed(self);
 }
 


### PR DESCRIPTION
## Summary
- call project_clear() when constructing a project so initialization flows through the standard reset path
- request COMMON-LISP packages inside project_clear() so both the first project and later loads populate built-in definitions
- document the regression in BUGS.md

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68cabef8db8883289818356e62df72bc