### PR TITLE
Highlight modified document tabs

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -135,7 +135,8 @@ app_startup (GApplication *app)
   gtk_css_provider_load_from_data(provider,
       // "tooltip * { color: #000; background-color: #eee; text-shadow: none; }",
       "tooltip label { color: #000; background-color: #eee; text-shadow: none; border: none } "
-      "tooltip { background-color: #eee; border: 1px solid #aaa; border-radius: 0; box-shadow: 0 0 20px -20px #aaa; }",
+      "tooltip { background-color: #eee; border: 1px solid #aaa; border-radius: 0; box-shadow: 0 0 20px -20px #aaa; } "
+      ".editor-tab-modified { color: #06c; }",
       -1, NULL);
   gtk_style_context_add_provider_for_screen(
       gdk_screen_get_default(),

--- a/src/editor.h
+++ b/src/editor.h
@@ -14,6 +14,7 @@ GtkWidget      *editor_new_for_document (Project *project, Document *document);
 GtkSourceBuffer *editor_get_buffer (Editor *self);
 Document    *editor_get_document (Editor *self);
 GtkWidget      *editor_get_view (Editor *self);
+void            editor_set_tab_label (Editor *self, GtkWidget *label);
 gboolean        editor_get_toplevel_range (Editor *self,
                     gsize offset, gsize *start, gsize *end);
 void            editor_extend_selection (Editor *self);

--- a/src/editor_container.c
+++ b/src/editor_container.c
@@ -42,6 +42,7 @@ editor_container_add_editor(EditorContainer *self, Document *document, Editor *e
   GtkWidget *view = GTK_WIDGET(editor);
   const gchar *path = document_get_relative_path(document);
   GtkWidget *label = gtk_label_new(path ? path : "untitled");
+  editor_set_tab_label(editor, label);
   gint page = gtk_notebook_append_page(GTK_NOTEBOOK(self), view, label);
   GtkWidget *page_widget = gtk_notebook_get_nth_page(GTK_NOTEBOOK(self), page);
   if (page_widget)


### PR DESCRIPTION
## Summary
- track the notebook tab label for each editor and add a CSS class when its buffer is modified
- use the application-wide CSS provider to color modified tab labels blue so they share the same styling everywhere

## Testing
- `make`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68dd83bd24d48328b367a292177cec2b