### PR TITLE
Rename project opening helpers

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -334,7 +334,7 @@ forwarding, preventing padded NULs from ever reaching `Process` or
 Loading a project after the initial startup left the notebook on the first
 file, ignoring the saved cursor location. The restore logic lived in
 `App.activate`, so only the first project opened during activation went through
-it. Moving the restoration into `file_open_path` makes both startup and
+it. Moving the restoration into `project_open_path` makes both startup and
 subsequent loads follow the same code path, restoring the last file every
 time.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ SOURCES += \
   file_add.c \
   file_delete.c \
   file_new.c \
-  file_open.c \
+  project_open.c \
   file_rename.c \
   file_save.c \
   function.c \

--- a/src/actions.c
+++ b/src/actions.c
@@ -1,6 +1,6 @@
 #include "actions.h"
 #include "file_save.h"
-#include "file_open.h"
+#include "project_open.h"
 #include "file_rename.h"
 #include "file_new.h"
 #include "file_add.h"
@@ -29,7 +29,7 @@ project_new_cb(GSimpleAction * /*action*/, GVariant * /*param*/, gpointer data)
 static void
 project_open_cb(GSimpleAction * /*action*/, GVariant * /*param*/, gpointer data)
 {
-  file_open(NULL, data);
+  project_open(NULL, data);
 }
 
 static void
@@ -38,7 +38,7 @@ recent_project(GSimpleAction * /*action*/, GVariant *param, gpointer data)
   App *self = data;
   const gchar *path = g_variant_get_string(param, NULL);
   if (path)
-    file_open_path(self, path);
+    project_open_path(self, path);
 }
 
 static void

--- a/src/app.c
+++ b/src/app.c
@@ -1,5 +1,5 @@
 #include "app.h"
-#include "file_open.h"
+#include "project_open.h"
 #include "interactions_view.h"
 #include "editor.h"
 #include "editor_container.h"
@@ -110,7 +110,7 @@ app_activate (GApplication *app)
   gtk_container_add(GTK_CONTAINER(self->window), vbox);
   const gchar *proj = preferences_get_project_file(self->preferences);
   if (proj)
-    file_open_path(self, proj);
+    project_open_path(self, proj);
   app_update_project_view(self);
   app_update_recent_menu(self);
   gtk_widget_show_all(self->window);

--- a/src/file_open.h
+++ b/src/file_open.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include <glib.h>
-typedef struct _App App;
-
-void file_open(GtkWidget *, gpointer data);
-gboolean file_open_path(App *app, const gchar *filename);
-

--- a/src/project_new_wizard.c
+++ b/src/project_new_wizard.c
@@ -3,7 +3,7 @@
 #include "app.h"
 #include "project.h"
 #include "asdf.h"
-#include "file_open.h"
+#include "project_open.h"
 #include <glib/gstdio.h>
 #include "util.h"
 
@@ -134,7 +134,7 @@ void project_new_wizard(GtkWidget */*widget*/, gpointer data) {
     asdf_add_component(asdf, g_string_new("unnamed"));
     asdf_save(asdf, asdf_get_filename(asdf));
     g_object_unref(asdf);
-    file_open_path(app, asd_path);
+    project_open_path(app, asd_path);
     g_free(unnamed);
     g_free(name_asd);
     g_free(asd_path);

--- a/src/project_open.c
+++ b/src/project_open.c
@@ -4,7 +4,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
-#include "file_open.h"
+#include "project_open.h"
 #include "app.h"
 #include "editor.h"
 #include "editor_container.h"
@@ -40,8 +40,8 @@ static gboolean save_if_modified(App *app) {
   return TRUE;
 }
 
-gboolean file_open_path(App *app, const gchar *filename) {
-  LOG(1, "file_open_path %s", filename);
+gboolean project_open_path(App *app, const gchar *filename) {
+  LOG(1, "project_open_path %s", filename);
   g_return_val_if_fail(app != NULL, FALSE);
   if (!save_if_modified(app))
     return FALSE;
@@ -96,7 +96,7 @@ gboolean file_open_path(App *app, const gchar *filename) {
   return TRUE;
 }
 
-void file_open(GtkWidget */*widget*/, gpointer data) {
+void project_open(GtkWidget */*widget*/, gpointer data) {
   App *app = (App *)data;
 
   GtkWidget *dialog = gtk_file_chooser_dialog_new(
@@ -109,7 +109,7 @@ void file_open(GtkWidget */*widget*/, gpointer data) {
 
   if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
     gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-    file_open_path(app, filename);
+    project_open_path(app, filename);
     g_free(filename);
   }
   gtk_widget_destroy(dialog);

--- a/src/project_open.h
+++ b/src/project_open.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <glib.h>
+typedef struct _App App;
+
+void project_open(GtkWidget *, gpointer data);
+gboolean project_open_path(App *app, const gchar *filename);
+


### PR DESCRIPTION
## Summary
- rename the file-based project opening module and its API to project_open*
- update all call sites and build metadata to use the new project_open names
- refresh documentation to mention project_open_path instead of the old name

## Testing
- make app-full *(fails: No rule to make target 'app-full')*
- make run

------
https://chatgpt.com/codex/tasks/task_e_68d823a82ecc832893f8fd31abeb0bab