### PR TITLE
Add EditorManager to manage project editors

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@ SOURCES += \
   menu_bar.c \
   app.c \
   editor_container.c \
+  editor_manager.c \
   editor_tooltip_window.c \
   editor.c \
   lisp_lexer.c \

--- a/src/actions.c
+++ b/src/actions.c
@@ -57,7 +57,7 @@ static void
 save_all(GSimpleAction * /*action*/, GVariant * /*param*/, gpointer data)
 {
   App *self = data;
-  file_save_all(app_get_project(self));
+  file_save_all(app_get_editor_manager(self), app_get_project(self));
 }
 
 static void
@@ -140,8 +140,7 @@ eval_current(GSimpleAction * /*action*/, GVariant * /*param*/, gpointer data)
   App *self = data;
   EditorContainer *notebook = app_get_notebook(self);
   Editor *view = editor_container_get_current_editor(notebook);
-  GtkTextBuffer *buffer = view ?
-      GTK_TEXT_BUFFER(editor_get_buffer(view)) : NULL;
+  GtkTextBuffer *buffer = view ? GTK_TEXT_BUFFER(editor_get_buffer(view)) : NULL;
   GtkTextIter it_start;
   GtkTextIter it_end;
   if (buffer && gtk_text_buffer_get_selection_bounds(buffer,
@@ -223,7 +222,8 @@ show_parser(App *self)
   EditorContainer *notebook = app_get_notebook(self);
   Editor *current = editor_container_get_current_editor(notebook);
   ProjectFile *file = editor_get_file(current);
-  GtkWidget *view = lisp_parser_view_new(file);
+  EditorManager *manager = app_get_editor_manager(self);
+  GtkWidget *view = lisp_parser_view_new(manager, file);
   GtkWidget *scrolled = gtk_scrolled_window_new(NULL, NULL);
   gtk_container_add(GTK_CONTAINER(scrolled), view);
   gtk_container_add(GTK_CONTAINER(win), scrolled);
@@ -262,8 +262,7 @@ app_maybe_save_all(App *self)
   gboolean modified = FALSE;
   for (gint i = 0; i < pages; i++) {
     GtkWidget *view = gtk_notebook_get_nth_page(GTK_NOTEBOOK(notebook), i);
-    GtkTextBuffer *buffer = view ?
-        GTK_TEXT_BUFFER(editor_get_buffer(GLIDE_EDITOR(view))) : NULL;
+    GtkTextBuffer *buffer = view ? GTK_TEXT_BUFFER(editor_get_buffer(GLIDE_EDITOR(view))) : NULL;
     if (buffer && gtk_text_buffer_get_modified(buffer)) {
       modified = TRUE;
       break;
@@ -282,7 +281,7 @@ app_maybe_save_all(App *self)
   if (res == GTK_RESPONSE_CANCEL)
     return FALSE;
   if (res == GTK_RESPONSE_ACCEPT)
-    file_save_all(app_get_project(self));
+    file_save_all(app_get_editor_manager(self), app_get_project(self));
   return TRUE;
 }
 

--- a/src/app.h
+++ b/src/app.h
@@ -8,6 +8,7 @@
 #include "editor.h"
 #include "editor_container.h"
 #include "status_service.h"
+#include "editor_manager.h"
 
 #ifndef STATIC
 #define STATIC
@@ -21,6 +22,7 @@ G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 STATIC App *app_new (Preferences *prefs, ReplSession *glide, StatusService *status_service);
 STATIC Editor *app_get_editor(App *self);
 STATIC EditorContainer *app_get_notebook(App *self);
+STATIC EditorManager *app_get_editor_manager(App *self);
 STATIC Project *app_get_project(App *self);
 STATIC void app_connect_editor(App *self, Editor *editor);
 STATIC ProjectFile *app_get_current_file(App *self);

--- a/src/asdf.c
+++ b/src/asdf.c
@@ -181,8 +181,7 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
         asdf_set_description(self, g_string_new(node_get_name(val)));
     } else if (g_strcmp0(kw, "SERIAL") == 0) {
       if (val->type == LISP_AST_NODE_TYPE_SYMBOL || val->type == LISP_AST_NODE_TYPE_NUMBER) {
-        const gchar *v = val->type == LISP_AST_NODE_TYPE_SYMBOL ?
-          node_get_name(val) : val->start_token->text;
+        const gchar *v = val->type == LISP_AST_NODE_TYPE_SYMBOL ? node_get_name(val) : val->start_token->text;
         self->serial = g_strcmp0(v, "T") == 0 || g_strcmp0(v, "1") == 0;
       }
     } else if (g_strcmp0(kw, "COMPONENTS") == 0) {

--- a/src/editor.h
+++ b/src/editor.h
@@ -19,5 +19,6 @@ gboolean        editor_get_toplevel_range (Editor *self,
 void            editor_extend_selection (Editor *self);
 void            editor_shrink_selection (Editor *self);
 gboolean        editor_show_tooltip_window (Editor *self);
+void            editor_set_errors(Editor *self, const GArray *errors);
 
 G_END_DECLS

--- a/src/editor_container.c
+++ b/src/editor_container.c
@@ -3,30 +3,18 @@
 struct _EditorContainer
 {
   GtkNotebook parent_instance;
-  Project *project;
 };
 
 G_DEFINE_TYPE(EditorContainer, editor_container, GTK_TYPE_NOTEBOOK)
 
-static void on_file_loaded(Project * /*project*/, ProjectFile *file, gpointer user_data);
-static void on_file_removed(Project * /*project*/, ProjectFile *file, gpointer user_data);
-
 static void
-editor_container_init(EditorContainer *self)
+editor_container_init(EditorContainer * /*self*/)
 {
-  self->project = NULL;
 }
 
 static void
 editor_container_dispose(GObject *object)
 {
-  EditorContainer *self = EDITOR_CONTAINER(object);
-  if (self->project) {
-    project_set_file_loaded_cb(self->project, NULL, NULL);
-    project_set_file_removed_cb(self->project, NULL, NULL);
-    project_unref(self->project);
-    self->project = NULL;
-  }
   G_OBJECT_CLASS(editor_container_parent_class)->dispose(object);
 }
 
@@ -39,37 +27,33 @@ editor_container_class_init(EditorContainerClass *klass)
 
 GtkWidget *
 
-editor_container_new(Project *project)
+editor_container_new(void)
 {
-  g_return_val_if_fail(project != NULL, NULL);
-
-  EditorContainer *self = g_object_new(EDITOR_TYPE_CONTAINER, NULL);
-  self->project = project_ref(project);
-
-  project_set_file_loaded_cb(project, on_file_loaded, self);
-  project_set_file_removed_cb(project, on_file_removed, self);
-
-  guint count = project_get_file_count(project);
-  for (guint i = 0; i < count; i++) {
-    ProjectFile *file = project_get_file(project, i);
-    editor_container_add_file(self, file);
-  }
-
-  return GTK_WIDGET(self);
+  return GTK_WIDGET(g_object_new(EDITOR_TYPE_CONTAINER, NULL));
 }
 
-static void
-on_file_loaded(Project * /*project*/, ProjectFile *file, gpointer user_data)
+gint
+editor_container_add_editor(EditorContainer *self, ProjectFile *file, Editor *editor)
 {
-  EditorContainer *self = EDITOR_CONTAINER(user_data);
-  gint page = editor_container_add_file(self, file);
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(self), page);
+  g_return_val_if_fail(EDITOR_IS_CONTAINER(self), -1);
+  g_return_val_if_fail(file != NULL, -1);
+  g_return_val_if_fail(GLIDE_IS_EDITOR(editor), -1);
+
+  GtkWidget *view = GTK_WIDGET(editor);
+  const gchar *path = project_file_get_relative_path(file);
+  GtkWidget *label = gtk_label_new(path ? path : "untitled");
+  gint page = gtk_notebook_append_page(GTK_NOTEBOOK(self), view, label);
+  GtkWidget *page_widget = gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page);
+  if (page_widget)
+    gtk_widget_show_all(page_widget);
+  return page;
 }
 
-static void
-on_file_removed(Project * /*project*/, ProjectFile *file, gpointer user_data)
+void
+editor_container_remove_file(EditorContainer *self, ProjectFile *file)
 {
-  EditorContainer *self = EDITOR_CONTAINER(user_data);
+  g_return_if_fail(EDITOR_IS_CONTAINER(self));
+  g_return_if_fail(file != NULL);
   gint pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(self));
   for (gint i = 0; i < pages; i++) {
     GtkWidget *page = gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), i);
@@ -79,20 +63,6 @@ on_file_removed(Project * /*project*/, ProjectFile *file, gpointer user_data)
       break;
     }
   }
-}
-
-gint
-editor_container_add_file(EditorContainer *self, ProjectFile *file)
-{
-  g_return_val_if_fail(EDITOR_IS_CONTAINER(self), -1);
-  g_return_val_if_fail(file != NULL, -1);
-
-  GtkWidget *view = editor_new_for_file(self->project, file);
-  const gchar *path = project_file_get_relative_path(file);
-  GtkWidget *label = gtk_label_new(path ? path : "untitled");
-  gint page = gtk_notebook_append_page(GTK_NOTEBOOK(self), view, label);
-  gtk_widget_show_all(gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page));
-  return page;
 }
 
 void

--- a/src/editor_container.h
+++ b/src/editor_container.h
@@ -9,9 +9,10 @@ G_BEGIN_DECLS
 #define EDITOR_TYPE_CONTAINER (editor_container_get_type())
 G_DECLARE_FINAL_TYPE(EditorContainer, editor_container, EDITOR, CONTAINER, GtkNotebook)
 
-GtkWidget *editor_container_new(Project *project);
+GtkWidget *editor_container_new(void);
 Editor *editor_container_get_current_editor(EditorContainer *self);
-gint editor_container_add_file(EditorContainer *self, ProjectFile *file);
+gint editor_container_add_editor(EditorContainer *self, ProjectFile *file, Editor *editor);
+void editor_container_remove_file(EditorContainer *self, ProjectFile *file);
 void editor_container_clear(EditorContainer *self);
 
 G_END_DECLS

--- a/src/editor_manager.c
+++ b/src/editor_manager.c
@@ -1,0 +1,153 @@
+#include "editor_manager.h"
+#include "project_file.h"
+#include "util.h"
+
+struct _EditorManager {
+  GObject parent_instance;
+
+  Project *project;
+  EditorContainer *container;
+  GHashTable *editors; /* ProjectFile* -> Editor* */
+};
+
+G_DEFINE_TYPE(EditorManager, editor_manager, G_TYPE_OBJECT)
+
+static void editor_manager_add_file(EditorManager *self, ProjectFile *file, gboolean focus);
+static void editor_manager_remove_file(EditorManager *self, ProjectFile *file);
+static void on_project_file_loaded(Project *project, ProjectFile *file, gpointer user_data);
+static void on_project_file_removed(Project *project, ProjectFile *file, gpointer user_data);
+static void on_project_file_changed(Project *project, ProjectFile *file, gpointer user_data);
+
+static void
+editor_manager_init(EditorManager *self)
+{
+  self->project = NULL;
+  self->container = NULL;
+  self->editors = NULL;
+}
+
+static void
+editor_manager_dispose(GObject *object)
+{
+  EditorManager *self = EDITOR_MANAGER(object);
+  if (self->project) {
+    project_set_file_loaded_cb(self->project, NULL, NULL);
+    project_set_file_removed_cb(self->project, NULL, NULL);
+    project_set_file_changed_cb(self->project, NULL, NULL);
+    project_unref(self->project);
+    self->project = NULL;
+  }
+  g_clear_object(&self->container);
+  if (self->editors) {
+    g_hash_table_destroy(self->editors);
+    self->editors = NULL;
+  }
+  G_OBJECT_CLASS(editor_manager_parent_class)->dispose(object);
+}
+
+static void
+editor_manager_class_init(EditorManagerClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS(klass);
+  object_class->dispose = editor_manager_dispose;
+}
+
+EditorManager *
+editor_manager_new(Project *project, EditorContainer *container)
+{
+  g_return_val_if_fail(project != NULL, NULL);
+  g_return_val_if_fail(EDITOR_IS_CONTAINER(container), NULL);
+
+  EditorManager *self = g_object_new(EDITOR_TYPE_MANAGER, NULL);
+  self->project = project_ref(project);
+  self->container = g_object_ref(container);
+  self->editors = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL,
+      (GDestroyNotify)g_object_unref);
+
+  project_set_file_loaded_cb(project, on_project_file_loaded, self);
+  project_set_file_removed_cb(project, on_project_file_removed, self);
+  project_set_file_changed_cb(project, on_project_file_changed, self);
+
+  guint count = project_get_file_count(project);
+  for (guint i = 0; i < count; i++) {
+    ProjectFile *file = project_get_file(project, i);
+    editor_manager_add_file(self, file, FALSE);
+  }
+
+  return self;
+}
+
+static void
+editor_manager_add_file(EditorManager *self, ProjectFile *file, gboolean focus)
+{
+  g_return_if_fail(EDITOR_IS_MANAGER(self));
+  g_return_if_fail(file != NULL);
+  if (g_hash_table_contains(self->editors, file))
+    return;
+
+  const gchar *path = project_file_get_path(file);
+  LOG(1, "editor_manager_add_file path=%s focus=%d", path ? path : "(null)", focus);
+  GtkWidget *widget = editor_new_for_file(self->project, file);
+  Editor *editor = GLIDE_EDITOR(widget);
+  g_hash_table_insert(self->editors, file, g_object_ref(editor));
+  gint page = editor_container_add_editor(self->container, file, editor);
+  gtk_widget_show_all(GTK_WIDGET(editor));
+  if (focus)
+    gtk_notebook_set_current_page(GTK_NOTEBOOK(self->container), page);
+  editor_set_errors(editor, project_file_get_errors(file));
+}
+
+static void
+editor_manager_remove_file(EditorManager *self, ProjectFile *file)
+{
+  g_return_if_fail(EDITOR_IS_MANAGER(self));
+  g_return_if_fail(file != NULL);
+  const gchar *path = project_file_get_path(file);
+  LOG(1, "editor_manager_remove_file path=%s", path ? path : "(null)");
+  editor_container_remove_file(self->container, file);
+  g_hash_table_remove(self->editors, file);
+}
+
+static void
+on_project_file_loaded(Project * /*project*/, ProjectFile *file, gpointer user_data)
+{
+  EditorManager *self = EDITOR_MANAGER(user_data);
+  editor_manager_add_file(self, file, TRUE);
+}
+
+static void
+on_project_file_removed(Project * /*project*/, ProjectFile *file, gpointer user_data)
+{
+  EditorManager *self = EDITOR_MANAGER(user_data);
+  editor_manager_remove_file(self, file);
+}
+
+static void
+on_project_file_changed(Project * /*project*/, ProjectFile *file, gpointer user_data)
+{
+  EditorManager *self = EDITOR_MANAGER(user_data);
+  const gchar *path = project_file_get_path(file);
+  LOG(1, "editor_manager_file_changed path=%s", path ? path : "(null)");
+  Editor *editor = editor_manager_get_editor(self, file);
+  if (!editor)
+    return;
+  editor_set_errors(editor, project_file_get_errors(file));
+}
+
+Editor *
+editor_manager_get_editor(EditorManager *self, ProjectFile *file)
+{
+  g_return_val_if_fail(EDITOR_IS_MANAGER(self), NULL);
+  if (!file || !self->editors)
+    return NULL;
+  return g_hash_table_lookup(self->editors, file);
+}
+
+GtkTextBuffer *
+editor_manager_get_buffer(EditorManager *self, ProjectFile *file)
+{
+  Editor *editor = editor_manager_get_editor(self, file);
+  if (!editor)
+    return NULL;
+  return GTK_TEXT_BUFFER(editor_get_buffer(editor));
+}

--- a/src/editor_manager.h
+++ b/src/editor_manager.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include "project.h"
+#include "editor_container.h"
+#include "editor.h"
+
+G_BEGIN_DECLS
+
+#define EDITOR_TYPE_MANAGER (editor_manager_get_type())
+G_DECLARE_FINAL_TYPE(EditorManager, editor_manager, EDITOR, MANAGER, GObject)
+
+EditorManager *editor_manager_new(Project *project, EditorContainer *container);
+GtkTextBuffer *editor_manager_get_buffer(EditorManager *self, ProjectFile *file);
+Editor        *editor_manager_get_editor(EditorManager *self, ProjectFile *file);
+
+G_END_DECLS

--- a/src/file_open.c
+++ b/src/file_open.c
@@ -10,6 +10,7 @@
 #include "app.h"
 #include "editor.h"
 #include "editor_container.h"
+#include "editor_manager.h"
 #include "project.h"
 #include "file_save.h"
 #include "preferences.h"
@@ -19,10 +20,11 @@
 
 static gboolean save_if_modified(App *app) {
   Project *project = app_get_project(app);
+  EditorManager *manager = app_get_editor_manager(app);
   if (project_get_file_count(project) == 0)
     return TRUE;
   ProjectFile *file = project_get_file(project, 0);
-  GtkTextBuffer *buffer = project_file_get_buffer(file);
+  GtkTextBuffer *buffer = manager ? editor_manager_get_buffer(manager, file) : NULL;
   if (buffer && gtk_text_buffer_get_modified(buffer)) {
     GtkWidget *dialog = gtk_message_dialog_new(NULL, GTK_DIALOG_MODAL,
         GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
@@ -35,7 +37,7 @@ static gboolean save_if_modified(App *app) {
     if (res == GTK_RESPONSE_CANCEL)
       return FALSE;
     if (res == GTK_RESPONSE_ACCEPT)
-      file_save(file);
+      file_save(manager, file);
   }
   return TRUE;
 }

--- a/src/file_save.c
+++ b/src/file_save.c
@@ -9,38 +9,32 @@
 #include "file_save.h"
 #include "project.h"
 #include "project_file.h"
+#include "editor_manager.h"
 
-void file_save(ProjectFile *file) {
+void file_save(EditorManager *manager, ProjectFile *file) {
   g_return_if_fail(file != NULL);
 
   const gchar *filename = project_file_get_path(file);
   if (!filename)
     return;
 
-  GtkTextBuffer *buffer = project_file_get_buffer(file);
-  g_return_if_fail(buffer != NULL);
-
-  GtkTextIter start, end;
-  gtk_text_buffer_get_start_iter(buffer, &start);
-  gtk_text_buffer_get_end_iter(buffer, &end);
-
-  gchar *buffer_text = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
+  const GString *content = project_file_get_content(file);
+  const gchar *text = content ? content->str : "";
+  gsize length = content ? content->len : 0;
 
   int fd = sys_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
   if (fd == -1) {
     g_printerr("Failed to open file for writing: %s (errno: %d)\n", filename, errno);
-    g_free(buffer_text);
     return;
   }
 
-  size_t to_write = strlen(buffer_text);
+  size_t to_write = length;
   size_t total_written = 0;
   while (total_written < to_write) {
-    ssize_t written = sys_write(fd, buffer_text + total_written, to_write - total_written);
+    ssize_t written = sys_write(fd, text + total_written, to_write - total_written);
     if (written == -1) {
       g_printerr("Error writing to file: %s (errno: %d)\n", filename, errno);
       sys_close(fd);
-      g_free(buffer_text);
       return;
     }
     total_written += written;
@@ -49,19 +43,20 @@ void file_save(ProjectFile *file) {
   if (sys_close(fd) == -1)
     g_printerr("Error closing file: %s (errno: %d)\n", filename, errno);
 
-  gtk_text_buffer_set_modified(buffer, FALSE);
-  g_free(buffer_text);
+  GtkTextBuffer *buffer = manager ? editor_manager_get_buffer(manager, file) : NULL;
+  if (buffer)
+    gtk_text_buffer_set_modified(buffer, FALSE);
 }
 
-void file_save_all(Project *project) {
+void file_save_all(EditorManager *manager, Project *project) {
   g_return_if_fail(project != NULL);
 
   guint count = project_get_file_count(project);
   for (guint i = 0; i < count; i++) {
     ProjectFile *file = project_get_file(project, i);
-    GtkTextBuffer *buffer = project_file_get_buffer(file);
+    GtkTextBuffer *buffer = manager ? editor_manager_get_buffer(manager, file) : NULL;
     if (buffer && gtk_text_buffer_get_modified(buffer))
-      file_save(file);
+      file_save(manager, file);
   }
 }
 

--- a/src/file_save.h
+++ b/src/file_save.h
@@ -2,7 +2,8 @@
 
 typedef struct _Project Project;
 typedef struct _ProjectFile ProjectFile;
+typedef struct _EditorManager EditorManager;
 
-void file_save(ProjectFile *file);
-void file_save_all(Project *project);
+void file_save(EditorManager *manager, ProjectFile *file);
+void file_save_all(EditorManager *manager, Project *project);
 

--- a/src/lisp_parser_view.h
+++ b/src/lisp_parser_view.h
@@ -4,12 +4,13 @@
 #include "project.h"
 #include <gtk/gtk.h>
 #include <gtksourceview/gtksource.h>
+#include "editor_manager.h"
 
 G_BEGIN_DECLS
 
 #define LISP_TYPE_PARSER_VIEW (lisp_parser_view_get_type())
 G_DECLARE_FINAL_TYPE(LispParserView, lisp_parser_view, LISP, PARSER_VIEW, GtkTreeView)
 
-GtkWidget *lisp_parser_view_new(ProjectFile *file);
+GtkWidget *lisp_parser_view_new(EditorManager *manager, ProjectFile *file);
 
 G_END_DECLS

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include "lisp_parser.c"
 #include "lisp_parser_view.c"
 #include "editor_container.c"
+#include "editor_manager.c"
 #include "editor_tooltip_window.c"
 #include "editor.c"
 #include "node.c"

--- a/src/project.h
+++ b/src/project.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <glib.h>
-typedef struct _GtkTextBuffer GtkTextBuffer;
 #include "project_file.h"
 #include "node.h"
 #include "asdf.h"
@@ -14,17 +13,19 @@ typedef struct _ReplSession ReplSession;
 typedef void (*ProjectFileLoadedCb)(Project *self, ProjectFile *file, gpointer user_data);
 typedef void (*ProjectFileRemovedCb)(Project *self, ProjectFile *file, gpointer user_data);
 typedef void (*ProjectChangedCb)(Project *self, gpointer user_data);
+typedef void (*ProjectFileChangedCb)(Project *self, ProjectFile *file, gpointer user_data);
 
 Project       *project_new(ReplSession *repl);
 Project       *project_ref(Project *self);
 void           project_unref(Project *self);
 void           project_set_file_loaded_cb(Project *self, ProjectFileLoadedCb cb, gpointer user_data);
 void           project_set_file_removed_cb(Project *self, ProjectFileRemovedCb cb, gpointer user_data);
+void           project_set_file_changed_cb(Project *self, ProjectFileChangedCb cb, gpointer user_data);
 void           project_set_changed_cb(Project *self, ProjectChangedCb cb, gpointer user_data);
 ProjectFile   *project_get_file(Project *self, guint index);
 guint          project_get_file_count(Project *self);
 ProjectFile   *project_add_file(Project *self, GString *content,
-    GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
+    const gchar *path, ProjectFileState state);
 ProjectFile   *project_add_loaded_file(Project *self, const gchar *path);
 void           project_remove_file(Project *self, ProjectFile *file);
 void           project_file_changed(Project *self, ProjectFile *file);

--- a/src/project_file.h
+++ b/src/project_file.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <glib.h>
-typedef struct _GtkTextBuffer GtkTextBuffer;
 #include "lisp_lexer.h"
 #include "lisp_parser.h"
 
@@ -21,14 +20,12 @@ typedef struct {
 } ProjectFileError;
 
 ProjectFile *project_file_new(Project *project, GString *content,
-    GtkTextBuffer *buffer, const gchar *path, ProjectFileState state);
+    const gchar *path, ProjectFileState state);
 ProjectFile *project_file_new_virtual(GString *content);
 void        project_file_free(ProjectFile *file);
 ProjectFileState project_file_get_state(ProjectFile *file);
 void        project_file_set_state(ProjectFile *file, ProjectFileState state);
-void        project_file_set_content(ProjectFile *file, GString *content,
-    GtkTextBuffer *buffer);
-void        project_file_bind_buffer(ProjectFile *file, GtkTextBuffer *buffer);
+void        project_file_set_content(ProjectFile *file, GString *content);
 const GString *project_file_get_content(ProjectFile *file);
 const GArray  *project_file_get_tokens(ProjectFile *file);
 const Node    *project_file_get_ast(ProjectFile *file);
@@ -36,7 +33,6 @@ void        project_file_set_tokens(ProjectFile *file, GArray *tokens);
 void        project_file_set_ast(ProjectFile *file, Node *ast);
 LispParser  *project_file_get_parser(ProjectFile *file);
 LispLexer   *project_file_get_lexer(ProjectFile *file);
-GtkTextBuffer *project_file_get_buffer(ProjectFile *file);
 const gchar *project_file_get_path(ProjectFile *file); /* borrowed */
 void        project_file_set_path(ProjectFile *file, const gchar *path);
 ProjectFile *project_file_load(Project *project, const gchar *path);
@@ -44,5 +40,4 @@ const gchar *project_file_get_relative_path(ProjectFile *file);
 void        project_file_clear_errors(ProjectFile *file);
 void        project_file_add_error(ProjectFile *file, gsize start, gsize end,
     const gchar *message);
-void        project_file_apply_errors(ProjectFile *file);
 const GArray *project_file_get_errors(ProjectFile *file);

--- a/src/project_priv.h
+++ b/src/project_priv.h
@@ -12,6 +12,8 @@ struct _Project {
   gpointer file_loaded_data;
   ProjectFileRemovedCb file_removed_cb;
   gpointer file_removed_data;
+  ProjectFileChangedCb file_changed_cb;
+  gpointer file_changed_data;
   ProjectChangedCb changed_cb;
   gpointer changed_data;
   Asdf *asdf; /* owned, nullable */

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -157,8 +157,7 @@ static void project_on_package_definition(Interaction *interaction, gpointer use
   Node *ast = lisp_parser_parse(parser, tokens, NULL);
   g_assert(ast && ast->children && ast->children->len > 0);
   Node *expr = g_array_index(ast->children, Node*, 0);
-  Node *name_node = (expr->children && expr->children->len > 1) ?
-    g_array_index(expr->children, Node*, 1) : NULL;
+  Node *name_node = (expr->children && expr->children->len > 1) ? g_array_index(expr->children, Node*, 1) : NULL;
   gchar *pkg_name = g_strdup(node_get_name(name_node));
   g_assert(pkg_name);
   LOG(1, "project_on_package_definition built package %s", pkg_name);

--- a/tests/editor_test.c
+++ b/tests/editor_test.c
@@ -10,7 +10,7 @@ static void test_undo_pristine(void)
     return;
   }
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(a b)"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(a b)"), NULL, PROJECT_FILE_LIVE);
 
   GtkWidget *widget = editor_new_for_file(project, file);
   Editor *editor = GLIDE_EDITOR(widget);
@@ -29,7 +29,7 @@ static void test_toplevel_range_eof_without_newline(void)
     return;
   }
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(+ 1 2)"), NULL, NULL,
+  ProjectFile *file = project_add_file(project, g_string_new("(+ 1 2)"), NULL,
       PROJECT_FILE_LIVE);
 
   GtkWidget *widget = editor_new_for_file(project, file);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -19,7 +19,7 @@ static void project_file_prepare(ProjectFile *file) {
 static void project_file_set_text(ProjectFile *file, const gchar *text) {
   g_return_if_fail(file);
   g_return_if_fail(text);
-  project_file_set_content(file, g_string_new(text), NULL);
+  project_file_set_content(file, g_string_new(text));
   project_file_prepare(file);
 }
 
@@ -53,7 +53,7 @@ static void test_default_file(void)
 static void test_parse_on_change(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(a)"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(a)"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, file);
   const GArray *tokens = project_file_get_tokens(file);
   g_assert_cmpint(tokens->len, ==, 3); /* (, a, ) */
@@ -103,7 +103,7 @@ static void test_file_load(void)
 static void test_function_analysis(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(defun foo () (bar))"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(defun foo () (bar))"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, file);
   const Node *ast = project_file_get_ast(file);
   const Node *form = g_array_index(ast->children, Node*, 0);
@@ -126,7 +126,7 @@ static void test_function_analysis(void)
 static void test_index(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(defun foo () (bar))"), NULL, NULL,
+  ProjectFile *file = project_add_file(project, g_string_new("(defun foo () (bar))"), NULL,
       PROJECT_FILE_LIVE);
   project_file_changed(project, file);
   const Node *ast = project_file_get_ast(file);
@@ -161,7 +161,7 @@ static void test_index(void)
 static void test_functions_table(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(defun foo () \"doc\")"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(defun foo () \"doc\")"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, file);
   Function *fn = project_get_function(project, "FOO");
   g_assert_nonnull(fn);
@@ -177,7 +177,7 @@ static void test_functions_table(void)
 static void test_function_tooltip(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(defun foo (x &rest rest) \"doc\")"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(defun foo (x &rest rest) \"doc\")"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, file);
   Function *fn = project_get_function(project, "FOO");
   gchar *tooltip = function_tooltip(fn);
@@ -193,7 +193,7 @@ static void test_function_tooltip(void)
 static void test_defun_requires_symbol_name(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(defun \"foo\" () nil)"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(defun \"foo\" () nil)"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, file);
 
   const GArray *errors = project_file_get_errors(file);
@@ -209,7 +209,7 @@ static void test_defun_requires_symbol_name(void)
 static void test_defun_requires_parameter_list(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new("(defun foo \"bad-params\" nil)"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *file = project_add_file(project, g_string_new("(defun foo \"bad-params\" nil)"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, file);
 
   const GArray *errors = project_file_get_errors(file);
@@ -225,10 +225,10 @@ static void test_defun_requires_parameter_list(void)
 static void test_incremental_index(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *f1 = project_add_file(project, g_string_new("(defun foo () nil)"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *f1 = project_add_file(project, g_string_new("(defun foo () nil)"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, f1);
 
-  ProjectFile *f2 = project_add_file(project, g_string_new("(defun bar () nil)"), NULL, NULL, PROJECT_FILE_LIVE);
+  ProjectFile *f2 = project_add_file(project, g_string_new("(defun bar () nil)"), NULL, PROJECT_FILE_LIVE);
   project_file_changed(project, f2);
 
   GHashTable *defs = project_get_index(project, SDT_FUNCTION_DEF);
@@ -256,7 +256,7 @@ static void test_function_call_argument_mismatch(void)
   project_add_function(project, fn);
   function_unref(fn);
 
-  ProjectFile *file = project_add_file(project, g_string_new("(bar 1)"), NULL, NULL,
+  ProjectFile *file = project_add_file(project, g_string_new("(bar 1)"), NULL,
       PROJECT_FILE_LIVE);
   project_file_changed(project, file);
 
@@ -308,7 +308,7 @@ static void test_relative_path(void)
   Project *project = project_new(NULL);
   project_set_path(project, tmpdir);
   gchar *filepath = g_build_filename(tmpdir, "file.lisp", NULL);
-  ProjectFile *file = project_add_file(project, g_string_new(""), NULL, filepath,
+  ProjectFile *file = project_add_file(project, g_string_new(""), filepath,
       PROJECT_FILE_LIVE);
   const gchar *rel = project_file_get_relative_path(file);
   g_assert_cmpstr(rel, ==, "file.lisp");
@@ -327,7 +327,7 @@ static void on_removed(Project * /*project*/, ProjectFile * /*file*/, gpointer u
 static void test_remove_file(void)
 {
   Project *project = project_new(NULL);
-  ProjectFile *file = project_add_file(project, g_string_new(""), NULL, "foo.lisp",
+  ProjectFile *file = project_add_file(project, g_string_new(""), "foo.lisp",
       PROJECT_FILE_LIVE);
   guint before = project_get_file_count(project);
   gboolean removed = FALSE;


### PR DESCRIPTION
## Summary
- add an EditorManager that listens to project events and owns editor instances, keeping track of which editor buffer belongs to each ProjectFile
- remove direct GtkTextBuffer handling from ProjectFile and update Editor to push content changes back to the model while relying on the manager for error highlighting
- update the app, file operations, parser view, and tests to use the new manager-based buffer access
- normalize ternary expressions to respect the 120-column wrapping guideline

## Testing
- make app-full
- (cd tests && make run)

------
https://chatgpt.com/codex/tasks/task_e_68d5250c20708328818e661f32790afb