### PR TITLE
Fix skipping logic for final auto-closing parenthesis

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -533,3 +533,14 @@ position was no longer valid. The handler now copies the updated iterator back
 into `location` after inserting the closing delimiter, keeping the iterator
 valid for the rest of the emission and eliminating the warning.
 
+## Skipping final closing parenthesis inserted another one
+
+Auto-closing parentheses stopped skipping the last existing `)` in a run. The
+handler advanced a copy of the cursor iterator with
+`gtk_text_iter_forward_char()` and aborted when the function returned `FALSE`.
+GTK reports `FALSE` when the iterator lands on the buffer end, which happens
+after moving past the final closing parenthesis, so the handler returned early
+and let GTK insert another `)`. The fix ignores the boolean return value and
+instead checks whether the iterator actually advanced, allowing skips even
+when the cursor ends up at the buffer end.
+

--- a/src/editor.c
+++ b/src/editor.c
@@ -386,7 +386,8 @@ editor_on_insert_text_before(GtkTextBuffer *buffer, GtkTextIter *location, gchar
     return;
 
   GtkTextIter skip_iter = *location;
-  if (!gtk_text_iter_forward_char(&skip_iter))
+  gtk_text_iter_forward_char(&skip_iter);
+  if (gtk_text_iter_equal(&skip_iter, location))
     return;
 
   gtk_text_buffer_place_cursor(buffer, &skip_iter);


### PR DESCRIPTION
## Summary
- ensure the closing-parenthesis skip handler treats reaching the buffer end as a successful advance
- document the regression and fix in BUGS.md

## Testing
- make -C src
- make -C tests run *(fails: `xvfb-run: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c6af876c8328b4550a1c380d5003