### PR TITLE
Inline document allocation in constructor

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -26,9 +26,7 @@ typedef struct {
   gchar *message;
 } DocumentError;
 
-Document    *document_new(Project *project, const gchar *path,
-    DocumentState state);
-Document    *document_new_virtual(GString *content);
+Document    *document_new(Project *project, DocumentState state);
 void         document_free(Document *document);
 DocumentState document_get_state(Document *document);
 void         document_set_state(Document *document, DocumentState state);

--- a/src/project.c
+++ b/src/project.c
@@ -69,7 +69,8 @@ Document *project_add_document(Project *self, GString *content,
 
   if (!content)
     content = g_string_new("");
-  Document *document = document_new(self, path, state);
+  Document *document = document_new(self, state);
+  document_set_path(document, path);
   g_ptr_array_add(self->documents, document);
   document_set_content(document, content);
 
@@ -88,7 +89,8 @@ Document *project_add_loaded_document(Project *self, const gchar *path) {
   if (!content)
     return NULL;
 
-  Document *document = document_new(self, path, DOCUMENT_LIVE);
+  Document *document = document_new(self, DOCUMENT_LIVE);
+  document_set_path(document, path);
   g_ptr_array_add(self->documents, document);
   document_set_content(document, content);
   project_document_loaded(self, document);

--- a/src/project_repl.c
+++ b/src/project_repl.c
@@ -303,7 +303,8 @@ static void project_handle_function_section(Project *project,
   Document *document = NULL;
   Node *lambda_node = NULL;
   if (lambda_list) {
-    document = document_new_virtual(g_string_new(lambda_list));
+    document = document_new(NULL, DOCUMENT_LIVE);
+    document_set_content(document, g_string_new(lambda_list));
     const Node *ast = document_get_ast(document);
     if (ast && ast->children && ast->children->len > 0)
       lambda_node = g_array_index(ast->children, Node*, 0);

--- a/tests/editor_selection_manager_test.c
+++ b/tests/editor_selection_manager_test.c
@@ -33,7 +33,8 @@ test_extend_and_shrink_nested_ranges(void)
   const gchar *text = "(foo (bar baz))";
   GtkTextBuffer *buffer = GTK_TEXT_BUFFER(gtk_source_buffer_new(NULL));
   gtk_text_buffer_set_text(buffer, text, -1);
-  Document *document = document_new_virtual(g_string_new(text));
+  Document *document = document_new(NULL, DOCUMENT_LIVE);
+  document_set_content(document, g_string_new(text));
   EditorSelectionManager *manager = editor_selection_manager_new();
 
   GtkTextIter iter;

--- a/tests/project_test.c
+++ b/tests/project_test.c
@@ -12,7 +12,9 @@ static void document_set_text(Document *document, const gchar *text) {
 }
 
 static Document *create_virtual_file(const gchar *text) {
-  return document_new_virtual(g_string_new(text));
+  Document *document = document_new(NULL, DOCUMENT_LIVE);
+  document_set_content(document, g_string_new(text));
+  return document;
 }
 
 static Function *create_function_with_lambda(const gchar *name,


### PR DESCRIPTION
## Summary
- inline the document allocation logic directly inside `document_new` now that it is the single entry point

## Testing
- cd src && make
- cd tests && make run

------
https://chatgpt.com/codex/tasks/task_e_68e7c9ba753c8328af43fab5cc99362e