### PR TITLE
Fix spacing before parentheses in function calls

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -348,8 +348,8 @@ show_editor_tooltip(App *self)
     return;
   }
 
-  EditorTooltipController *controller = editor_get_tooltip_controller (current);
-  if (!controller || !editor_tooltip_controller_show (controller))
+  EditorTooltipController *controller = editor_get_tooltip_controller(current);
+  if (!controller || !editor_tooltip_controller_show(controller))
     LOG(1, "Actions.show_editor_tooltip: no tooltip content");
 }
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -7,21 +7,21 @@
 
 G_BEGIN_DECLS
 
-#define EDITOR_TYPE (editor_get_type ())
-G_DECLARE_FINAL_TYPE (Editor, editor, GLIDE, EDITOR, GtkScrolledWindow)
+#define EDITOR_TYPE (editor_get_type())
+G_DECLARE_FINAL_TYPE(Editor, editor, GLIDE, EDITOR, GtkScrolledWindow)
 
 typedef struct _EditorTooltipController EditorTooltipController;
 
-GtkWidget      *editor_new_for_document (Project *project, Document *document);
-GtkSourceBuffer *editor_get_buffer (Editor *self);
-Document    *editor_get_document (Editor *self);
-GtkWidget      *editor_get_view (Editor *self);
-void            editor_set_tab_label (Editor *self, GtkWidget *label);
-gboolean        editor_get_toplevel_range (Editor *self,
+GtkWidget      *editor_new_for_document(Project *project, Document *document);
+GtkSourceBuffer *editor_get_buffer(Editor *self);
+Document    *editor_get_document(Editor *self);
+GtkWidget      *editor_get_view(Editor *self);
+void            editor_set_tab_label(Editor *self, GtkWidget *label);
+gboolean        editor_get_toplevel_range(Editor *self,
                     gsize offset, gsize *start, gsize *end);
-void            editor_extend_selection (Editor *self);
-void            editor_shrink_selection (Editor *self);
-EditorTooltipController *editor_get_tooltip_controller (Editor *self);
+void            editor_extend_selection(Editor *self);
+void            editor_shrink_selection(Editor *self);
+EditorTooltipController *editor_get_tooltip_controller(Editor *self);
 void            editor_set_errors(Editor *self, const GArray *errors);
 
 G_END_DECLS

--- a/src/editor_selection_manager.h
+++ b/src/editor_selection_manager.h
@@ -6,11 +6,11 @@
 G_BEGIN_DECLS
 
 #define EDITOR_TYPE_SELECTION_MANAGER (editor_selection_manager_get_type())
-G_DECLARE_FINAL_TYPE (EditorSelectionManager, editor_selection_manager, GLIDE, EDITOR_SELECTION_MANAGER, GObject)
+G_DECLARE_FINAL_TYPE(EditorSelectionManager, editor_selection_manager, GLIDE, EDITOR_SELECTION_MANAGER, GObject)
 
-EditorSelectionManager *editor_selection_manager_new (void);
+EditorSelectionManager *editor_selection_manager_new(void);
 
-gboolean editor_selection_manager_find_parent_range (EditorSelectionManager *self,
+gboolean editor_selection_manager_find_parent_range(EditorSelectionManager *self,
                     GtkTextBuffer *buffer,
                     Document *document,
                     gsize start,
@@ -18,10 +18,10 @@ gboolean editor_selection_manager_find_parent_range (EditorSelectionManager *sel
                     gsize *new_start,
                     gsize *new_end);
 
-void     editor_selection_manager_extend (EditorSelectionManager *self,
+void     editor_selection_manager_extend(EditorSelectionManager *self,
                     GtkTextBuffer *buffer,
                     Document *document);
-void     editor_selection_manager_shrink (EditorSelectionManager *self,
+void     editor_selection_manager_shrink(EditorSelectionManager *self,
                     GtkTextBuffer *buffer);
 
 G_END_DECLS

--- a/src/editor_tooltip_controller.h
+++ b/src/editor_tooltip_controller.h
@@ -10,11 +10,11 @@ typedef struct _Editor Editor;
 typedef struct _Project Project;
 typedef struct _EditorTooltipController EditorTooltipController;
 
-EditorTooltipController *editor_tooltip_controller_new   (GtkWidget *view, Project *project);
-void                     editor_tooltip_controller_free  (EditorTooltipController *self);
-gboolean                 editor_tooltip_controller_query (EditorTooltipController *self,
+EditorTooltipController *editor_tooltip_controller_new(GtkWidget *view, Project *project);
+void                     editor_tooltip_controller_free(EditorTooltipController *self);
+gboolean                 editor_tooltip_controller_query(EditorTooltipController *self,
     Editor *editor, GtkWidget *widget, gint x, gint y);
-gboolean                 editor_tooltip_controller_show  (EditorTooltipController *self);
+gboolean                 editor_tooltip_controller_show(EditorTooltipController *self);
 
 G_END_DECLS
 

--- a/src/editor_tooltip_window.h
+++ b/src/editor_tooltip_window.h
@@ -8,17 +8,17 @@ G_BEGIN_DECLS
 typedef struct _EditorTooltipWindow EditorTooltipWindow;
 typedef struct _EditorTooltipWindowClass EditorTooltipWindowClass;
 
-#define EDITOR_TYPE_TOOLTIP_WINDOW (editor_tooltip_window_get_type ())
+#define EDITOR_TYPE_TOOLTIP_WINDOW (editor_tooltip_window_get_type())
 #define EDITOR_TOOLTIP_WINDOW(obj) \
     (G_TYPE_CHECK_INSTANCE_CAST ((obj), EDITOR_TYPE_TOOLTIP_WINDOW, EditorTooltipWindow))
 #define EDITOR_IS_TOOLTIP_WINDOW(obj) \
     (G_TYPE_CHECK_INSTANCE_TYPE ((obj), EDITOR_TYPE_TOOLTIP_WINDOW))
 
-gboolean               editor_tooltip_window_set_content (EditorTooltipWindow *self,
+gboolean               editor_tooltip_window_set_content(EditorTooltipWindow *self,
     const gchar *error_markup, const gchar *doc_markup);
-gboolean               editor_tooltip_window_has_content (EditorTooltipWindow *self);
-EditorTooltipWindow   *editor_tooltip_window_new          (void);
-GType                  editor_tooltip_window_get_type     (void);
+gboolean               editor_tooltip_window_has_content(EditorTooltipWindow *self);
+EditorTooltipWindow   *editor_tooltip_window_new(void);
+GType                  editor_tooltip_window_get_type(void);
 
 G_END_DECLS
 

--- a/src/main.c
+++ b/src/main.c
@@ -10,10 +10,10 @@
 #include <gtksourceview/gtksource.h>
 
 int
-main (int argc, char *argv[])
+main(int argc, char *argv[])
 {
   LOG(1, "Main.main");
-  Preferences *prefs = preferences_new (g_get_user_config_dir ());
+  Preferences *prefs = preferences_new(g_get_user_config_dir());
   const gchar *sdk_path = preferences_get_sdk(prefs);
   const gchar *proc_argv[] = {
     sdk_path, "--noinform",
@@ -25,9 +25,9 @@ main (int argc, char *argv[])
   ReplProcess *repl_proc = repl_process_new(proc);
   StatusService *status_service = status_service_new();
   ReplSession *repl = repl_session_new(repl_proc, status_service);
-  App *app     = app_new (prefs, repl, status_service);
+  App *app     = app_new(prefs, repl, status_service);
 
-  int status = g_application_run (G_APPLICATION (app), argc, argv);
+  int status = g_application_run(G_APPLICATION(app), argc, argv);
   g_object_unref(app);
   repl_session_unref(repl);
   repl_process_unref(repl_proc);


### PR DESCRIPTION
## Summary
- remove stray spaces between function names and parentheses in various headers
- clean up tooltip controller call sites to follow spacing convention
- align main entry point with project coding style

## Testing
- make
- make run

------
https://chatgpt.com/codex/tasks/task_e_68e6898389c483288a4f90f5003f4638