### PR TITLE
Handle document load failures before storing projects

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -37,7 +37,7 @@ const GArray  *document_get_tokens(Document *document);
 const Node    *document_get_ast(Document *document);
 const gchar *document_get_path(Document *document); /* borrowed */
 void         document_set_path(Document *document, const gchar *path);
-GString     *document_load_buffer(const gchar *path);
+gboolean     document_load_from_file(Document *document, const gchar *path);
 const gchar *document_get_relative_path(Document *document);
 void         document_clear_errors(Document *document);
 void         document_add_error(Document *document, DocumentError error);

--- a/src/project.c
+++ b/src/project.c
@@ -85,14 +85,12 @@ Document *project_add_loaded_document(Project *self, const gchar *path) {
 
   LOG(1, "project_add_loaded_document path=%s", path);
 
-  GString *content = document_load_buffer(path);
-  if (!content)
-    return NULL;
-
   Document *document = document_new(self, DOCUMENT_LIVE);
-  document_set_path(document, path);
+  if (!document_load_from_file(document, path)) {
+    document_free(document);
+    return NULL;
+  }
   g_ptr_array_add(self->documents, document);
-  document_set_content(document, content);
   project_document_loaded(self, document);
   return document;
 }


### PR DESCRIPTION
## Summary
- avoid adding new documents to the project array until after they successfully load from disk
- free the temporary document when loading fails to prevent leaks

## Testing
- make -C src
- make -C tests run

------
https://chatgpt.com/codex/tasks/task_e_68e977025df88328b67d4e87bd37c670