### PR TITLE
Add Ctrl+S accelerator for save all

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -286,6 +286,9 @@ actions_init(App *self)
   const gchar *tooltip_accels[] = {"<Alt>t", NULL};
   gtk_application_set_accels_for_action(GTK_APPLICATION(self),
       "app.show-tooltip", tooltip_accels);
+  const gchar *save_all_accels[] = {"<Primary>s", NULL};
+  gtk_application_set_accels_for_action(GTK_APPLICATION(self),
+      "app.save-all", save_all_accels);
   const gchar *shrink_accels[] = {"<Primary><Shift>w", NULL};
   gtk_application_set_accels_for_action(GTK_APPLICATION(self),
       "app.shrink-selection", shrink_accels);


### PR DESCRIPTION
## Summary
- add a Ctrl+S accelerator binding to the save-all application action so the shortcut matches user expectations

## Testing
- make
- make run

------
https://chatgpt.com/codex/tasks/task_e_68dd8120a620832896f0c90ad3befd03