### PR TITLE
Centralize document change notifications

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -74,6 +74,8 @@ void document_set_content(Document *document, GString *content) {
     document->content = NULL;
   }
   document_assign_content(document, content);
+  if (document->project)
+    project_document_changed(document->project, document);
 }
 
 const GString *document_get_content(Document *document) {

--- a/src/editor.c
+++ b/src/editor.c
@@ -85,7 +85,6 @@ on_buffer_changed (GtkTextBuffer * /*buffer*/, gpointer user_data)
   if (self && self->project && self->document) {
     editor_clear_errors(self);
     editor_sync_content(self);
-    project_document_changed(self->project, self->document);
   }
   if (self)
     editor_update_function_highlight (self);


### PR DESCRIPTION
## Summary
- trigger project document-change handling directly from `document_set_content`, removing the UI's responsibility for cross-model coordination
- keep the editor buffer-change handler focused on syncing text and highlighting logic

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d6ca2019788328aee4dc62377f02d7