### PR TITLE
Move document parsing into Document module

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -33,11 +33,10 @@ void         document_free(Document *document);
 DocumentState document_get_state(Document *document);
 void         document_set_state(Document *document, DocumentState state);
 void         document_set_content(Document *document, GString *content);
+void         document_reparse(Document *document);
 const GString *document_get_content(Document *document);
 const GArray  *document_get_tokens(Document *document);
 const Node    *document_get_ast(Document *document);
-void         document_set_tokens(Document *document, GArray *tokens);
-void         document_set_ast(Document *document, Node *ast);
 const gchar *document_get_path(Document *document); /* borrowed */
 void         document_set_path(Document *document, const gchar *path);
 Document    *document_load(Project *project, const gchar *path);

--- a/src/editor.c
+++ b/src/editor.c
@@ -280,7 +280,6 @@ editor_new_for_document (Project *project, Document *document)
     gtk_source_buffer_end_not_undoable_action(self->buffer);
   }
 
-  project_document_changed (self->project, self->document);
   gtk_text_buffer_set_modified (GTK_TEXT_BUFFER (self->buffer), FALSE);
   g_signal_connect (self->buffer, "changed", G_CALLBACK (on_buffer_changed), self);
   g_signal_connect (self->buffer, "modified-changed",

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -272,11 +272,7 @@ static void project_handle_function_section(Project *project,
   Node *lambda_node = NULL;
   if (lambda_list) {
     document = document_new_virtual(g_string_new(lambda_list));
-    const GString *content = document_get_content(document);
-    GArray *tokens = lisp_lexer_lex(content);
-    Node *ast = lisp_parser_parse(tokens, document);
-    document_set_tokens(document, tokens);
-    document_set_ast(document, ast);
+    const Node *ast = document_get_ast(document);
     if (ast && ast->children && ast->children->len > 0)
       lambda_node = g_array_index(ast->children, Node*, 0);
   }


### PR DESCRIPTION
## Summary
- reparse documents within the document module whenever their content changes
- adjust project logic to consume document ASTs instead of driving lexing/parsing itself
- update project REPL handling, editor setup, and tests to align with the new parsing pipeline

## Testing
- make
- make run

------
https://chatgpt.com/codex/tasks/task_e_68e4fc214e7c8328b730aa7865afea41