### PR TITLE
Run analysis when loading project files

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -15,6 +15,15 @@ The application crashed on startup because `editor_dispose` explicitly unreferen
 widget. The `GtkScrolledWindow` parent already disposes of its children, so unreferencing the view again left GTK trying
 to dispose an already finalized object, triggering the GLib critical `instance with invalid (NULL) class pointer`.
 
+## Project load skipped error analysis
+
+Loading a project invoked the `document_loaded` signal before running the
+`project_document_changed` pipeline. The editor built the AST after creating its
+buffer, so the parse succeeded, but the analyser never ran during the load
+notification and listeners saw an empty diagnostics array. The loader now
+reuses the same reparse-and-analyse helper as document edits before announcing a
+loaded file, so both startup and incremental edits surface the same errors.
+
 ## Argument error tooltip duplicated documentation
 
 Hovering an argument arity error showed the function documentation twice: once as escaped plain text in the error

--- a/src/project.c
+++ b/src/project.c
@@ -65,6 +65,30 @@ Document *project_add_document(Project *self, GString *content,
   return document;
 }
 
+static void project_reparse_document(Project *self, Document *document) {
+  g_return_if_fail(self != NULL);
+  g_return_if_fail(document != NULL);
+
+  document_clear_errors(document);
+  project_index_remove_document(self->index, document);
+
+  const GString *content = document_get_content(document);
+  if (!content)
+    return;
+
+  GArray *tokens = lisp_lexer_lex(content);
+  document_set_tokens(document, tokens);
+
+  Node *ast = lisp_parser_parse(tokens, document);
+  document_set_ast(document, ast);
+
+  if (!ast)
+    return;
+
+  analyse_ast(self, ast);
+  project_index_walk(self->index, ast);
+}
+
 Document *project_add_loaded_document(Project *self, const gchar *path) {
   g_return_val_if_fail(self != NULL, NULL);
   g_return_val_if_fail(path != NULL, NULL);
@@ -78,7 +102,7 @@ Document *project_add_loaded_document(Project *self, const gchar *path) {
 
   g_ptr_array_add(self->documents, document);
 
-  project_changed(self);
+  project_reparse_document(self, document);
   project_document_loaded(self, document);
 
   return document;
@@ -237,19 +261,7 @@ void project_document_changed(Project *self, Document *document) {
   g_return_if_fail(document != NULL);
   g_return_if_fail(glide_is_ui_thread());
   LOG(1, "project_document_changed path=%s", document_get_path(document));
-  document_clear_errors(document);
-  project_index_remove_document(self->index, document);
-  const GString *content = document_get_content(document);
-  if (!content)
-    return;
-  GArray *tokens = lisp_lexer_lex(content);
-  document_set_tokens(document, tokens);
-  Node *ast = lisp_parser_parse(tokens, document);
-  document_set_ast(document, ast);
-  if (ast)
-    analyse_ast(self, ast);
-  if (ast)
-    project_index_walk(self->index, ast);
+  project_reparse_document(self, document);
   if (self->document_changed_cb)
     self->document_changed_cb(self, document, self->document_changed_data);
   project_changed(self);


### PR DESCRIPTION
## Summary
- share a helper that lexes, parses, analyses, and reindexes documents so edits and loads reuse the same code path
- run the helper when adding loaded project files before emitting the document-loaded notification
- record the regression and its fix in BUGS.md

## Testing
- make app-full
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d7972bd6448328b334160425f719b9