### PR TITLE
Add node_find_sdt_containing_offset helper

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -55,6 +55,7 @@ gboolean node_is_toplevel(const Node *node);
 gsize node_get_start_offset(const Node *node);
 gsize node_get_end_offset(const Node *node);
 const Node *node_find_containing_range(const Node *node, gsize start, gsize end);
+const Node *node_find_sdt_containing_offset(const Node *node, gsize offset);
 const gchar *node_sd_type_to_string(StringDesignatorType sd_type);
 gchar *node_debug_string(const Node *node);
 gchar *node_to_string(const Node *node);


### PR DESCRIPTION
## Summary
- add an SDT-aware range helper that includes the trailing caret position when locating matches
- expose the new `node_find_sdt_containing_offset` function so callers can rely on the SDT rule

## Testing
- make
- make run

------
https://chatgpt.com/codex/tasks/task_e_68da6bcebbe88328b19d2ef585860e25