### PR TITLE
Create tooltip controller with project context

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -146,7 +146,7 @@ editor_init(Editor *self)
   self->project = NULL;
   self->document = NULL;
   self->selection_stack = g_array_new(FALSE, FALSE, sizeof(SelectionRange));
-  self->tooltip_controller = editor_tooltip_controller_new(GTK_WIDGET(self->view));
+  self->tooltip_controller = NULL;
   GtkTextBuffer *buffer = GTK_TEXT_BUFFER(self->buffer);
   self->function_def_tag = gtk_text_buffer_create_tag(buffer, "function-def-highlight", "background", "#fef", NULL);
   self->function_use_tag = gtk_text_buffer_create_tag(buffer, "function-use-highlight", "background", "#eef", NULL);
@@ -249,8 +249,7 @@ editor_new_for_document(Project *project, Document *document)
   Editor *self = g_object_new(EDITOR_TYPE, NULL);
   self->project = project_ref(project);
   self->document = document;
-  if (self->tooltip_controller)
-    editor_tooltip_controller_set_project(self->tooltip_controller, project);
+  self->tooltip_controller = editor_tooltip_controller_new(GTK_WIDGET(self->view), project);
 
   const GString *existing = document_get_content(self->document);
   if (existing && existing->str) {

--- a/src/editor_tooltip_controller.c
+++ b/src/editor_tooltip_controller.c
@@ -20,11 +20,15 @@ static gchar *editor_tooltip_controller_build_function_markup (Document *documen
 static gchar *editor_tooltip_controller_build_error_markup (Document *document, gsize offset);
 
 EditorTooltipController *
-editor_tooltip_controller_new (GtkWidget *view)
+editor_tooltip_controller_new (GtkWidget *view, Project *project)
 {
+  g_return_val_if_fail (project != NULL, NULL);
+
   EditorTooltipController *self = g_new0 (EditorTooltipController, 1);
   if (!self)
     return NULL;
+
+  self->project = project_ref (project);
 
   if (view)
     editor_tooltip_controller_ensure_window (self, view);
@@ -44,20 +48,6 @@ editor_tooltip_controller_free (EditorTooltipController *self)
   }
   g_clear_object (&self->window);
   g_free (self);
-}
-
-void
-editor_tooltip_controller_set_project (EditorTooltipController *self, Project *project)
-{
-  g_return_if_fail (self != NULL);
-
-  if (project)
-    project_ref (project);
-
-  if (self->project)
-    project_unref (self->project);
-
-  self->project = project;
 }
 
 static gboolean

--- a/src/editor_tooltip_controller.h
+++ b/src/editor_tooltip_controller.h
@@ -10,10 +10,8 @@ typedef struct _Editor Editor;
 typedef struct _Project Project;
 typedef struct _EditorTooltipController EditorTooltipController;
 
-EditorTooltipController *editor_tooltip_controller_new   (GtkWidget *view);
+EditorTooltipController *editor_tooltip_controller_new   (GtkWidget *view, Project *project);
 void                     editor_tooltip_controller_free  (EditorTooltipController *self);
-void                     editor_tooltip_controller_set_project (EditorTooltipController *self,
-    Project *project);
 gboolean                 editor_tooltip_controller_query (EditorTooltipController *self,
     Editor *editor, GtkWidget *widget, gint x, gint y);
 gboolean                 editor_tooltip_controller_show  (EditorTooltipController *self);


### PR DESCRIPTION
## Summary
- create the editor tooltip controller when binding a document so the project is immediately available
- update the tooltip controller constructor to accept the project instead of setting it later

## Testing
- make
- make run


------
https://chatgpt.com/codex/tasks/task_e_68e66ee5266483289e9b076a2a2896fe