### PR TITLE
Fix toplevel evaluation selecting entire buffer

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -61,6 +61,14 @@ beginning of a line. Evaluation now asks `Editor` for the enclosing
 top‑level range, which is shared with the selection expansion logic, so the
 correct expression is sent to swank.
 
+## Eval toplevel evaluated entire buffer
+
+Evaluating a top-level form sometimes forwarded the whole buffer to the REPL.
+`editor_get_toplevel_range` walked to the parent node repeatedly until the
+request reached the AST root, whose bounds match the entire buffer, and
+returned that range. The parent search now stops when it reaches the root node,
+so evaluation selects the actual surrounding form instead of the whole file.
+
 ## eval-and-capture evaluated raw strings
 
 `eval-and-capture` expected a parsed form but the server sent it expressions as

--- a/src/editor.c
+++ b/src/editor.c
@@ -381,6 +381,11 @@ find_parent_range (GtkTextBuffer *buffer, ProjectFile *file,
     parent = node->parent;
   }
 
+  if (!parent) {
+    LOG(1, "at root node, cannot extend");
+    return FALSE;
+  }
+
   if (node_start == start && node_end == end) {
     if (start == 0 && end == len) {
       LOG(1, "at buffer range, cannot extend");


### PR DESCRIPTION
## Summary
- prevent editor toplevel range detection from extending past the AST root
- document the regression in BUGS.md

## Testing
- make app-full
- make run


------
https://chatgpt.com/codex/tasks/task_e_68cbc1161f8483289e73c7fccaa1563a