### PR TITLE
Implement incremental document sync updates

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -31,6 +31,8 @@ void         document_free(Document *document);
 DocumentState document_get_state(Document *document);
 void         document_set_state(Document *document, DocumentState state);
 void         document_set_content(Document *document, GString *content);
+void         document_insert_text(Document *document, gsize offset, const gchar *text, gssize length);
+void         document_delete_text(Document *document, gsize start, gsize end);
 void         document_reparse(Document *document);
 const GString *document_get_content(Document *document);
 const GArray  *document_get_tokens(Document *document);

--- a/src/document_sync.c
+++ b/src/document_sync.c
@@ -7,11 +7,14 @@
 struct _DocumentSync {
   Document *document;
   GtkTextBuffer *buffer;
-  gulong buffer_changed_handler_id;
-  gboolean suppress_buffer_changed;
+  gulong insert_text_handler_id;
+  gulong delete_range_handler_id;
+  gboolean suppress_buffer_signals;
 };
 
-static void document_sync_on_buffer_changed(GtkTextBuffer *buffer, gpointer user_data);
+static void document_sync_on_buffer_insert_text(GtkTextBuffer *buffer, GtkTextIter *location, gchar *text, gint len, gpointer user_data);
+static void document_sync_on_buffer_delete_range(GtkTextBuffer *buffer, GtkTextIter *start, GtkTextIter *end, gpointer user_data);
+static gsize document_sync_buffer_offset_to_bytes(DocumentSync *self, gint char_offset);
 
 DocumentSync *
 document_sync_new(Document *document, GtkTextBuffer *buffer)
@@ -23,9 +26,13 @@ document_sync_new(Document *document, GtkTextBuffer *buffer)
   DocumentSync *self = g_new0(DocumentSync, 1);
   self->document = document;
   self->buffer = GTK_TEXT_BUFFER(g_object_ref(buffer));
-  self->buffer_changed_handler_id = g_signal_connect(self->buffer,
-      "changed",
-      G_CALLBACK(document_sync_on_buffer_changed),
+  self->insert_text_handler_id = g_signal_connect(self->buffer,
+      "insert-text",
+      G_CALLBACK(document_sync_on_buffer_insert_text),
+      self);
+  self->delete_range_handler_id = g_signal_connect(self->buffer,
+      "delete-range",
+      G_CALLBACK(document_sync_on_buffer_delete_range),
       self);
   return self;
 }
@@ -37,9 +44,12 @@ document_sync_free(DocumentSync *self)
     return;
   g_return_if_fail(glide_is_ui_thread());
 
-  if (self->buffer && self->buffer_changed_handler_id)
-    g_signal_handler_disconnect(self->buffer, self->buffer_changed_handler_id);
-  self->buffer_changed_handler_id = 0;
+  if (self->buffer && self->insert_text_handler_id)
+    g_signal_handler_disconnect(self->buffer, self->insert_text_handler_id);
+  if (self->buffer && self->delete_range_handler_id)
+    g_signal_handler_disconnect(self->buffer, self->delete_range_handler_id);
+  self->insert_text_handler_id = 0;
+  self->delete_range_handler_id = 0;
   g_clear_object(&self->buffer);
   self->document = NULL;
   g_free(self);
@@ -70,18 +80,18 @@ document_sync_update_buffer(DocumentSync *self)
   g_return_if_fail(self->document != NULL);
   g_return_if_fail(self->buffer != NULL);
   g_return_if_fail(glide_is_ui_thread());
-  g_return_if_fail(!self->suppress_buffer_changed);
+  g_return_if_fail(!self->suppress_buffer_signals);
 
   const GString *existing = document_get_content(self->document);
   const gchar *text = (existing && existing->str) ? existing->str : "";
   gboolean is_source = GTK_SOURCE_IS_BUFFER(self->buffer);
-  self->suppress_buffer_changed = TRUE;
+  self->suppress_buffer_signals = TRUE;
   if (is_source)
     gtk_source_buffer_begin_not_undoable_action(GTK_SOURCE_BUFFER(self->buffer));
   gtk_text_buffer_set_text(self->buffer, text, -1);
   if (is_source)
     gtk_source_buffer_end_not_undoable_action(GTK_SOURCE_BUFFER(self->buffer));
-  self->suppress_buffer_changed = FALSE;
+  self->suppress_buffer_signals = FALSE;
 }
 
 Document *
@@ -99,15 +109,52 @@ document_sync_get_buffer(DocumentSync *self)
 }
 
 static void
-document_sync_on_buffer_changed(GtkTextBuffer *buffer, gpointer user_data)
+document_sync_on_buffer_insert_text(GtkTextBuffer *buffer, GtkTextIter *location, gchar *text, gint len, gpointer user_data)
 {
   DocumentSync *self = user_data;
   g_return_if_fail(self != NULL);
   g_return_if_fail(self->buffer == buffer);
   g_return_if_fail(glide_is_ui_thread());
 
-  if (self->suppress_buffer_changed)
+  if (self->suppress_buffer_signals)
     return;
 
-  document_sync_update_document(self);
+  g_return_if_fail(self->document != NULL);
+  g_return_if_fail(text != NULL);
+
+  gsize byte_offset = document_sync_buffer_offset_to_bytes(self, gtk_text_iter_get_offset(location));
+  document_insert_text(self->document, byte_offset, text, len);
+}
+
+static void
+document_sync_on_buffer_delete_range(GtkTextBuffer *buffer, GtkTextIter *start, GtkTextIter *end, gpointer user_data)
+{
+  DocumentSync *self = user_data;
+  g_return_if_fail(self != NULL);
+  g_return_if_fail(self->buffer == buffer);
+  g_return_if_fail(glide_is_ui_thread());
+
+  if (self->suppress_buffer_signals)
+    return;
+
+  g_return_if_fail(self->document != NULL);
+  gint start_char_offset = gtk_text_iter_get_offset(start);
+  gint end_char_offset = gtk_text_iter_get_offset(end);
+  gsize start_byte_offset = document_sync_buffer_offset_to_bytes(self, start_char_offset);
+  gsize end_byte_offset = document_sync_buffer_offset_to_bytes(self, end_char_offset);
+  document_delete_text(self->document, start_byte_offset, end_byte_offset);
+}
+
+static gsize
+document_sync_buffer_offset_to_bytes(DocumentSync *self, gint char_offset)
+{
+  g_return_val_if_fail(self != NULL, 0);
+  const GString *content = document_get_content(self->document);
+  const gchar *text = (content && content->str) ? content->str : "";
+  g_return_val_if_fail(char_offset >= 0, 0);
+  const gchar *ptr = g_utf8_offset_to_pointer(text, char_offset);
+  gsize byte_offset = (gsize)(ptr - text);
+  gsize current_length = content ? content->len : 0;
+  g_return_val_if_fail(byte_offset <= current_length, byte_offset);
+  return byte_offset;
 }


### PR DESCRIPTION
## Summary
- add document APIs to insert and delete text without replacing the whole buffer
- convert DocumentSync to mirror GtkTextBuffer insert/delete signals and update the document incrementally
- guard programmatic buffer updates while converting character offsets to byte offsets for the document
- enforce document text edits require explicit byte lengths and a pre-initialized buffer so incremental updates assert on misuse

## Testing
- make
- make run *(fails: `xvfb-run` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3aa57033c832893e1f896b59abaa7