### PR TITLE
Remove unused document changed callbacks

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -20,8 +20,6 @@ static Project *project_init(void) {
   self->document_loaded_data = NULL;
   self->document_removed_cb = NULL;
   self->document_removed_data = NULL;
-  self->document_changed_cb = NULL;
-  self->document_changed_data = NULL;
   return self;
 }
 
@@ -259,8 +257,6 @@ void project_document_changed(Project *self, Document *document) {
   g_return_if_fail(glide_is_ui_thread());
   LOG(1, "project_document_changed path=%s", document_get_path(document));
   project_reparse_document(self, document);
-  if (self->document_changed_cb)
-    self->document_changed_cb(self, document, self->document_changed_data);
   project_changed(self);
 }
 
@@ -282,13 +278,6 @@ void project_set_document_loaded_cb(Project *self, DocumentLoadedCb cb, gpointer
   g_return_if_fail(glide_is_ui_thread());
   self->document_loaded_cb = cb;
   self->document_loaded_data = user_data;
-}
-
-void project_set_document_changed_cb(Project *self, DocumentChangedCb cb, gpointer user_data) {
-  g_return_if_fail(self != NULL);
-  g_return_if_fail(glide_is_ui_thread());
-  self->document_changed_cb = cb;
-  self->document_changed_data = user_data;
 }
 
 void project_document_loaded(Project *self, Document *document) {

--- a/src/project.h
+++ b/src/project.h
@@ -13,14 +13,12 @@ typedef struct _ReplSession ReplSession;
 typedef void (*DocumentLoadedCb)(Project *self, Document *document, gpointer user_data);
 typedef void (*DocumentRemovedCb)(Project *self, Document *document, gpointer user_data);
 typedef void (*ProjectChangedCb)(Project *self, gpointer user_data);
-typedef void (*DocumentChangedCb)(Project *self, Document *document, gpointer user_data);
 
 Project       *project_new(ReplSession *repl);
 Project       *project_ref(Project *self);
 void           project_unref(Project *self);
 void           project_set_document_loaded_cb(Project *self, DocumentLoadedCb cb, gpointer user_data);
 void           project_set_document_removed_cb(Project *self, DocumentRemovedCb cb, gpointer user_data);
-void           project_set_document_changed_cb(Project *self, DocumentChangedCb cb, gpointer user_data);
 void           project_set_changed_cb(Project *self, ProjectChangedCb cb, gpointer user_data);
 Document   *project_get_document(Project *self, guint index);
 guint          project_get_document_count(Project *self);

--- a/src/project_priv.h
+++ b/src/project_priv.h
@@ -12,8 +12,6 @@ struct _Project {
   gpointer document_loaded_data;
   DocumentRemovedCb document_removed_cb;
   gpointer document_removed_data;
-  DocumentChangedCb document_changed_cb;
-  gpointer document_changed_data;
   ProjectChangedCb changed_cb;
   gpointer changed_data;
   Asdf *asdf; /* owned, nullable */


### PR DESCRIPTION
## Summary
- remove the project-level document changed callback fields and setter
- rely on existing project_changed notifications after document reparsing

## Testing
- make
- make run


------
https://chatgpt.com/codex/tasks/task_e_68e4d2280ee8832885afa6c1ffebc419