### PR TITLE
Simplify marker offset retrieval

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,6 +21,7 @@ SOURCES += \
   editor_tooltip_controller.c \
   editor_tooltip_window.c \
   evaluate.c \
+  marker_manager.c \
   file_add.c \
   file_delete.c \
   file_new.c \

--- a/src/document.h
+++ b/src/document.h
@@ -3,6 +3,7 @@
 #include <glib.h>
 #include "lisp_lexer.h"
 #include "lisp_parser.h"
+#include "marker_manager.h"
 
 typedef struct _Project Project;
 
@@ -44,3 +45,6 @@ const gchar *document_get_relative_path(Document *document);
 void         document_clear_errors(Document *document);
 void         document_add_error(Document *document, DocumentError error);
 const GArray *document_get_errors(Document *document);
+Marker      *document_add_marker(Document *document, gsize offset);
+void         document_remove_marker(Document *document, Marker *marker);
+gboolean     document_is_marker_valid(Document *document, Marker *marker);

--- a/src/marker_manager.h
+++ b/src/marker_manager.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <glib.h>
+
+typedef struct _Document Document;
+typedef struct _MarkerManager MarkerManager;
+typedef struct _Marker Marker;
+
+struct _Marker {
+  gssize relative_offset; /* relative to parent, or absolute when root */
+  gboolean valid;
+};
+
+MarkerManager *marker_manager_new(Document *document);
+void           marker_manager_free(MarkerManager *manager);
+Marker        *marker_manager_add_marker(MarkerManager *manager, gsize offset);
+void           marker_manager_remove_marker(MarkerManager *manager, Marker *marker);
+gsize          marker_get_offset(Marker *marker);
+gboolean       marker_manager_is_valid(MarkerManager *manager, Marker *marker);
+void           marker_manager_handle_insert(MarkerManager *manager, gsize offset, gsize length);
+void           marker_manager_handle_delete(MarkerManager *manager, gsize start, gsize end);
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ COMMON = verbosity.c
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0 gtksourceview-4`
 TESTS = preferences_test process_test repl_process_test repl_session_test lisp_parser_test \
   project_test project_repl_test asdf_test analyser_test package_test \
-  status_service_test editor_selection_manager_test editor_test
+  status_service_test editor_selection_manager_test editor_test marker_manager_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -31,16 +31,24 @@ repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c s
 lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+project_test: project_test.c project_index.c project.c project_repl.c asdf.c document.c marker_manager.c analyse.c \
+  analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c \
+  process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_repl_test: project_repl_test.c repl_test_helpers.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+project_repl_test: project_repl_test.c repl_test_helpers.c project_index.c project.c project_repl.c asdf.c document.c \
+  marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c \
+  repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c lisp_lexer.c lisp_parser.c node.c package.c project_index.c project.c project_repl.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+asdf_test: asdf_test.c asdf.c lisp_lexer.c lisp_parser.c node.c package.c project_index.c project.c project_repl.c document.c \
+  marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c repl_session.c repl_process.c process.c \
+  status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c project_index.c project.c project_repl.c asdf.c document.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c \
+  project_index.c project.c project_repl.c asdf.c document.c marker_manager.c repl_session.c repl_process.c process.c \
+  status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 package_test: package_test.c package.c node.c $(COMMON)
@@ -49,10 +57,17 @@ package_test: package_test.c package.c node.c $(COMMON)
 status_service_test: status_service_test.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_selection_manager_test: editor_selection_manager_test.c editor_selection_manager.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+editor_selection_manager_test: editor_selection_manager_test.c editor_selection_manager.c project_index.c project.c project_repl.c \
+  asdf.c document.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c \
+  lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_test: editor_test.c editor.c document_sync.c editor_selection_manager.c editor_tooltip_controller.c editor_tooltip_window.c project_index.c project.c project_repl.c asdf.c document.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+editor_test: editor_test.c editor.c document_sync.c editor_selection_manager.c editor_tooltip_controller.c editor_tooltip_window.c \
+  project_index.c project.c project_repl.c asdf.c document.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c \
+  function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+:$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
+marker_manager_test: marker_manager_test.c marker_manager.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all

--- a/tests/marker_manager_test.c
+++ b/tests/marker_manager_test.c
@@ -1,0 +1,76 @@
+#include "marker_manager.h"
+#include <glib.h>
+
+static void test_add_and_offsets(void) {
+  MarkerManager *manager = marker_manager_new(NULL);
+  Marker *first = marker_manager_add_marker(manager, 10);
+  Marker *second = marker_manager_add_marker(manager, 20);
+  Marker *third = marker_manager_add_marker(manager, 5);
+
+  g_assert_cmpuint(marker_get_offset(first), ==, 10);
+  g_assert_cmpuint(marker_get_offset(second), ==, 20);
+  g_assert_cmpuint(marker_get_offset(third), ==, 5);
+
+  marker_manager_free(manager);
+}
+
+static void test_insert_shifts_following_markers(void) {
+  MarkerManager *manager = marker_manager_new(NULL);
+  Marker *before = marker_manager_add_marker(manager, 5);
+  Marker *pivot = marker_manager_add_marker(manager, 15);
+  Marker *after = marker_manager_add_marker(manager, 25);
+
+  marker_manager_handle_insert(manager, 15, 4);
+
+  g_assert_cmpuint(marker_get_offset(before), ==, 5);
+  g_assert_cmpuint(marker_get_offset(pivot), ==, 19);
+  g_assert_cmpuint(marker_get_offset(after), ==, 29);
+
+  marker_manager_free(manager);
+}
+
+static void test_delete_invalidates_and_shifts(void) {
+  MarkerManager *manager = marker_manager_new(NULL);
+  Marker *before = marker_manager_add_marker(manager, 5);
+  Marker *inside_one = marker_manager_add_marker(manager, 12);
+  Marker *inside_two = marker_manager_add_marker(manager, 18);
+  Marker *after = marker_manager_add_marker(manager, 30);
+
+  marker_manager_handle_delete(manager, 10, 20);
+
+  g_assert_true(marker_manager_is_valid(manager, before));
+  g_assert_cmpuint(marker_get_offset(before), ==, 5);
+  g_assert_false(marker_manager_is_valid(manager, inside_one));
+  g_assert_false(marker_manager_is_valid(manager, inside_two));
+  g_assert_true(marker_manager_is_valid(manager, after));
+  g_assert_cmpuint(marker_get_offset(after), ==, 20);
+
+  marker_manager_free(manager);
+}
+
+static void test_remove_marker_keeps_tree_balanced(void) {
+  MarkerManager *manager = marker_manager_new(NULL);
+  Marker *root = marker_manager_add_marker(manager, 20);
+  Marker *left = marker_manager_add_marker(manager, 10);
+  Marker *right = marker_manager_add_marker(manager, 30);
+  Marker *right_left = marker_manager_add_marker(manager, 25);
+  Marker *right_right = marker_manager_add_marker(manager, 40);
+
+  marker_manager_remove_marker(manager, root);
+
+  g_assert_cmpuint(marker_get_offset(left), ==, 10);
+  g_assert_cmpuint(marker_get_offset(right), ==, 30);
+  g_assert_cmpuint(marker_get_offset(right_left), ==, 25);
+  g_assert_cmpuint(marker_get_offset(right_right), ==, 40);
+
+  marker_manager_free(manager);
+}
+
+int main(int argc, char *argv[]) {
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/marker_manager/add_and_offsets", test_add_and_offsets);
+  g_test_add_func("/marker_manager/insert_shifts", test_insert_shifts_following_markers);
+  g_test_add_func("/marker_manager/delete_invalidates", test_delete_invalidates_and_shifts);
+  g_test_add_func("/marker_manager/remove_marker", test_remove_marker_keeps_tree_balanced);
+  return g_test_run();
+}


### PR DESCRIPTION
## Summary
- replace manager/document-based marker offset helpers with a single marker_get_offset API
- update marker manager tests to exercise the new accessor

## Testing
- make -C src
- make run -C tests (fails: `xvfb-run` missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ac8bfce08328be2a3c1640f20d41)