### PR TITLE
Refactor project events to use a unified callback

### DIFF
--- a/src/project.h
+++ b/src/project.h
@@ -10,16 +10,24 @@
 typedef struct _Project Project;
 typedef struct _ReplSession ReplSession;
 
-typedef void (*DocumentLoadedCb)(Project *self, Document *document, gpointer user_data);
-typedef void (*DocumentRemovedCb)(Project *self, Document *document, gpointer user_data);
-typedef void (*ProjectChangedCb)(Project *self, gpointer user_data);
+typedef enum {
+  PROJECT_CHANGE_EVENT_DOCUMENT_LOADED,
+  PROJECT_CHANGE_EVENT_DOCUMENT_REMOVED,
+  PROJECT_CHANGE_EVENT_CHANGED,
+} ProjectChangeEventType;
+
+typedef struct {
+  ProjectChangeEventType type;
+  Document *document;
+} ProjectChangeEvent;
+
+typedef void (*ProjectEventCb)(Project *self, const ProjectChangeEvent *event, gpointer user_data);
 
 Project       *project_new(ReplSession *repl);
 Project       *project_ref(Project *self);
 void           project_unref(Project *self);
-void           project_set_document_loaded_cb(Project *self, DocumentLoadedCb cb, gpointer user_data);
-void           project_set_document_removed_cb(Project *self, DocumentRemovedCb cb, gpointer user_data);
-void           project_set_changed_cb(Project *self, ProjectChangedCb cb, gpointer user_data);
+guint          project_add_event_cb(Project *self, ProjectEventCb cb, gpointer user_data);
+void           project_remove_event_cb(Project *self, guint handler_id);
 Document   *project_get_document(Project *self, guint index);
 guint          project_get_document_count(Project *self);
 Document   *project_add_document(Project *self, GString *content,

--- a/src/project_priv.h
+++ b/src/project_priv.h
@@ -8,12 +8,8 @@
 struct _Project {
   GPtrArray *documents; /* Document* */
   ProjectIndex *index;
-  DocumentLoadedCb document_loaded_cb;
-  gpointer document_loaded_data;
-  DocumentRemovedCb document_removed_cb;
-  gpointer document_removed_data;
-  ProjectChangedCb changed_cb;
-  gpointer changed_data;
+  GPtrArray *event_handlers; /* ProjectEventHandler* */
+  guint next_event_handler_id;
   Asdf *asdf; /* owned, nullable */
   ReplSession *repl;
   gchar *path;


### PR DESCRIPTION
## Summary
- add a single project event callback API that emits typed change events
- update project consumers to handle unified events and remove legacy callbacks
- adjust project unit tests to listen for the new event interface

## Testing
- make
- make run


------
https://chatgpt.com/codex/tasks/task_e_68e4f1ae06d88328aa57cf600177f3e9