### PR TITLE
Fix process destruction deadlock

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -505,3 +505,12 @@ generic underline styling, so readers could not tell which part of the call was
 undefined and the visual treatment matched other diagnostics. The analyser now
 attaches the error range to the callee symbol and the editor renders undefined
 functions in red text, making the problem location and severity clear.
+
+## Process tests hung while destroying children
+
+Running the process unit tests occasionally stalled after completing the second
+case. `process_destroy` waited for the stdout and stderr threads to finish
+before closing their pipes, so if a child process was still running, the reads
+blocked indefinitely and the test never progressed. The destroy routine now
+closes the pipes first, which breaks the blocking reads and allows the threads
+to join even when the child misbehaves.

--- a/src/process.c
+++ b/src/process.c
@@ -61,13 +61,22 @@ Process *process_ref(Process *self) {
 }
 
 static void process_destroy(Process *process) {
+  if (process->in_fd >= 0) {
+    close(process->in_fd);
+    process->in_fd = -1;
+  }
+  if (process->out_fd >= 0) {
+    close(process->out_fd);
+    process->out_fd = -1;
+  }
+  if (process->err_fd >= 0) {
+    close(process->err_fd);
+    process->err_fd = -1;
+  }
   if (process->out_thread)
     g_thread_join(process->out_thread);
   if (process->err_thread)
     g_thread_join(process->err_thread);
-  if (process->in_fd >= 0) close(process->in_fd);
-  if (process->out_fd >= 0) close(process->out_fd);
-  if (process->err_fd >= 0) close(process->err_fd);
   if (process->pid)
     g_spawn_close_pid(process->pid);
   g_strfreev(process->argv);


### PR DESCRIPTION
## Summary
- close process pipes before joining the stdout and stderr reader threads so blocking reads unblock
- document the hang in BUGS.md

## Testing
- make -C src
- make -C tests run

------
https://chatgpt.com/codex/tasks/task_e_68ea548544208328a67f6154cc3dd9b5