### PR TITLE
Provide defun analysis error messages

### DIFF
--- a/src/analyse_defun.c
+++ b/src/analyse_defun.c
@@ -3,32 +3,37 @@
 #include "function.h"
 #include "project_file.h"
 
-static void analyse_defun_mark_error(Node *expr) {
-  if (!expr || !expr->file)
+static void analyse_defun_mark_error(Node *node, const gchar *message) {
+  if (!node || !node->file)
     return;
-  gsize start = node_get_start_offset(expr);
-  gsize end = node_get_end_offset(expr);
+  gsize start = node_get_start_offset(node);
+  gsize end = node_get_end_offset(node);
   if (end <= start)
     return;
-  project_file_add_error(expr->file, start, end);
+  project_file_add_error(node->file, start, end, message);
 }
 
 void analyse_defun(Project *project, Node *expr, AnalyseContext *context) {
   g_return_if_fail(expr);
   g_return_if_fail(expr->children);
 
+  g_return_if_fail(expr->children->len > 1);
   Node *name_node = g_array_index(expr->children, Node*, 1);
-  if (!name_node || name_node->type != LISP_AST_NODE_TYPE_SYMBOL) {
-    analyse_defun_mark_error(expr);
+  g_return_if_fail(name_node);
+  if (name_node->type != LISP_AST_NODE_TYPE_SYMBOL) {
+    analyse_defun_mark_error(name_node, "DEFUN requires a symbol name.");
     return;
   }
   Node *name_symbol = node_get_symbol_name_node(name_node);
-  if (name_symbol && !name_symbol->sd_type)
+  g_return_if_fail(name_symbol);
+  if (!name_symbol->sd_type)
     node_set_sd_type(name_symbol, SDT_FUNCTION_DEF, context->package);
 
+  g_return_if_fail(expr->children->len > 2);
   Node *args = g_array_index(expr->children, Node*, 2);
-  if (!args || args->type != LISP_AST_NODE_TYPE_LIST) {
-    analyse_defun_mark_error(expr);
+  g_return_if_fail(args);
+  if (args->type != LISP_AST_NODE_TYPE_LIST) {
+    analyse_defun_mark_error(args, "DEFUN requires a parameter list.");
     return;
   }
   if (args->type == LISP_AST_NODE_TYPE_LIST && args->children) {

--- a/src/project_file.h
+++ b/src/project_file.h
@@ -18,6 +18,7 @@ typedef struct _ProjectFile ProjectFile;
 typedef struct {
   gsize start;
   gsize end;
+  gchar *message;
 } ProjectFileError;
 
 ProjectFile *project_file_new(Project *project, TextProvider *provider,
@@ -37,6 +38,7 @@ void        project_file_set_path(ProjectFile *file, const gchar *path);
 gboolean    project_file_load(ProjectFile *file);
 const gchar *project_file_get_relative_path(ProjectFile *file);
 void        project_file_clear_errors(ProjectFile *file);
-void        project_file_add_error(ProjectFile *file, gsize start, gsize end);
+void        project_file_add_error(ProjectFile *file, gsize start, gsize end,
+    const gchar *message);
 void        project_file_apply_errors(ProjectFile *file);
 const GArray *project_file_get_errors(ProjectFile *file);


### PR DESCRIPTION
## Summary
- include explicit error messages when analyse_defun flags malformed DEFUN forms
- cover DEFUN validation with project tests for missing symbol names and parameter lists
- ensure DEFUN diagnostics assert parser-provided nodes exist and highlight the offending elements

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68cbd698bf50832883c8c1e08a9949b9