### PR TITLE
Stop forcing bold styling in error tooltips

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -16,6 +16,12 @@ tooltip and once in the coloured documentation section. The analyser appended th
 contains the doc string, to the diagnostic message so the editor displayed both copies. The analyser now limits the
 error message to the argument count details and leaves the documentation to the dedicated function tooltip.
 
+## Error tooltips forced bold brown text
+
+Diagnostics displayed in the editor used `<span foreground="darkred"><b>…</b></span>` markup around the message. GTK
+rendered that markup in brown bold text, so the tooltip looked unlike the rest of the UI. The editor now returns the
+escaped message directly and lets the theme style tooltips consistently.
+
 ## Crash when restoring last file at startup
 
 The application crashed when restoring the previously opened file at startup.

--- a/src/editor.c
+++ b/src/editor.c
@@ -400,10 +400,7 @@ editor_build_error_tooltip_markup (Editor *self, gsize offset)
         err->start, err->end, err->message ? err->message : "(null)");
     const gchar *message = (err->message && *err->message) ? err->message : "Error";
     gchar *message_esc = g_markup_escape_text (message, -1);
-    gchar *markup = g_strdup_printf ("<span foreground=\"darkred\"><b>%s</b></span>",
-        message_esc);
-    g_free (message_esc);
-    return markup;
+    return message_esc;
   }
   LOG (1, "Editor.build_error_tooltip: no match at offset %zu", offset);
   return NULL;


### PR DESCRIPTION
## Summary
- remove the hard-coded markup that forced error tooltips to render in brown bold text
- document the bug and its fix in BUGS.md

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d279706d748328a14d1bf79a66a3f7