### PR TITLE
Fix auto-insert closing delimiter iterator reuse

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -522,3 +522,14 @@ the end offset one character too early, so the check failed even though the
 runtime behaviour was right. The test now matches the inclusive range the
 selection manager produces.
 
+## Auto-inserted delimiters invalidated iterators
+
+Typing `(` or `"` triggered the new auto-closing logic, which inserted the
+matching delimiter inside the `insert-text` signal handler. GTK invalidates
+all outstanding iterators after a buffer mutation, so the original `location`
+pointer handed to the signal became stale once the closing character was
+inserted. Returning with that invalid iterator made GTK warn that the buffer
+position was no longer valid. The handler now copies the updated iterator back
+into `location` after inserting the closing delimiter, keeping the iterator
+valid for the rest of the emission and eliminating the warning.
+

--- a/src/editor.c
+++ b/src/editor.c
@@ -380,6 +380,8 @@ editor_on_insert_text(GtkTextBuffer *buffer, GtkTextIter *location, gchar *text,
   gtk_text_buffer_insert(buffer, &iter, closing_str, closing_len);
   self->auto_inserting = FALSE;
 
+  gtk_text_iter_assign(location, &iter);
+
   GtkTextMark *insert_mark = gtk_text_buffer_get_insert(buffer);
   GtkTextIter cursor_iter;
   gtk_text_buffer_get_iter_at_mark(buffer, &cursor_iter, insert_mark);


### PR DESCRIPTION
## Summary
- keep the insert-text iterator valid when auto-inserting matching delimiters
- document the iterator invalidation bug in BUGS.md

## Testing
- make -C src
- make -C tests run (fails because xvfb-run is unavailable)
- ./repl_session_test
- ./lisp_parser_test
- ./project_test
- ./project_repl_test
- ./asdf_test
- ./analyser_test
- ./package_test
- ./status_service_test
- ./editor_selection_manager_test
- ./editor_test

------
https://chatgpt.com/codex/tasks/task_e_68f375ede1508328a79f417105e3c0d2