### PR TITLE
Guard DocumentSync buffer suppression state

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ SOURCES += \
   app.c \
   asdf.c \
   document.c \
+  document_sync.c \
   editor.c \
   editor_container.c \
   editor_manager.c \

--- a/src/document_sync.c
+++ b/src/document_sync.c
@@ -70,12 +70,11 @@ document_sync_update_buffer(DocumentSync *self)
   g_return_if_fail(self->document != NULL);
   g_return_if_fail(self->buffer != NULL);
   g_return_if_fail(glide_is_ui_thread());
+  g_return_if_fail(!self->suppress_buffer_changed);
 
   const GString *existing = document_get_content(self->document);
   const gchar *text = (existing && existing->str) ? existing->str : "";
   gboolean is_source = GTK_SOURCE_IS_BUFFER(self->buffer);
-
-  g_return_if_fail(!self->suppress_buffer_changed);
   self->suppress_buffer_changed = TRUE;
   if (is_source)
     gtk_source_buffer_begin_not_undoable_action(GTK_SOURCE_BUFFER(self->buffer));

--- a/src/document_sync.c
+++ b/src/document_sync.c
@@ -1,0 +1,114 @@
+#include "document_sync.h"
+
+#include <gtksourceview/gtksource.h>
+
+#include "util.h"
+
+struct _DocumentSync {
+  Document *document;
+  GtkTextBuffer *buffer;
+  gulong buffer_changed_handler_id;
+  gboolean suppress_buffer_changed;
+};
+
+static void document_sync_on_buffer_changed(GtkTextBuffer *buffer, gpointer user_data);
+
+DocumentSync *
+document_sync_new(Document *document, GtkTextBuffer *buffer)
+{
+  g_return_val_if_fail(document != NULL, NULL);
+  g_return_val_if_fail(buffer != NULL, NULL);
+  g_return_val_if_fail(glide_is_ui_thread(), NULL);
+
+  DocumentSync *self = g_new0(DocumentSync, 1);
+  self->document = document;
+  self->buffer = GTK_TEXT_BUFFER(g_object_ref(buffer));
+  self->buffer_changed_handler_id = g_signal_connect(self->buffer,
+      "changed",
+      G_CALLBACK(document_sync_on_buffer_changed),
+      self);
+  return self;
+}
+
+void
+document_sync_free(DocumentSync *self)
+{
+  if (!self)
+    return;
+  g_return_if_fail(glide_is_ui_thread());
+
+  if (self->buffer && self->buffer_changed_handler_id)
+    g_signal_handler_disconnect(self->buffer, self->buffer_changed_handler_id);
+  self->buffer_changed_handler_id = 0;
+  g_clear_object(&self->buffer);
+  self->document = NULL;
+  g_free(self);
+}
+
+void
+document_sync_update_document(DocumentSync *self)
+{
+  g_return_if_fail(self != NULL);
+  g_return_if_fail(self->document != NULL);
+  g_return_if_fail(self->buffer != NULL);
+  g_return_if_fail(glide_is_ui_thread());
+
+  GtkTextIter start;
+  GtkTextIter end;
+  gtk_text_buffer_get_start_iter(self->buffer, &start);
+  gtk_text_buffer_get_end_iter(self->buffer, &end);
+  gchar *text = gtk_text_buffer_get_text(self->buffer, &start, &end, FALSE);
+  GString *content = g_string_new(text ? text : "");
+  g_free(text);
+  document_set_content(self->document, content);
+}
+
+void
+document_sync_update_buffer(DocumentSync *self)
+{
+  g_return_if_fail(self != NULL);
+  g_return_if_fail(self->document != NULL);
+  g_return_if_fail(self->buffer != NULL);
+  g_return_if_fail(glide_is_ui_thread());
+
+  const GString *existing = document_get_content(self->document);
+  const gchar *text = (existing && existing->str) ? existing->str : "";
+  gboolean is_source = GTK_SOURCE_IS_BUFFER(self->buffer);
+
+  g_return_if_fail(!self->suppress_buffer_changed);
+  self->suppress_buffer_changed = TRUE;
+  if (is_source)
+    gtk_source_buffer_begin_not_undoable_action(GTK_SOURCE_BUFFER(self->buffer));
+  gtk_text_buffer_set_text(self->buffer, text, -1);
+  if (is_source)
+    gtk_source_buffer_end_not_undoable_action(GTK_SOURCE_BUFFER(self->buffer));
+  self->suppress_buffer_changed = FALSE;
+}
+
+Document *
+document_sync_get_document(DocumentSync *self)
+{
+  g_return_val_if_fail(self != NULL, NULL);
+  return self->document;
+}
+
+GtkTextBuffer *
+document_sync_get_buffer(DocumentSync *self)
+{
+  g_return_val_if_fail(self != NULL, NULL);
+  return self->buffer;
+}
+
+static void
+document_sync_on_buffer_changed(GtkTextBuffer *buffer, gpointer user_data)
+{
+  DocumentSync *self = user_data;
+  g_return_if_fail(self != NULL);
+  g_return_if_fail(self->buffer == buffer);
+  g_return_if_fail(glide_is_ui_thread());
+
+  if (self->suppress_buffer_changed)
+    return;
+
+  document_sync_update_document(self);
+}

--- a/src/document_sync.h
+++ b/src/document_sync.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include "document.h"
+
+typedef struct _DocumentSync DocumentSync;
+
+DocumentSync *document_sync_new(Document *document, GtkTextBuffer *buffer);
+void          document_sync_free(DocumentSync *self);
+void          document_sync_update_document(DocumentSync *self);
+void          document_sync_update_buffer(DocumentSync *self);
+Document     *document_sync_get_document(DocumentSync *self);
+GtkTextBuffer *document_sync_get_buffer(DocumentSync *self);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -52,7 +52,7 @@ status_service_test: status_service_test.c status_service.c $(COMMON)
 editor_selection_manager_test: editor_selection_manager_test.c editor_selection_manager.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_test: editor_test.c editor.c editor_selection_manager.c editor_tooltip_controller.c editor_tooltip_window.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+editor_test: editor_test.c editor.c document_sync.c editor_selection_manager.c editor_tooltip_controller.c editor_tooltip_window.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all


### PR DESCRIPTION
## Summary
- ensure DocumentSync refuses to update the buffer while already suppressing callbacks
- remove the redundant editor-side guard now that DocumentSync owns change handling

## Testing
- make -C src
- make -C tests run (fails: missing xvfb-run)


------
https://chatgpt.com/codex/tasks/task_e_68f393c0d1ec8328934c82e6844c5f78