### PR TITLE
Fix spacing before parentheses in key modules

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -57,7 +57,7 @@ G_DEFINE_TYPE(App, app, GTK_TYPE_APPLICATION)
 
 /* ---  class_init ------------------------------------------------------- */
 static void
-app_activate (GApplication *app)
+app_activate(GApplication *app)
 {
   App *self = GLIDE_APP(app);
 
@@ -120,11 +120,11 @@ app_activate (GApplication *app)
 }
 
 static void
-app_startup (GApplication *app)
+app_startup(GApplication *app)
 {
   LOG(1, "App.startup");
   /* Chain up first */
-  G_APPLICATION_CLASS (app_parent_class)->startup (app);
+  G_APPLICATION_CLASS(app_parent_class)->startup(app);
   g_return_if_fail(glide_is_ui_thread());
   App *self = GLIDE_APP(app);
   self->project = project_new(self->glide);
@@ -146,7 +146,7 @@ app_startup (GApplication *app)
 }
 
 static void
-app_dispose (GObject *object)
+app_dispose(GObject *object)
 {
   App *self = GLIDE_APP(object);
 
@@ -166,15 +166,15 @@ app_dispose (GObject *object)
     self->preferences = NULL;
   }
   g_clear_pointer(&self->glide, repl_session_unref);
-  G_OBJECT_CLASS (app_parent_class)->dispose (object);
+  G_OBJECT_CLASS(app_parent_class)->dispose(object);
 }
 
 static void
-app_class_init (AppClass *klass)
+app_class_init(AppClass *klass)
 {
   LOG(1, "App.class_init");
-  GApplicationClass *app_class = G_APPLICATION_CLASS (klass);
-  GObjectClass      *obj_class = G_OBJECT_CLASS (klass);
+  GApplicationClass *app_class = G_APPLICATION_CLASS(klass);
+  GObjectClass      *obj_class = G_OBJECT_CLASS(klass);
 
   app_class->startup  = app_startup;
   app_class->activate = app_activate;
@@ -182,7 +182,7 @@ app_class_init (AppClass *klass)
 }
 
 static void
-app_init (App *self)
+app_init(App *self)
 {
   LOG(1, "App.init");
   /* Everything that needs only the *instance* goes here */
@@ -199,12 +199,12 @@ app_init (App *self)
 }
 
 STATIC App *
-app_new (Preferences *prefs, ReplSession *glide, StatusService *status_service)
+app_new(Preferences *prefs, ReplSession *glide, StatusService *status_service)
 {
   LOG(1, "App.new");
-  g_return_val_if_fail (glide, NULL);
+  g_return_val_if_fail(glide, NULL);
 
-  App *self = g_object_new (GLIDE_TYPE,
+  App *self = g_object_new(GLIDE_TYPE,
       /* GtkApplication properties */
       "application-id",    "org.example.Glide",
       "flags",             G_APPLICATION_HANDLES_OPEN,
@@ -221,7 +221,7 @@ STATIC Editor *
 app_get_editor(App *self)
 {
   LOG(1, "App.get_editor");
-  g_return_val_if_fail (GLIDE_IS_APP (self), NULL);
+  g_return_val_if_fail(GLIDE_IS_APP(self), NULL);
   if (!self->editor_container)
     return NULL;
   return editor_container_get_current_editor(self->editor_container);
@@ -416,16 +416,16 @@ app_update_recent_menu(App *self)
 
 
 STATIC Preferences *
-app_get_preferences (App *self)
+app_get_preferences(App *self)
 {
-  g_return_val_if_fail (GLIDE_IS_APP (self), NULL);
+  g_return_val_if_fail(GLIDE_IS_APP(self), NULL);
   return self->preferences;
 }
 
 STATIC ReplSession *
-app_get_glide (App *self)
+app_get_glide(App *self)
 {
-  g_return_val_if_fail (GLIDE_IS_APP (self), NULL);
+  g_return_val_if_fail(GLIDE_IS_APP(self), NULL);
   return self->glide;
 }
 
@@ -438,18 +438,18 @@ app_set_recent_menu(App *self, GMenu *menu)
 
 
 STATIC void
-app_quit (App *self)
+app_quit(App *self)
 {
   LOG(1, "App.quit");
-  g_return_if_fail (GLIDE_IS_APP (self));
-  g_application_quit (G_APPLICATION (self));
+  g_return_if_fail(GLIDE_IS_APP(self));
+  g_application_quit(G_APPLICATION(self));
 }
 
 STATIC void
-app_on_quit (App *self)
+app_on_quit(App *self)
 {
   LOG(1, "App.on_quit");
-  g_return_if_fail (GLIDE_IS_APP (self));
+  g_return_if_fail(GLIDE_IS_APP(self));
   Preferences *prefs = app_get_preferences(self);
   Document *document = app_get_current_document(self);
   if (prefs && document) {
@@ -467,6 +467,6 @@ app_on_quit (App *self)
   }
   if (!app_close_project(self, FALSE))
     return;
-  app_quit (self);
+  app_quit(self);
 }
 

--- a/src/app.h
+++ b/src/app.h
@@ -19,7 +19,7 @@ G_BEGIN_DECLS
 #define GLIDE_TYPE (app_get_type())
 G_DECLARE_FINAL_TYPE(App, app, GLIDE, APP, GtkApplication)
 
-STATIC App *app_new (Preferences *prefs, ReplSession *glide, StatusService *status_service);
+STATIC App *app_new(Preferences *prefs, ReplSession *glide, StatusService *status_service);
 STATIC Editor *app_get_editor(App *self);
 STATIC EditorContainer *app_get_editor_container(App *self);
 STATIC EditorManager *app_get_editor_manager(App *self);

--- a/src/editor_tooltip_controller.c
+++ b/src/editor_tooltip_controller.c
@@ -13,197 +13,197 @@ struct _EditorTooltipController
   Project *project;
 };
 
-static gboolean editor_tooltip_controller_ensure_window (EditorTooltipController *self, GtkWidget *view);
-static const Node *editor_tooltip_controller_find_sdt_node (Document *document, gsize offset);
-static gchar *editor_tooltip_controller_build_function_markup (Document *document, Project *project,
+static gboolean editor_tooltip_controller_ensure_window(EditorTooltipController *self, GtkWidget *view);
+static const Node *editor_tooltip_controller_find_sdt_node(Document *document, gsize offset);
+static gchar *editor_tooltip_controller_build_function_markup(Document *document, Project *project,
     gsize offset);
-static gchar *editor_tooltip_controller_build_error_markup (Document *document, gsize offset);
+static gchar *editor_tooltip_controller_build_error_markup(Document *document, gsize offset);
 
 EditorTooltipController *
-editor_tooltip_controller_new (GtkWidget *view, Project *project)
+editor_tooltip_controller_new(GtkWidget *view, Project *project)
 {
-  g_return_val_if_fail (project != NULL, NULL);
+  g_return_val_if_fail(project != NULL, NULL);
 
-  EditorTooltipController *self = g_new0 (EditorTooltipController, 1);
+  EditorTooltipController *self = g_new0(EditorTooltipController, 1);
   if (!self)
     return NULL;
 
-  self->project = project_ref (project);
+  self->project = project_ref(project);
 
   if (view)
-    editor_tooltip_controller_ensure_window (self, view);
+    editor_tooltip_controller_ensure_window(self, view);
 
   return self;
 }
 
 void
-editor_tooltip_controller_free (EditorTooltipController *self)
+editor_tooltip_controller_free(EditorTooltipController *self)
 {
   if (!self)
     return;
 
   if (self->project) {
-    project_unref (self->project);
+    project_unref(self->project);
     self->project = NULL;
   }
-  g_clear_object (&self->window);
-  g_free (self);
+  g_clear_object(&self->window);
+  g_free(self);
 }
 
 static gboolean
-editor_tooltip_controller_ensure_window (EditorTooltipController *self, GtkWidget *view)
+editor_tooltip_controller_ensure_window(EditorTooltipController *self, GtkWidget *view)
 {
-  g_return_val_if_fail (self != NULL, FALSE);
+  g_return_val_if_fail(self != NULL, FALSE);
 
   if (self->window)
     return TRUE;
 
-  if (!view || !GTK_IS_WIDGET (view))
+  if (!view || !GTK_IS_WIDGET(view))
     return FALSE;
 
-  self->window = editor_tooltip_window_new ();
+  self->window = editor_tooltip_window_new();
   if (!self->window)
     return FALSE;
 
-  g_object_ref_sink (G_OBJECT (self->window));
-  gtk_widget_set_tooltip_window (view, GTK_WINDOW (self->window));
+  g_object_ref_sink(G_OBJECT(self->window));
+  gtk_widget_set_tooltip_window(view, GTK_WINDOW(self->window));
   return TRUE;
 }
 
 static const Node *
-editor_tooltip_controller_find_sdt_node (Document *document, gsize offset)
+editor_tooltip_controller_find_sdt_node(Document *document, gsize offset)
 {
-  g_return_val_if_fail (document != NULL, NULL);
+  g_return_val_if_fail(document != NULL, NULL);
 
-  const Node *ast = document_get_ast (document);
+  const Node *ast = document_get_ast(document);
   if (!ast)
     return NULL;
 
-  return node_find_sdt_containing_offset (ast, offset);
+  return node_find_sdt_containing_offset(ast, offset);
 }
 
 static gchar *
-editor_tooltip_controller_build_function_markup (Document *document, Project *project, gsize offset)
+editor_tooltip_controller_build_function_markup(Document *document, Project *project, gsize offset)
 {
-  const Node *node = editor_tooltip_controller_find_sdt_node (document, offset);
+  const Node *node = editor_tooltip_controller_find_sdt_node(document, offset);
   if (!node) {
-    LOG (2, "EditorTooltipController.build_function_markup: no node");
+    LOG(2, "EditorTooltipController.build_function_markup: no node");
     return NULL;
   }
 
-  gchar *node_str = node_to_string (node);
-  LOG (2, "EditorTooltipController.build_function_markup: node %s", node_str ? node_str : "<unknown>");
-  g_free (node_str);
+  gchar *node_str = node_to_string(node);
+  LOG(2, "EditorTooltipController.build_function_markup: node %s", node_str ? node_str : "<unknown>");
+  g_free(node_str);
 
-  if (!node_is (node, SDT_FUNCTION_USE)) {
-    LOG (2, "EditorTooltipController.build_function_markup: node not a function use");
+  if (!node_is(node, SDT_FUNCTION_USE)) {
+    LOG(2, "EditorTooltipController.build_function_markup: node not a function use");
     return NULL;
   }
 
-  const gchar *name = node_get_name (node);
-  LOG (2, "EditorTooltipController.build_function_markup: function %s", name ? name : "(null)");
+  const gchar *name = node_get_name(node);
+  LOG(2, "EditorTooltipController.build_function_markup: function %s", name ? name : "(null)");
 
   if (!project) {
-    LOG (1, "EditorTooltipController.build_function_markup: project unavailable");
+    LOG(1, "EditorTooltipController.build_function_markup: project unavailable");
     return NULL;
   }
 
-  Function *fn = project_get_function (project, name);
+  Function *fn = project_get_function(project, name);
   if (!fn) {
-    LOG (1, "EditorTooltipController.build_function_markup: function not found");
+    LOG(1, "EditorTooltipController.build_function_markup: function not found");
     return NULL;
   }
 
-  gchar *markup = function_tooltip (fn);
+  gchar *markup = function_tooltip(fn);
   if (!markup)
-    LOG (1, "EditorTooltipController.build_function_markup: no tooltip");
+    LOG(1, "EditorTooltipController.build_function_markup: no tooltip");
 
   return markup;
 }
 
 static gchar *
-editor_tooltip_controller_build_error_markup (Document *document, gsize offset)
+editor_tooltip_controller_build_error_markup(Document *document, gsize offset)
 {
   if (!document)
     return NULL;
 
-  const GArray *errors = document_get_errors (document);
+  const GArray *errors = document_get_errors(document);
   if (!errors || errors->len == 0)
     return NULL;
 
-  LOG (2, "EditorTooltipController.build_error_markup checking %u errors", errors->len);
+  LOG(2, "EditorTooltipController.build_error_markup checking %u errors", errors->len);
   for (guint i = 0; i < errors->len; i++) {
-    const DocumentError *err = &g_array_index ((GArray *) errors, DocumentError, i);
+    const DocumentError *err = &g_array_index((GArray *) errors, DocumentError, i);
     if (offset < err->start || offset >= err->end)
       continue;
 
-    LOG (1, "EditorTooltipController.build_error_markup: match range=[%zu,%zu) message=%s",
+    LOG(1, "EditorTooltipController.build_error_markup: match range=[%zu,%zu) message=%s",
         err->start, err->end, err->message ? err->message : "(null)");
     const gchar *message = (err->message && *err->message) ? err->message : "Error";
-    return g_markup_escape_text (message, -1);
+    return g_markup_escape_text(message, -1);
   }
 
-  LOG (2, "EditorTooltipController.build_error_markup: no match at offset %zu", offset);
+  LOG(2, "EditorTooltipController.build_error_markup: no match at offset %zu", offset);
   return NULL;
 }
 
 gboolean
-editor_tooltip_controller_query (EditorTooltipController *self, Editor *editor, GtkWidget *widget, gint x, gint y)
+editor_tooltip_controller_query(EditorTooltipController *self, Editor *editor, GtkWidget *widget, gint x, gint y)
 {
-  g_assert (glide_is_ui_thread ());
-  g_return_val_if_fail (self != NULL, FALSE);
-  g_return_val_if_fail (GLIDE_IS_EDITOR (editor), FALSE);
-  g_return_val_if_fail (GTK_IS_WIDGET (widget), FALSE);
+  g_assert(glide_is_ui_thread());
+  g_return_val_if_fail(self != NULL, FALSE);
+  g_return_val_if_fail(GLIDE_IS_EDITOR(editor), FALSE);
+  g_return_val_if_fail(GTK_IS_WIDGET(widget), FALSE);
 
-  Document *document = editor_get_document (editor);
+  Document *document = editor_get_document(editor);
   if (!document)
     return FALSE;
 
   if (!self->project)
     return FALSE;
 
-  if (!editor_tooltip_controller_ensure_window (self, widget))
+  if (!editor_tooltip_controller_ensure_window(self, widget))
     return FALSE;
 
   GtkTextIter iter;
   gint bx;
   gint by;
-  gtk_text_view_window_to_buffer_coords (GTK_TEXT_VIEW (widget), GTK_TEXT_WINDOW_WIDGET, x, y, &bx, &by);
-  gtk_text_view_get_iter_at_location (GTK_TEXT_VIEW (widget), &iter, bx, by);
-  gsize offset = gtk_text_iter_get_offset (&iter);
-  LOG (2, "EditorTooltipController.query offset=%zu", offset);
+  gtk_text_view_window_to_buffer_coords(GTK_TEXT_VIEW(widget), GTK_TEXT_WINDOW_WIDGET, x, y, &bx, &by);
+  gtk_text_view_get_iter_at_location(GTK_TEXT_VIEW(widget), &iter, bx, by);
+  gsize offset = gtk_text_iter_get_offset(&iter);
+  LOG(2, "EditorTooltipController.query offset=%zu", offset);
 
-  gchar *error_markup = editor_tooltip_controller_build_error_markup (document, offset);
-  gchar *function_markup = editor_tooltip_controller_build_function_markup (document, self->project, offset);
+  gchar *error_markup = editor_tooltip_controller_build_error_markup(document, offset);
+  gchar *function_markup = editor_tooltip_controller_build_function_markup(document, self->project, offset);
 
   gboolean shown = FALSE;
   if (self->window)
-    shown = editor_tooltip_window_set_content (self->window, error_markup, function_markup);
+    shown = editor_tooltip_window_set_content(self->window, error_markup, function_markup);
 
-  g_free (function_markup);
-  g_free (error_markup);
+  g_free(function_markup);
+  g_free(error_markup);
 
   return shown;
 }
 
 gboolean
-editor_tooltip_controller_show (EditorTooltipController *self)
+editor_tooltip_controller_show(EditorTooltipController *self)
 {
-  g_assert (glide_is_ui_thread ());
-  g_return_val_if_fail (self != NULL, FALSE);
+  g_assert(glide_is_ui_thread());
+  g_return_val_if_fail(self != NULL, FALSE);
 
   if (!self->window) {
-    LOG (1, "EditorTooltipController.show: no tooltip window");
+    LOG(1, "EditorTooltipController.show: no tooltip window");
     return FALSE;
   }
 
-  if (!editor_tooltip_window_has_content (self->window)) {
-    LOG (1, "EditorTooltipController.show: no cached tooltip content");
+  if (!editor_tooltip_window_has_content(self->window)) {
+    LOG(1, "EditorTooltipController.show: no cached tooltip content");
     return FALSE;
   }
 
-  gtk_widget_show (GTK_WIDGET (self->window));
-  gtk_window_present (GTK_WINDOW (self->window));
+  gtk_widget_show(GTK_WIDGET(self->window));
+  gtk_window_present(GTK_WINDOW(self->window));
 
   return TRUE;
 }


### PR DESCRIPTION
## Summary
- remove stray spaces before parentheses in the editor tooltip controller implementation
- align App lifecycle helpers and header declarations with the project spacing convention

## Testing
- make (from src/)
- make run (from tests/)


------
https://chatgpt.com/codex/tasks/task_e_68e687e7658483289819670eb394da17