### PR TITLE
Extract selection manager from editor

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,7 @@ SOURCES += \
   editor.c \
   editor_container.c \
   editor_manager.c \
+  editor_selection_manager.c \
   editor_tooltip_controller.c \
   editor_tooltip_window.c \
   evaluate.c \

--- a/src/editor_selection_manager.c
+++ b/src/editor_selection_manager.c
@@ -1,0 +1,188 @@
+#include "editor_selection_manager.h"
+
+#include "node.h"
+#include "util.h"
+
+typedef struct {
+  gsize start;
+  gsize end;
+} SelectionRange;
+
+struct _EditorSelectionManager
+{
+  GObject parent_instance;
+  GArray *selection_stack;
+};
+
+G_DEFINE_TYPE(EditorSelectionManager, editor_selection_manager, G_TYPE_OBJECT)
+
+EditorSelectionManager *
+editor_selection_manager_new(void)
+{
+  return g_object_new(EDITOR_TYPE_SELECTION_MANAGER, NULL);
+}
+
+static void
+editor_selection_manager_select_range(GtkTextBuffer *buffer, gsize start, gsize end)
+{
+  GtkTextIter it_start;
+  GtkTextIter it_end;
+  gtk_text_buffer_get_iter_at_offset(buffer, &it_start, start);
+  gtk_text_buffer_get_iter_at_offset(buffer, &it_end, end);
+  gtk_text_buffer_select_range(buffer, &it_start, &it_end);
+}
+
+static void
+editor_selection_manager_dispose(GObject *object)
+{
+  EditorSelectionManager *self = GLIDE_EDITOR_SELECTION_MANAGER(object);
+
+  if (self->selection_stack) {
+    g_array_free(self->selection_stack, TRUE);
+    self->selection_stack = NULL;
+  }
+
+  G_OBJECT_CLASS(editor_selection_manager_parent_class)->dispose(object);
+}
+
+static void
+editor_selection_manager_class_init(EditorSelectionManagerClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS(klass);
+  object_class->dispose = editor_selection_manager_dispose;
+}
+
+static void
+editor_selection_manager_init(EditorSelectionManager *self)
+{
+  self->selection_stack = g_array_new(FALSE, FALSE, sizeof(SelectionRange));
+}
+
+gboolean
+editor_selection_manager_find_parent_range(EditorSelectionManager *self, GtkTextBuffer *buffer,
+    Document *document, gsize start, gsize end, gsize *new_start, gsize *new_end)
+{
+  g_return_val_if_fail(GLIDE_IS_EDITOR_SELECTION_MANAGER(self), FALSE);
+  g_return_val_if_fail(GTK_IS_TEXT_BUFFER(buffer), FALSE);
+  g_return_val_if_fail(document != NULL, FALSE);
+  g_return_val_if_fail(new_start != NULL, FALSE);
+  g_return_val_if_fail(new_end != NULL, FALSE);
+
+  GtkTextIter end_iter;
+  gtk_text_buffer_get_end_iter(buffer, &end_iter);
+  gsize len = gtk_text_iter_get_offset(&end_iter);
+
+  LOG(1, "find_parent_range start=%zu end=%zu", start, end);
+
+  const Node *ast = document_get_ast(document);
+  if (!ast)
+    return FALSE;
+
+  const Node *node = node_find_containing_range(ast, start, end);
+  if (!node) {
+    LOG(1, "no node found");
+    return FALSE;
+  }
+
+  gsize node_start = node_get_start_offset(node);
+  gsize node_end = node_get_end_offset(node);
+  const Node *parent = node->parent;
+
+  while (node_start == start && node_end == end && parent) {
+    LOG(1, "parent has same range [%zu,%zu), climbing", node_start, node_end);
+    node = parent;
+    node_start = node_get_start_offset(node);
+    node_end = node_get_end_offset(node);
+    parent = node->parent;
+  }
+
+  if (!parent) {
+    LOG(1, "at root node, cannot extend");
+    return FALSE;
+  }
+
+  if (node_start == start && node_end == end) {
+    if (start == 0 && end == len) {
+      LOG(1, "at buffer range, cannot extend");
+      return FALSE;
+    }
+    *new_start = 0;
+    *new_end = len;
+    LOG(1, "extending to buffer [%zu,%zu)", *new_start, *new_end);
+    return TRUE;
+  }
+
+  *new_start = node_start;
+  *new_end = node_end;
+  LOG(1, "new range [%zu,%zu)", *new_start, *new_end);
+  return TRUE;
+}
+
+void
+editor_selection_manager_extend(EditorSelectionManager *self, GtkTextBuffer *buffer, Document *document)
+{
+  g_return_if_fail(GLIDE_IS_EDITOR_SELECTION_MANAGER(self));
+  g_return_if_fail(GTK_IS_TEXT_BUFFER(buffer));
+  if (!document)
+    return;
+
+  GtkTextIter it_start;
+  GtkTextIter it_end;
+  if (!gtk_text_buffer_get_selection_bounds(buffer, &it_start, &it_end)) {
+    GtkTextMark *mark = gtk_text_buffer_get_insert(buffer);
+    gtk_text_buffer_get_iter_at_mark(buffer, &it_start, mark);
+    it_end = it_start;
+  }
+
+  gsize start = gtk_text_iter_get_offset(&it_start);
+  gsize end = gtk_text_iter_get_offset(&it_end);
+
+  LOG(1, "extend_selection start=%zu end=%zu stack_len=%u", start, end,
+      self->selection_stack ? self->selection_stack->len : 0);
+
+  if (!self->selection_stack)
+    self->selection_stack = g_array_new(FALSE, FALSE, sizeof(SelectionRange));
+
+  if (self->selection_stack->len == 0) {
+    SelectionRange original = { start, end };
+    g_array_append_val(self->selection_stack, original);
+  }
+
+  gsize new_start = start;
+  gsize new_end = end;
+  if (!editor_selection_manager_find_parent_range(self, buffer, document, start, end, &new_start, &new_end)) {
+    LOG(1, "no parent range found, resetting");
+    if (self->selection_stack->len > 0) {
+      SelectionRange orig = g_array_index(self->selection_stack, SelectionRange, 0);
+      editor_selection_manager_select_range(buffer, orig.start, orig.end);
+    }
+    g_array_set_size(self->selection_stack, 0);
+    return;
+  }
+
+  SelectionRange new_range = { new_start, new_end };
+  g_array_append_val(self->selection_stack, new_range);
+  editor_selection_manager_select_range(buffer, new_start, new_end);
+  LOG(1, "selection extended to [%zu,%zu)", new_start, new_end);
+}
+
+void
+editor_selection_manager_shrink(EditorSelectionManager *self, GtkTextBuffer *buffer)
+{
+  g_return_if_fail(GLIDE_IS_EDITOR_SELECTION_MANAGER(self));
+  g_return_if_fail(GTK_IS_TEXT_BUFFER(buffer));
+  if (!self->selection_stack || self->selection_stack->len == 0)
+    return;
+
+  if (self->selection_stack->len <= 1) {
+    SelectionRange orig = g_array_index(self->selection_stack, SelectionRange, 0);
+    editor_selection_manager_select_range(buffer, orig.start, orig.end);
+    g_array_set_size(self->selection_stack, 0);
+    return;
+  }
+
+  g_array_remove_index(self->selection_stack, self->selection_stack->len - 1);
+  SelectionRange prev = g_array_index(self->selection_stack, SelectionRange,
+      self->selection_stack->len - 1);
+  editor_selection_manager_select_range(buffer, prev.start, prev.end);
+}

--- a/src/editor_selection_manager.h
+++ b/src/editor_selection_manager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "document.h"
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define EDITOR_TYPE_SELECTION_MANAGER (editor_selection_manager_get_type())
+G_DECLARE_FINAL_TYPE (EditorSelectionManager, editor_selection_manager, GLIDE, EDITOR_SELECTION_MANAGER, GObject)
+
+EditorSelectionManager *editor_selection_manager_new (void);
+
+gboolean editor_selection_manager_find_parent_range (EditorSelectionManager *self,
+                    GtkTextBuffer *buffer,
+                    Document *document,
+                    gsize start,
+                    gsize end,
+                    gsize *new_start,
+                    gsize *new_end);
+
+void     editor_selection_manager_extend (EditorSelectionManager *self,
+                    GtkTextBuffer *buffer,
+                    Document *document);
+void     editor_selection_manager_shrink (EditorSelectionManager *self,
+                    GtkTextBuffer *buffer);
+
+G_END_DECLS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ COMMON = verbosity.c
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
 TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test \
   project_test project_repl_test asdf_test analyser_test package_test \
-  status_service_test editor_test
+  status_service_test editor_selection_manager_test editor_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -49,7 +49,10 @@ package_test: package_test.c package.c node.c $(COMMON)
 status_service_test: status_service_test.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_test: editor_test.c editor.c editor_tooltip_controller.c editor_tooltip_window.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+editor_selection_manager_test: editor_selection_manager_test.c editor_selection_manager.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+:$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
+editor_test: editor_test.c editor.c editor_selection_manager.c editor_tooltip_controller.c editor_tooltip_window.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all
@@ -64,6 +67,7 @@ run: all
 :./analyser_test
 :./package_test
 :./status_service_test
+:./editor_selection_manager_test
 :./editor_test
 
 clean:

--- a/tests/editor_selection_manager_test.c
+++ b/tests/editor_selection_manager_test.c
@@ -1,0 +1,89 @@
+#include "editor_selection_manager.h"
+#include <gtk/gtk.h>
+#include <gtksourceview/gtksource.h>
+
+static gboolean have_display;
+
+static void
+assert_selection(GtkTextBuffer *buffer, gsize expected_start, gsize expected_end)
+{
+  GtkTextIter start;
+  GtkTextIter end;
+  g_assert_true(gtk_text_buffer_get_selection_bounds(buffer, &start, &end));
+  g_assert_cmpuint(gtk_text_iter_get_offset(&start), ==, expected_start);
+  g_assert_cmpuint(gtk_text_iter_get_offset(&end), ==, expected_end);
+}
+
+static void
+assert_cursor(GtkTextBuffer *buffer, gsize expected_offset)
+{
+  GtkTextIter iter;
+  gtk_text_buffer_get_iter_at_mark(buffer, &iter, gtk_text_buffer_get_insert(buffer));
+  g_assert_cmpuint(gtk_text_iter_get_offset(&iter), ==, expected_offset);
+}
+
+static void
+test_extend_and_shrink_nested_ranges(void)
+{
+  if (!have_display) {
+    g_test_skip("no display");
+    return;
+  }
+
+  const gchar *text = "(foo (bar baz))";
+  GtkTextBuffer *buffer = GTK_TEXT_BUFFER(gtk_source_buffer_new(NULL));
+  gtk_text_buffer_set_text(buffer, text, -1);
+  Document *document = document_new_virtual(g_string_new(text));
+  EditorSelectionManager *manager = editor_selection_manager_new();
+
+  GtkTextIter iter;
+  gtk_text_buffer_get_iter_at_offset(buffer, &iter, 7);
+  gtk_text_buffer_place_cursor(buffer, &iter);
+
+  editor_selection_manager_extend(manager, buffer, document);
+  assert_selection(buffer, 6, 9);
+
+  editor_selection_manager_extend(manager, buffer, document);
+  assert_selection(buffer, 5, 13);
+
+  editor_selection_manager_extend(manager, buffer, document);
+  assert_selection(buffer, 0, 15);
+
+  editor_selection_manager_extend(manager, buffer, document);
+  g_assert_false(gtk_text_buffer_get_selection_bounds(buffer, NULL, NULL));
+  assert_cursor(buffer, 7);
+
+  gtk_text_buffer_place_cursor(buffer, &iter);
+  editor_selection_manager_extend(manager, buffer, document);
+  editor_selection_manager_extend(manager, buffer, document);
+  assert_selection(buffer, 5, 13);
+
+  editor_selection_manager_shrink(manager, buffer);
+  assert_selection(buffer, 6, 9);
+
+  editor_selection_manager_shrink(manager, buffer);
+  g_assert_false(gtk_text_buffer_get_selection_bounds(buffer, NULL, NULL));
+  assert_cursor(buffer, 7);
+
+  editor_selection_manager_shrink(manager, buffer);
+  g_assert_false(gtk_text_buffer_get_selection_bounds(buffer, NULL, NULL));
+  assert_cursor(buffer, 7);
+
+  g_object_unref(buffer);
+  document_free(document);
+  g_object_unref(manager);
+}
+
+int
+main(int argc, char *argv[])
+{
+  g_test_init(&argc, &argv, NULL);
+  have_display = gtk_init_check(&argc, &argv);
+  GMainContext *ctx = g_main_context_default();
+  g_main_context_push_thread_default(ctx);
+  g_test_add_func("/editor_selection_manager/extend_and_shrink_nested_ranges",
+      test_extend_and_shrink_nested_ranges);
+  int ret = g_test_run();
+  g_main_context_pop_thread_default(ctx);
+  return ret;
+}


### PR DESCRIPTION
## Summary
- introduce an EditorSelectionManager GObject responsible for managing the selection range stack and parent lookups
- refactor Editor to use the selection manager for extending, shrinking, and discovering selection ranges
- add a unit test exercising nested selection behaviour and wire new sources into the build

## Testing
- make -C src
- make -C tests run

------
https://chatgpt.com/codex/tasks/task_e_68e67ae58a248328bfbb9373bdc5cb27