### PR TITLE
Use generic document error type and validate ranges

### DIFF
--- a/src/analyse.c
+++ b/src/analyse.c
@@ -14,7 +14,13 @@ static void analyse_mark_error(Node *node, const gchar *message) {
   gsize end = node_get_end_offset(node);
   if (end <= start)
     return;
-  document_add_error(node->document, start, end, message);
+  DocumentError error = {
+    .start = start,
+    .end = end,
+    .type = DOCUMENT_ERROR_TYPE_GENERIC,
+    .message = (gchar*) message
+  };
+  document_add_error(node->document, error);
 }
 
 static const gchar *analyse_get_symbol_name(const Node *node) {

--- a/src/analyse_defun.c
+++ b/src/analyse_defun.c
@@ -10,7 +10,13 @@ static void analyse_defun_mark_error(Node *node, const gchar *message) {
   gsize end = node_get_end_offset(node);
   if (end <= start)
     return;
-  document_add_error(node->document, start, end, message);
+  DocumentError error = {
+    .start = start,
+    .end = end,
+    .type = DOCUMENT_ERROR_TYPE_GENERIC,
+    .message = (gchar*) message
+  };
+  document_add_error(node->document, error);
 }
 
 void analyse_defun(Project *project, Node *expr, AnalyseContext *context) {

--- a/src/document.c
+++ b/src/document.c
@@ -184,17 +184,18 @@ void document_clear_errors(Document *document) {
   }
 }
 
-void document_add_error(Document *document, gsize start, gsize end, const gchar *message) {
+void document_add_error(Document *document, DocumentError error) {
   g_return_if_fail(document != NULL);
   if (!document->errors)
     document->errors = g_array_new(FALSE, FALSE, sizeof(DocumentError));
-  if (end <= start)
-    return;
+  g_return_if_fail(error.end > error.start);
   const gchar *path = document->path ? document->path : "(null)";
-  LOG(1, "document_add_error path=%s range=[%zu,%zu) message=%s", path, start,
-      end, message ? message : "(null)");
-  DocumentError err = { start, end, message ? g_strdup(message) : NULL };
-  g_array_append_val(document->errors, err);
+  LOG(1, "document_add_error path=%s range=[%zu,%zu) type=%d message=%s",
+      path, error.start, error.end, error.type,
+      error.message ? error.message : "(null)");
+  DocumentError stored = error;
+  stored.message = error.message ? g_strdup(error.message) : NULL;
+  g_array_append_val(document->errors, stored);
 }
 
 static Document *document_create(Project *project, GString *content, const gchar *path, DocumentState state) {

--- a/src/document.h
+++ b/src/document.h
@@ -13,9 +13,15 @@ typedef enum {
 
 typedef struct _Document Document;
 
+typedef enum {
+  DOCUMENT_ERROR_TYPE_GENERIC,
+  DOCUMENT_ERROR_TYPE_UNRESOLVED_SYMBOL
+} DocumentErrorType;
+
 typedef struct {
   gsize start;
   gsize end;
+  DocumentErrorType type;
   gchar *message;
 } DocumentError;
 
@@ -36,6 +42,5 @@ void         document_set_path(Document *document, const gchar *path);
 Document    *document_load(Project *project, const gchar *path);
 const gchar *document_get_relative_path(Document *document);
 void         document_clear_errors(Document *document);
-void         document_add_error(Document *document, gsize start, gsize end,
-    const gchar *message);
+void         document_add_error(Document *document, DocumentError error);
 const GArray *document_get_errors(Document *document);

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -200,6 +200,7 @@ static void test_defun_requires_symbol_name(void)
   const DocumentError *err = &g_array_index((GArray*)errors, DocumentError, 0);
   g_assert_nonnull(err->message);
   g_assert_cmpstr(err->message, ==, "DEFUN requires a symbol name.");
+  g_assert_cmpint(err->type, ==, DOCUMENT_ERROR_TYPE_GENERIC);
 
   project_unref(project);
 }
@@ -216,6 +217,7 @@ static void test_defun_requires_parameter_list(void)
   const DocumentError *err = &g_array_index((GArray*)errors, DocumentError, 0);
   g_assert_nonnull(err->message);
   g_assert_cmpstr(err->message, ==, "DEFUN requires a parameter list.");
+  g_assert_cmpint(err->type, ==, DOCUMENT_ERROR_TYPE_GENERIC);
 
   project_unref(project);
 }
@@ -271,6 +273,7 @@ static void test_function_call_argument_mismatch(void)
   g_assert_nonnull(project_get_function(project, "BAR"));
   g_assert_cmpstr(err->message, ==,
       "Expected 2 arguments for BAR but found 1");
+  g_assert_cmpint(err->type, ==, DOCUMENT_ERROR_TYPE_GENERIC);
 
   document_set_text(document, "(bar 1 2)");
   project_document_changed(project, document);
@@ -289,6 +292,7 @@ static void test_function_call_argument_mismatch(void)
   g_assert_nonnull(err->message);
   g_assert_cmpstr(err->message, ==,
       "Expected 2 arguments for BAR but found 3");
+  g_assert_cmpint(err->type, ==, DOCUMENT_ERROR_TYPE_GENERIC);
 
   document_set_text(document, "(bar 1 2)");
   project_document_changed(project, document);


### PR DESCRIPTION
## Summary
- rename the default document error classification to DOCUMENT_ERROR_TYPE_GENERIC so it no longer references the editor UI
- enforce a g_return_if_fail guard for invalid error ranges in document_add_error
- update analysis helpers and tests to use the renamed error type

## Testing
- make (in src)
- make run (in tests)


------
https://chatgpt.com/codex/tasks/task_e_68e0c7ed0db08328b77bfb6c8ae034e3