### PR TITLE
Simplify editor tooltip layout styling

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@ SOURCES += \
   menu_bar.c \
   app.c \
   lisp_source_notebook.c \
+  editor_tooltip_widget.c \
   editor.c \
   lisp_lexer.c \
   lisp_parser.c \

--- a/src/editor.c
+++ b/src/editor.c
@@ -101,7 +101,7 @@ editor_dispose (GObject *object)
     g_array_free (self->selection_stack, TRUE);
     self->selection_stack = NULL;
   }
-  g_clear_object ((GObject **) &self->tooltip_widget);
+  g_clear_object (&self->tooltip_widget);
 
   G_OBJECT_CLASS (editor_parent_class)->dispose (object);
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -1,5 +1,6 @@
 #include "editor.h"
 #include "gtk_text_provider.h"
+#include "editor_tooltip_widget.h"
 #include "project.h"
 #include "util.h"
 
@@ -19,6 +20,7 @@ struct _Editor
   GArray *selection_stack;
   GtkTextTag *function_def_tag;
   GtkTextTag *function_use_tag;
+  EditorTooltipWidget *tooltip_widget;
 };
 
 G_DEFINE_TYPE (Editor, editor, GTK_TYPE_SCROLLED_WINDOW)
@@ -56,6 +58,9 @@ editor_init (Editor *self)
   self->project = NULL;
   self->file = NULL;
   self->selection_stack = g_array_new (FALSE, FALSE, sizeof (SelectionRange));
+  self->tooltip_widget = editor_tooltip_widget_new ();
+  if (self->tooltip_widget)
+    g_object_ref_sink (G_OBJECT (self->tooltip_widget));
   GtkTextBuffer *buffer = GTK_TEXT_BUFFER (self->buffer);
   self->function_def_tag = gtk_text_buffer_create_tag (buffer,
       "function-def-highlight", "background", "#fef", NULL);
@@ -96,6 +101,7 @@ editor_dispose (GObject *object)
     g_array_free (self->selection_stack, TRUE);
     self->selection_stack = NULL;
   }
+  g_clear_object ((GObject **) &self->tooltip_widget);
 
   G_OBJECT_CLASS (editor_parent_class)->dispose (object);
 }
@@ -327,19 +333,19 @@ editor_on_query_tooltip (GtkWidget *widget, gint x, gint y, gboolean /*keyboard_
   gchar *function_markup = editor_build_function_tooltip_markup (self, offset, end);
   gboolean shown = FALSE;
 
-  if (error_markup && function_markup) {
-    GString *combined = g_string_new (error_markup);
-    g_string_append (combined, "\n\n");
-    g_string_append (combined, function_markup);
-    gtk_tooltip_set_markup (tooltip, combined->str);
-    g_string_free (combined, TRUE);
-    shown = TRUE;
-  } else if (function_markup) {
-    gtk_tooltip_set_markup (tooltip, function_markup);
-    shown = TRUE;
-  } else if (error_markup) {
-    gtk_tooltip_set_markup (tooltip, error_markup);
-    shown = TRUE;
+  if (!self->tooltip_widget) {
+    self->tooltip_widget = editor_tooltip_widget_new ();
+    if (self->tooltip_widget)
+      g_object_ref_sink (G_OBJECT (self->tooltip_widget));
+  }
+
+  if (self->tooltip_widget) {
+    if (editor_tooltip_widget_set_content (self->tooltip_widget, error_markup, function_markup)) {
+      gtk_tooltip_set_custom (tooltip, GTK_WIDGET (self->tooltip_widget));
+      shown = TRUE;
+    } else {
+      gtk_tooltip_set_custom (tooltip, NULL);
+    }
   }
 
   g_free (function_markup);

--- a/src/editor_tooltip_widget.c
+++ b/src/editor_tooltip_widget.c
@@ -1,0 +1,165 @@
+#include "editor_tooltip_widget.h"
+
+#include "util.h"
+
+struct _EditorTooltipWidget
+{
+  GtkBox parent_instance;
+
+  GtkWidget *error_box;
+  GtkWidget *error_label;
+  GtkWidget *separator;
+  GtkWidget *doc_box;
+  GtkWidget *doc_label;
+};
+
+struct _EditorTooltipWidgetClass
+{
+  GtkBoxClass parent_class;
+};
+
+G_DEFINE_TYPE (EditorTooltipWidget, editor_tooltip_widget, GTK_TYPE_BOX)
+
+static void editor_tooltip_widget_init_css (void);
+
+static void
+editor_tooltip_widget_init (EditorTooltipWidget *self)
+{
+  gtk_orientable_set_orientation (GTK_ORIENTABLE (self), GTK_ORIENTATION_VERTICAL);
+  gtk_box_set_spacing (GTK_BOX (self), 0);
+
+  editor_tooltip_widget_init_css ();
+
+  GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET (self));
+  gtk_style_context_add_class (context, "editor-tooltip");
+
+  self->error_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+  GtkStyleContext *error_context = gtk_widget_get_style_context (self->error_box);
+  gtk_style_context_add_class (error_context, "editor-tooltip-error");
+  gtk_widget_set_hexpand (self->error_box, TRUE);
+
+  self->error_label = gtk_label_new (NULL);
+  gtk_label_set_line_wrap (GTK_LABEL (self->error_label), TRUE);
+  gtk_label_set_xalign (GTK_LABEL (self->error_label), 0.0);
+  gtk_container_add (GTK_CONTAINER (self->error_box), self->error_label);
+  gtk_widget_show (self->error_label);
+
+  gtk_box_pack_start (GTK_BOX (self), self->error_box, TRUE, TRUE, 0);
+  gtk_widget_set_visible (self->error_box, FALSE);
+
+  self->separator = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+  GtkStyleContext *separator_context = gtk_widget_get_style_context (self->separator);
+  gtk_style_context_add_class (separator_context, "editor-tooltip-separator");
+  gtk_widget_set_hexpand (self->separator, TRUE);
+  gtk_box_pack_start (GTK_BOX (self), self->separator, TRUE, TRUE, 0);
+  gtk_widget_set_visible (self->separator, FALSE);
+
+  self->doc_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+  GtkStyleContext *doc_context = gtk_widget_get_style_context (self->doc_box);
+  gtk_style_context_add_class (doc_context, "editor-tooltip-doc");
+  gtk_widget_set_hexpand (self->doc_box, TRUE);
+
+  self->doc_label = gtk_label_new (NULL);
+  gtk_label_set_line_wrap (GTK_LABEL (self->doc_label), TRUE);
+  gtk_label_set_xalign (GTK_LABEL (self->doc_label), 0.0);
+  gtk_container_add (GTK_CONTAINER (self->doc_box), self->doc_label);
+  gtk_widget_show (self->doc_label);
+
+  gtk_box_pack_start (GTK_BOX (self), self->doc_box, TRUE, TRUE, 0);
+  gtk_widget_set_visible (self->doc_box, FALSE);
+}
+
+static void
+editor_tooltip_widget_class_init (EditorTooltipWidgetClass *klass)
+{
+  (void) klass;
+}
+
+EditorTooltipWidget *
+editor_tooltip_widget_new (void)
+{
+  return g_object_new (EDITOR_TYPE_TOOLTIP_WIDGET, NULL);
+}
+
+static void
+editor_tooltip_widget_clear_section (GtkWidget *box, GtkWidget *label)
+{
+  if (!box || !label)
+    return;
+  gtk_label_set_text (GTK_LABEL (label), "");
+  gtk_widget_set_visible (box, FALSE);
+}
+
+gboolean
+editor_tooltip_widget_set_content (EditorTooltipWidget *self,
+    const gchar *error_markup, const gchar *doc_markup)
+{
+  g_return_val_if_fail (EDITOR_IS_TOOLTIP_WIDGET (self), FALSE);
+
+  gboolean show_error = (error_markup && *error_markup);
+  gboolean show_doc = (doc_markup && *doc_markup);
+
+  if (show_error)
+    gtk_label_set_markup (GTK_LABEL (self->error_label), error_markup);
+  else
+    editor_tooltip_widget_clear_section (self->error_box, self->error_label);
+
+  if (show_doc)
+    gtk_label_set_markup (GTK_LABEL (self->doc_label), doc_markup);
+  else
+    editor_tooltip_widget_clear_section (self->doc_box, self->doc_label);
+
+  gtk_widget_set_visible (self->error_box, show_error);
+  gtk_widget_set_visible (self->doc_box, show_doc);
+  gtk_widget_set_visible (self->separator, show_error && show_doc);
+
+  if (show_error || show_doc)
+    gtk_widget_show_all (GTK_WIDGET (self));
+
+  return show_error || show_doc;
+}
+
+static void
+editor_tooltip_widget_init_css (void)
+{
+  static gboolean css_loaded = FALSE;
+  if (css_loaded)
+    return;
+
+  const gchar *css =
+      ".editor-tooltip {"
+      "  background-color: transparent;"
+      "  padding: 0;"
+      "  margin: 0;"
+      "}"
+      ".editor-tooltip-error {"
+      "  background-color: #f3f3f3;"
+      "  padding: 6px 8px;"
+      "}"
+      ".editor-tooltip-doc {"
+      "  background-color: #ffffff;"
+      "  padding: 6px 8px;"
+      "}"
+      ".editor-tooltip-separator {"
+      "  background-color: #a1a1a1;"
+      "  min-height: 1px;"
+      "  margin: 0;"
+      "}";
+
+  GtkCssProvider *provider = gtk_css_provider_new ();
+  GError *error = NULL;
+  gtk_css_provider_load_from_data (provider, css, -1, &error);
+  if (error) {
+    LOG (1, "EditorTooltipWidget.init_css: css error: %s", error->message);
+    g_error_free (error);
+  }
+
+  GdkScreen *screen = gdk_screen_get_default ();
+  if (screen)
+    gtk_style_context_add_provider_for_screen (screen,
+        GTK_STYLE_PROVIDER (provider),
+        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  g_object_unref (provider);
+
+  css_loaded = TRUE;
+}

--- a/src/editor_tooltip_widget.h
+++ b/src/editor_tooltip_widget.h
@@ -1,0 +1,24 @@
+#ifndef EDITOR_TOOLTIP_WIDGET_H
+#define EDITOR_TOOLTIP_WIDGET_H
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+typedef struct _EditorTooltipWidget EditorTooltipWidget;
+typedef struct _EditorTooltipWidgetClass EditorTooltipWidgetClass;
+
+#define EDITOR_TYPE_TOOLTIP_WIDGET (editor_tooltip_widget_get_type())
+#define EDITOR_TOOLTIP_WIDGET(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), EDITOR_TYPE_TOOLTIP_WIDGET, EditorTooltipWidget))
+#define EDITOR_IS_TOOLTIP_WIDGET(obj) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), EDITOR_TYPE_TOOLTIP_WIDGET))
+
+gboolean               editor_tooltip_widget_set_content (EditorTooltipWidget *self,
+    const gchar *error_markup, const gchar *doc_markup);
+EditorTooltipWidget   *editor_tooltip_widget_new          (void);
+GType       editor_tooltip_widget_get_type     (void);
+
+G_END_DECLS
+
+#endif /* EDITOR_TOOLTIP_WIDGET_H */

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 #include "lisp_parser.c"
 #include "lisp_parser_view.c"
 #include "lisp_source_notebook.c"
+#include "editor_tooltip_widget.c"
 #include "editor.c"
 #include "node.c"
 #include "package.c"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,7 +49,7 @@ package_test: package_test.c package.c node.c $(COMMON)
 status_service_test: status_service_test.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_test: editor_test.c editor.c gtk_text_provider.c project_index.c project.c project_repl.c asdf.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+editor_test: editor_test.c editor.c editor_tooltip_widget.c gtk_text_provider.c project_index.c project.c project_repl.c asdf.c project_file.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c string_text_provider.c text_provider.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all


### PR DESCRIPTION
## Summary
- simplify the tooltip widget layout so the error and documentation sections expand to the tooltip edges with a shared separator
- reduce the CSS to only set the light gray error background, white documentation background, padding, and a thin divider line

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d27cc1a49483289d13ffb7f6eaaf32