### PR TITLE
Reset ctrl-hover feedback after goto definition

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -102,6 +102,7 @@ editor_on_button_press_event (GtkWidget *widget, GdkEventButton *event,
 
   g_action_group_activate_action (G_ACTION_GROUP (app), "goto-definition",
       NULL);
+  editor_clear_ctrl_hover (self);
   return TRUE;
 }
 


### PR DESCRIPTION
## Summary
- clear the control-hover highlight and cursor once a goto-definition click is activated so feedback resets immediately

## Testing
- make (in src)
- make run (in tests)


------
https://chatgpt.com/codex/tasks/task_e_68dd5f41ee70832892e7a7d754ebada7