### PR TITLE
Fix duplicated documentation in argument errors

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -9,6 +9,13 @@ The application crashed on startup because `editor_dispose` explicitly unreferen
 widget. The `GtkScrolledWindow` parent already disposes of its children, so unreferencing the view again left GTK trying
 to dispose an already finalized object, triggering the GLib critical `instance with invalid (NULL) class pointer`.
 
+## Argument error tooltip duplicated documentation
+
+Hovering an argument arity error showed the function documentation twice: once as escaped plain text in the error
+tooltip and once in the coloured documentation section. The analyser appended the function tooltip, which already
+contains the doc string, to the diagnostic message so the editor displayed both copies. The analyser now limits the
+error message to the argument count details and leaves the documentation to the dedicated function tooltip.
+
 ## Crash when restoring last file at startup
 
 The application crashed when restoring the previously opened file at startup.

--- a/src/analyse.c
+++ b/src/analyse.c
@@ -113,15 +113,11 @@ static gboolean analyse_validate_call(Project *project, Node *expr) {
   guint actual = expr->children->len > 0 ? expr->children->len - 1 : 0;
   if (actual < min_args || (has_max && actual > max_args)) {
     guint expected = actual < min_args ? min_args : max_args;
-    gchar *tooltip = function_tooltip(function);
-    gchar *message = tooltip && *tooltip
-        ? g_strdup_printf("Expected %u arguments but found %u\n%s", expected,
-            actual, tooltip)
-        : g_strdup_printf("Expected %u arguments but found %u", expected,
-            actual);
+    gchar *message = g_strdup_printf(
+        "Expected %u arguments for %s but found %u", expected, fn_name,
+        actual);
     analyse_mark_error(expr, message);
     g_free(message);
-    g_free(tooltip);
     return FALSE;
   }
   return TRUE;

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -286,15 +286,9 @@ static void test_function_call_argument_mismatch(void)
   gsize len = text_provider_get_length(file_provider);
   g_assert_cmpuint(err->end, ==, len);
   g_assert_nonnull(err->message);
-  Function *project_fn = project_get_function(project, "BAR");
-  g_assert_nonnull(project_fn);
-  gchar *tooltip = function_tooltip(project_fn);
-  g_assert_nonnull(tooltip);
-  gchar *expected_msg = g_strdup_printf(
-      "Expected %u arguments but found %u\n%s", 2u, 1u, tooltip);
-  g_assert_cmpstr(err->message, ==, expected_msg);
-  g_free(expected_msg);
-  g_free(tooltip);
+  g_assert_nonnull(project_get_function(project, "BAR"));
+  g_assert_cmpstr(err->message, ==,
+      "Expected 2 arguments for BAR but found 1");
 
   StringTextProvider *stp = (StringTextProvider*)file_provider;
   g_free(stp->text);
@@ -314,13 +308,8 @@ static void test_function_call_argument_mismatch(void)
   g_assert_cmpuint(errors->len, ==, 1);
   err = &g_array_index((GArray*)errors, ProjectFileError, 0);
   g_assert_nonnull(err->message);
-  tooltip = function_tooltip(project_fn);
-  g_assert_nonnull(tooltip);
-  expected_msg = g_strdup_printf(
-      "Expected %u arguments but found %u\n%s", 2u, 3u, tooltip);
-  g_assert_cmpstr(err->message, ==, expected_msg);
-  g_free(expected_msg);
-  g_free(tooltip);
+  g_assert_cmpstr(err->message, ==,
+      "Expected 2 arguments for BAR but found 3");
 
   g_free(stp->text);
   stp->text = g_strdup("(bar 1 2)");


### PR DESCRIPTION
## Summary
- stop including function tooltips in arity error diagnostics so error tooltips no longer echo the documentation
- document the duplicate documentation bug fix in BUGS.md
- update the project tests to expect the new diagnostic strings

## Testing
- make app-full
- (cd tests && make run)

------
https://chatgpt.com/codex/tasks/task_e_68d276866c648328afab59c0ae111fd6