### PR TITLE
Refactor Lisp lexer/parser to be stateless

### DIFF
--- a/src/asdf.c
+++ b/src/asdf.c
@@ -147,10 +147,8 @@ uint asdf_get_dependency_count(Asdf *self) {
 
 static void parse_file_contents(Asdf *self, const gchar *contents) {
   GString *text = g_string_new(contents ? contents : "");
-  LispLexer *lexer = lisp_lexer_new();
-  GArray *tokens = lisp_lexer_lex(lexer, text);
-  LispParser *parser = lisp_parser_new();
-  Node *ast = lisp_parser_parse(parser, tokens, NULL);
+  GArray *tokens = lisp_lexer_lex(text);
+  Node *ast = lisp_parser_parse(tokens, NULL);
   if (!ast)
     goto cleanup;
 
@@ -213,8 +211,6 @@ cleanup:
     node_free_deep(ast);
   if (tokens)
     g_array_free(tokens, TRUE);
-  lisp_parser_free(parser);
-  lisp_lexer_free(lexer);
   g_string_free(text, TRUE);
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -15,8 +15,6 @@ struct _Document {
   GString *content; /* owned */
   GArray *tokens; /* owned, LispToken */
   Node *ast; /* owned */
-  LispLexer *lexer; /* owned */
-  LispParser *parser; /* owned */
   Project *project;
   GArray *errors; /* DocumentError */
 };
@@ -42,8 +40,6 @@ Document *document_new_virtual(GString *content) {
 
 void document_free(Document *document) {
   if (!document) return;
-  if (document->parser) lisp_parser_free(document->parser);
-  if (document->lexer) lisp_lexer_free(document->lexer);
   document_clear_ast(document);
   document_clear_tokens(document);
   if (document->content)
@@ -73,14 +69,6 @@ void document_set_content(Document *document, GString *content) {
   document_clear_errors(document);
   document_clear_ast(document);
   document_clear_tokens(document);
-  if (document->parser) {
-    lisp_parser_free(document->parser);
-    document->parser = NULL;
-  }
-  if (document->lexer) {
-    lisp_lexer_free(document->lexer);
-    document->lexer = NULL;
-  }
   if (document->content) {
     g_string_free(document->content, TRUE);
     document->content = NULL;
@@ -101,16 +89,6 @@ const GArray *document_get_tokens(Document *document) {
 const Node *document_get_ast(Document *document) {
   g_return_val_if_fail(document != NULL, NULL);
   return document->ast;
-}
-
-LispParser *document_get_parser(Document *document) {
-  g_return_val_if_fail(document != NULL, NULL);
-  return document->parser;
-}
-
-LispLexer *document_get_lexer(Document *document) {
-  g_return_val_if_fail(document != NULL, NULL);
-  return document->lexer;
 }
 
 const gchar *document_get_path(Document *document) {
@@ -235,8 +213,6 @@ static Document *document_create(Project *project, GString *content,
 
 static void document_assign_content(Document *document, GString *content) {
   document->content = content ? content : g_string_new("");
-  document->lexer = lisp_lexer_new();
-  document->parser = lisp_parser_new();
   document->tokens = NULL;
   document->ast = NULL;
 }

--- a/src/document.h
+++ b/src/document.h
@@ -31,8 +31,6 @@ const GArray  *document_get_tokens(Document *document);
 const Node    *document_get_ast(Document *document);
 void         document_set_tokens(Document *document, GArray *tokens);
 void         document_set_ast(Document *document, Node *ast);
-LispParser  *document_get_parser(Document *document);
-LispLexer   *document_get_lexer(Document *document);
 const gchar *document_get_path(Document *document); /* borrowed */
 void         document_set_path(Document *document, const gchar *path);
 Document    *document_load(Project *project, const gchar *path);

--- a/src/lisp_lexer.c
+++ b/src/lisp_lexer.c
@@ -2,10 +2,6 @@
 #include <glib.h>
 #include "lisp_lexer.h"
 
-struct _LispLexer {
-  guint reserved;
-};
-
 static void lisp_token_free(gpointer token);
 static inline gunichar gstring_get_char(const GString *text, gsize offset);
 static inline gsize gstring_next_offset(const GString *text, gsize offset);
@@ -41,17 +37,7 @@ static inline gchar *gstring_slice_dup(const GString *text, gsize start, gsize e
   return g_strndup(text->str + start, end - start);
 }
 
-LispLexer *lisp_lexer_new(void) {
-  return g_new0(LispLexer, 1);
-}
-
-void lisp_lexer_free(LispLexer *lexer) {
-  g_return_if_fail(lexer != NULL);
-  g_free(lexer);
-}
-
-GArray *lisp_lexer_lex(LispLexer *lexer, const GString *text) {
-  g_return_val_if_fail(lexer != NULL, NULL);
+GArray *lisp_lexer_lex(const GString *text) {
   g_return_val_if_fail(text != NULL, NULL);
 
   GArray *tokens = g_array_new(FALSE, TRUE, sizeof(LispToken));

--- a/src/lisp_lexer.h
+++ b/src/lisp_lexer.h
@@ -4,8 +4,6 @@
 
 G_BEGIN_DECLS
 
-typedef struct _LispLexer LispLexer;
-
 typedef enum {
   LISP_TOKEN_TYPE_NUMBER,
   LISP_TOKEN_TYPE_SYMBOL,
@@ -29,8 +27,6 @@ typedef struct {
   gsize end_offset;
 } LispToken;
 
-LispLexer *lisp_lexer_new(void);
-void       lisp_lexer_free(LispLexer *lexer);
-GArray    *lisp_lexer_lex(LispLexer *lexer, const GString *text);
+GArray    *lisp_lexer_lex(const GString *text);
 
 G_END_DECLS

--- a/src/lisp_parser.c
+++ b/src/lisp_parser.c
@@ -1,24 +1,10 @@
 #include <glib.h>
 #include "lisp_parser.h"
 
-struct _LispParser {
-  guint reserved;
-};
 static Node *parse_expression(Document *document, GArray *tokens, guint *position);
 static Node *parse_symbol(Document *document, GArray *tokens, guint *position);
 
-LispParser *lisp_parser_new(void) {
-  return g_new0(LispParser, 1);
-}
-
-void lisp_parser_free(LispParser *parser) {
-  g_return_if_fail(parser != NULL);
-  g_free(parser);
-}
-
-Node *lisp_parser_parse(LispParser *parser, GArray *tokens, Document *document) {
-  g_return_val_if_fail(parser != NULL, NULL);
-
+Node *lisp_parser_parse(GArray *tokens, Document *document) {
   Node *ast = node_new(LISP_AST_NODE_TYPE_LIST, document);
   ast->children = g_array_new(FALSE, FALSE, sizeof(Node*));
 

--- a/src/lisp_parser.h
+++ b/src/lisp_parser.h
@@ -6,12 +6,9 @@
 
 G_BEGIN_DECLS
 
-typedef struct _LispParser LispParser;
 typedef struct _Document Document;
 
-LispParser *lisp_parser_new(void);
-void        lisp_parser_free(LispParser *parser);
-Node       *lisp_parser_parse(LispParser *parser, GArray *tokens, Document *document);
+Node       *lisp_parser_parse(GArray *tokens, Document *document);
 
 G_END_DECLS
 

--- a/src/project.c
+++ b/src/project.c
@@ -237,18 +237,14 @@ void project_document_changed(Project *self, Document *document) {
   g_return_if_fail(document != NULL);
   g_return_if_fail(glide_is_ui_thread());
   LOG(1, "project_document_changed path=%s", document_get_path(document));
-  if (!document_get_lexer(document) || !document_get_parser(document))
-    return;
   document_clear_errors(document);
   project_index_remove_document(self->index, document);
-  LispLexer *lexer = document_get_lexer(document);
-  LispParser *parser = document_get_parser(document);
   const GString *content = document_get_content(document);
   if (!content)
     return;
-  GArray *tokens = lisp_lexer_lex(lexer, content);
+  GArray *tokens = lisp_lexer_lex(content);
   document_set_tokens(document, tokens);
-  Node *ast = lisp_parser_parse(parser, tokens, document);
+  Node *ast = lisp_parser_parse(tokens, document);
   document_set_ast(document, ast);
   if (ast)
     analyse_ast(self, ast);

--- a/tests/analyser_test.c
+++ b/tests/analyser_test.c
@@ -6,8 +6,6 @@
 #include <glib.h>
 
 typedef struct {
-  LispLexer *lexer;
-  LispParser *parser;
   GArray *tokens;
   Node *ast;
 } ParseFixture;
@@ -15,10 +13,8 @@ typedef struct {
 static ParseFixture parse_fixture_new(const gchar *text) {
   ParseFixture fixture;
   GString *content = g_string_new(text);
-  fixture.lexer = lisp_lexer_new();
-  fixture.tokens = lisp_lexer_lex(fixture.lexer, content);
-  fixture.parser = lisp_parser_new();
-  fixture.ast = lisp_parser_parse(fixture.parser, fixture.tokens, NULL);
+  fixture.tokens = lisp_lexer_lex(content);
+  fixture.ast = lisp_parser_parse(fixture.tokens, NULL);
   g_string_free(content, TRUE);
   return fixture;
 }
@@ -28,8 +24,6 @@ static void parse_fixture_free(ParseFixture *fixture) {
     node_free_deep(fixture->ast);
   if (fixture->tokens)
     g_array_free(fixture->tokens, TRUE);
-  lisp_parser_free(fixture->parser);
-  lisp_lexer_free(fixture->lexer);
 }
 
 static void test_analyse(void) {

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -4,8 +4,6 @@
 #include <glib.h>
 
 typedef struct {
-  LispLexer *lexer;
-  LispParser *parser;
   GArray *tokens;
   Node *ast;
 } ParserFixture;
@@ -13,10 +11,8 @@ typedef struct {
 static ParserFixture parser_fixture_from_text(const gchar *text) {
   ParserFixture fixture;
   GString *content = g_string_new(text);
-  fixture.lexer = lisp_lexer_new();
-  fixture.tokens = lisp_lexer_lex(fixture.lexer, content);
-  fixture.parser = lisp_parser_new();
-  fixture.ast = lisp_parser_parse(fixture.parser, fixture.tokens, NULL);
+  fixture.tokens = lisp_lexer_lex(content);
+  fixture.ast = lisp_parser_parse(fixture.tokens, NULL);
   g_string_free(content, TRUE);
   return fixture;
 }
@@ -26,8 +22,6 @@ static void parser_fixture_free(ParserFixture *fixture) {
     node_free_deep(fixture->ast);
   if (fixture->tokens)
     g_array_free(fixture->tokens, TRUE);
-  lisp_parser_free(fixture->parser);
-  lisp_lexer_free(fixture->lexer);
 }
 
 static void test_empty_file(void) {

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -7,11 +7,9 @@
 
 static void document_prepare(Document *document) {
   g_return_if_fail(document);
-  LispLexer *lexer = document_get_lexer(document);
   const GString *content = document_get_content(document);
-  GArray *tokens = lisp_lexer_lex(lexer, content);
-  LispParser *parser = document_get_parser(document);
-  Node *ast = lisp_parser_parse(parser, tokens, document);
+  GArray *tokens = lisp_lexer_lex(content);
+  Node *ast = lisp_parser_parse(tokens, document);
   document_set_tokens(document, tokens);
   document_set_ast(document, ast);
 }


### PR DESCRIPTION
## Summary
- remove the empty LispLexer/LispParser wrappers and expose the lexer/parser logic as plain helper functions
- update document management, project processing, and REPL package handling to call the stateless helpers directly
- adapt ASDF parsing and parser-related tests to the simplified APIs

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d690cf7a808328b879a1e2ca7ec72f