### PR TITLE
Refactor project file constructors

### DIFF
--- a/src/file_add.c
+++ b/src/file_add.c
@@ -2,7 +2,6 @@
 #include "file_add.h"
 #include "app.h"
 #include "project.h"
-#include "string_text_provider.h"
 #include "lisp_source_notebook.h"
 #include "editor.h"
 #include "project_file.h"
@@ -22,11 +21,8 @@ void file_add(GtkWidget */*widget*/, gpointer data) {
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), dir);
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-    TextProvider *provider = string_text_provider_new("");
-    ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
-    text_provider_unref(provider);
+    ProjectFile *file = project_add_loaded_file(project, filename);
     if (file) {
-      project_file_load(file);
       Editor *view = lisp_source_notebook_get_current_editor(app_get_notebook(app));
       if (view)
         app_connect_editor(app, view);

--- a/src/file_new.c
+++ b/src/file_new.c
@@ -2,7 +2,6 @@
 #include "file_new.h"
 #include "app.h"
 #include "project.h"
-#include "string_text_provider.h"
 #include "lisp_source_notebook.h"
 #include "editor.h"
 #include "project_file.h"
@@ -30,11 +29,8 @@ void file_new(GtkWidget */*widget*/, gpointer data) {
       const gchar *dir = project_get_path(project);
       gchar *path = g_build_filename(dir ? dir : ".", fname, NULL);
       g_file_set_contents(path, "", 0, NULL);
-      TextProvider *provider = string_text_provider_new("");
-      ProjectFile *file = project_add_file(project, provider, NULL, path, PROJECT_FILE_LIVE);
-      text_provider_unref(provider);
+      ProjectFile *file = project_add_loaded_file(project, path);
       if (file) {
-        project_file_load(file);
         Editor *view = lisp_source_notebook_get_current_editor(app_get_notebook(app));
         if (view)
           app_connect_editor(app, view);

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -11,7 +11,6 @@
 #include "editor.h"
 #include "lisp_source_notebook.h"
 #include "project.h"
-#include "string_text_provider.h"
 #include "file_save.h"
 #include "preferences.h"
 #include "asdf.h"
@@ -65,11 +64,9 @@ gboolean file_open_path(App *app, const gchar *filename) {
       gchar *path = g_build_filename(dir, comp->str, NULL);
       gchar *full = ensure_lisp_extension(path);
       g_free(path);
-      TextProvider *provider = string_text_provider_new("");
-      ProjectFile *pf = project_add_file(project, provider, NULL, full, PROJECT_FILE_LIVE);
-      text_provider_unref(provider);
-      if (pf)
-        project_file_load(pf);
+      ProjectFile *pf = project_add_loaded_file(project, full);
+      if (!pf)
+        g_warning("Failed to load %s", full);
       g_free(full);
     }
     g_free(dir);
@@ -80,11 +77,9 @@ gboolean file_open_path(App *app, const gchar *filename) {
     g_object_unref(asdf);
     gchar *dir = g_path_get_dirname(filename);
     project_set_path(project, dir);
-    TextProvider *provider = string_text_provider_new("");
-    ProjectFile *file = project_add_file(project, provider, NULL, filename, PROJECT_FILE_LIVE);
-    text_provider_unref(provider);
-    if (file)
-      project_file_load(file);
+    ProjectFile *file = project_add_loaded_file(project, filename);
+    if (!file)
+      g_warning("Failed to load %s", filename);
     g_free(dir);
   }
 

--- a/src/project.c
+++ b/src/project.c
@@ -59,6 +59,25 @@ ProjectFile *project_add_file(Project *self, TextProvider *provider,
   return file;
 }
 
+ProjectFile *project_add_loaded_file(Project *self, const gchar *path) {
+  g_return_val_if_fail(self != NULL, NULL);
+  g_return_val_if_fail(path != NULL, NULL);
+  g_return_val_if_fail(glide_is_ui_thread(), NULL);
+
+  LOG(1, "project_add_loaded_file path=%s", path);
+
+  ProjectFile *file = project_file_load(self, path);
+  if (!file)
+    return NULL;
+
+  g_ptr_array_add(self->files, file);
+
+  project_changed(self);
+  project_file_loaded(self, file);
+
+  return file;
+}
+
 void project_remove_file(Project *self, ProjectFile *file) {
   g_return_if_fail(self != NULL);
   g_return_if_fail(file != NULL);

--- a/src/project.h
+++ b/src/project.h
@@ -26,6 +26,7 @@ ProjectFile   *project_get_file(Project *self, guint index);
 guint          project_get_file_count(Project *self);
 ProjectFile   *project_add_file(Project *self, TextProvider *provider,
     GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
+ProjectFile   *project_add_loaded_file(Project *self, const gchar *path);
 void           project_remove_file(Project *self, ProjectFile *file);
 void           project_file_changed(Project *self, ProjectFile *file);
 void           project_file_loaded(Project *self, ProjectFile *file);

--- a/src/project_file.h
+++ b/src/project_file.h
@@ -35,7 +35,7 @@ LispLexer   *project_file_get_lexer(ProjectFile *file);
 GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
 const gchar *project_file_get_path(ProjectFile *file); /* borrowed */
 void        project_file_set_path(ProjectFile *file, const gchar *path);
-gboolean    project_file_load(ProjectFile *file);
+ProjectFile *project_file_load(Project *project, const gchar *path);
 const gchar *project_file_get_relative_path(ProjectFile *file);
 void        project_file_clear_errors(ProjectFile *file);
 void        project_file_add_error(ProjectFile *file, gsize start, gsize end,

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -69,16 +69,12 @@ static void test_file_load(void)
   g_file_set_contents(filepath, contents, -1, NULL);
 
   Project *project = project_new(NULL);
-  TextProvider *provider = string_text_provider_new("");
-  ProjectFile *file = project_add_file(project, provider, NULL, filepath,
-      PROJECT_FILE_LIVE);
-  text_provider_unref(provider);
 
   int count = 0;
   project_set_file_loaded_cb(project, on_file_loaded, &count);
 
-  gboolean ok = project_file_load(file);
-  g_assert_true(ok);
+  ProjectFile *file = project_add_loaded_file(project, filepath);
+  g_assert_nonnull(file);
   g_assert_cmpint(count, ==, 1);
 
   TextProvider *tp = project_file_get_provider(file);


### PR DESCRIPTION
## Summary
- refactor project file creation to share initialization and return new instances from `project_file_load`
- add `project_add_loaded_file` and update file creation flows to rely on the new constructor
- update tests to exercise the new API and ensure callbacks still fire

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d40bdc73e083288da58ad09b47d47e