### PR TITLE
Replace g_utf8_next_char usage

### DIFF
--- a/src/lisp_lexer.c
+++ b/src/lisp_lexer.c
@@ -1,5 +1,6 @@
 // Ensure all dependency headers are processed before our own header.
 #include <glib.h>
+#include "util.h"
 #include "lisp_lexer.h"
 
 static void lisp_token_free(gpointer token);
@@ -23,7 +24,7 @@ static inline gsize gstring_next_offset(const GString *text, gsize offset) {
   if (!text || offset >= text->len)
     return text ? text->len : 0;
   const gchar *ptr = text->str + offset;
-  ptr = g_utf8_next_char(ptr);
+  ptr = utf8_next_char(ptr);
   return (gsize)(ptr - text->str);
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,21 @@
 
 #include <glib.h>
 
+static inline const char *utf8_next_char(const char *p)
+{
+  unsigned char c = (unsigned char)*p;
+  if ((c & 0x80) == 0)
+    return p + 1;
+  if ((c & 0xE0) == 0xC0)
+    return p + 2;
+  if ((c & 0xF0) == 0xE0)
+    return p + 3;
+  if ((c & 0xF8) == 0xF0)
+    return p + 4;
+  /* fallback: treat as single byte to avoid infinite loop */
+  return p + 1;
+}
+
 static inline gboolean glide_is_ui_thread(void)
 {
   return g_main_context_is_owner(g_main_context_default());


### PR DESCRIPTION
## Summary
- add a utf8_next_char helper to util.h to replace g_utf8_next_char usage
- update the Lisp lexer to depend on util.h and use the new helper

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d6f275a0c4832891780f485ba1ff74