### PR TITLE
Add refcounted markers and reuse existing nodes

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -298,14 +298,14 @@ const GArray *document_get_errors(Document *document) {
   return document->errors;
 }
 
-Marker *document_add_marker(Document *document, gsize offset) {
+Marker *document_get_marker(Document *document, gsize offset) {
   g_return_val_if_fail(document != NULL, NULL);
-  return marker_manager_add_marker(document->marker_manager, offset);
+  return marker_manager_get_marker(document->marker_manager, offset);
 }
 
-void document_remove_marker(Document *document, Marker *marker) {
+void document_unref_marker(Document *document, Marker *marker) {
   g_return_if_fail(document != NULL);
-  marker_manager_remove_marker(document->marker_manager, marker);
+  marker_manager_unref_marker(document->marker_manager, marker);
 }
 
 gboolean document_is_marker_valid(Document *document, Marker *marker) {

--- a/src/document.h
+++ b/src/document.h
@@ -45,6 +45,6 @@ const gchar *document_get_relative_path(Document *document);
 void         document_clear_errors(Document *document);
 void         document_add_error(Document *document, DocumentError error);
 const GArray *document_get_errors(Document *document);
-Marker      *document_add_marker(Document *document, gsize offset);
-void         document_remove_marker(Document *document, Marker *marker);
+Marker      *document_get_marker(Document *document, gsize offset);
+void         document_unref_marker(Document *document, Marker *marker);
 gboolean     document_is_marker_valid(Document *document, Marker *marker);

--- a/src/marker_manager.h
+++ b/src/marker_manager.h
@@ -9,12 +9,13 @@ typedef struct _Marker Marker;
 struct _Marker {
   gssize relative_offset; /* relative to parent, or absolute when root */
   gboolean valid;
+  guint ref_count;
 };
 
 MarkerManager *marker_manager_new(Document *document);
 void           marker_manager_free(MarkerManager *manager);
-Marker        *marker_manager_add_marker(MarkerManager *manager, gsize offset);
-void           marker_manager_remove_marker(MarkerManager *manager, Marker *marker);
+Marker        *marker_manager_get_marker(MarkerManager *manager, gsize offset);
+void           marker_manager_unref_marker(MarkerManager *manager, Marker *marker);
 gsize          marker_get_offset(Marker *marker);
 gboolean       marker_manager_is_valid(MarkerManager *manager, Marker *marker);
 void           marker_manager_handle_insert(MarkerManager *manager, gsize offset, gsize length);

--- a/tests/marker_manager_test.c
+++ b/tests/marker_manager_test.c
@@ -3,9 +3,9 @@
 
 static void test_add_and_offsets(void) {
   MarkerManager *manager = marker_manager_new(NULL);
-  Marker *first = marker_manager_add_marker(manager, 10);
-  Marker *second = marker_manager_add_marker(manager, 20);
-  Marker *third = marker_manager_add_marker(manager, 5);
+  Marker *first = marker_manager_get_marker(manager, 10);
+  Marker *second = marker_manager_get_marker(manager, 20);
+  Marker *third = marker_manager_get_marker(manager, 5);
 
   g_assert_cmpuint(marker_get_offset(first), ==, 10);
   g_assert_cmpuint(marker_get_offset(second), ==, 20);
@@ -16,9 +16,9 @@ static void test_add_and_offsets(void) {
 
 static void test_insert_shifts_following_markers(void) {
   MarkerManager *manager = marker_manager_new(NULL);
-  Marker *before = marker_manager_add_marker(manager, 5);
-  Marker *pivot = marker_manager_add_marker(manager, 15);
-  Marker *after = marker_manager_add_marker(manager, 25);
+  Marker *before = marker_manager_get_marker(manager, 5);
+  Marker *pivot = marker_manager_get_marker(manager, 15);
+  Marker *after = marker_manager_get_marker(manager, 25);
 
   marker_manager_handle_insert(manager, 15, 4);
 
@@ -31,10 +31,10 @@ static void test_insert_shifts_following_markers(void) {
 
 static void test_delete_invalidates_and_shifts(void) {
   MarkerManager *manager = marker_manager_new(NULL);
-  Marker *before = marker_manager_add_marker(manager, 5);
-  Marker *inside_one = marker_manager_add_marker(manager, 12);
-  Marker *inside_two = marker_manager_add_marker(manager, 18);
-  Marker *after = marker_manager_add_marker(manager, 30);
+  Marker *before = marker_manager_get_marker(manager, 5);
+  Marker *inside_one = marker_manager_get_marker(manager, 12);
+  Marker *inside_two = marker_manager_get_marker(manager, 18);
+  Marker *after = marker_manager_get_marker(manager, 30);
 
   marker_manager_handle_delete(manager, 10, 20);
 
@@ -48,15 +48,15 @@ static void test_delete_invalidates_and_shifts(void) {
   marker_manager_free(manager);
 }
 
-static void test_remove_marker_keeps_tree_balanced(void) {
+static void test_unref_marker_keeps_tree_balanced(void) {
   MarkerManager *manager = marker_manager_new(NULL);
-  Marker *root = marker_manager_add_marker(manager, 20);
-  Marker *left = marker_manager_add_marker(manager, 10);
-  Marker *right = marker_manager_add_marker(manager, 30);
-  Marker *right_left = marker_manager_add_marker(manager, 25);
-  Marker *right_right = marker_manager_add_marker(manager, 40);
+  Marker *root = marker_manager_get_marker(manager, 20);
+  Marker *left = marker_manager_get_marker(manager, 10);
+  Marker *right = marker_manager_get_marker(manager, 30);
+  Marker *right_left = marker_manager_get_marker(manager, 25);
+  Marker *right_right = marker_manager_get_marker(manager, 40);
 
-  marker_manager_remove_marker(manager, root);
+  marker_manager_unref_marker(manager, root);
 
   g_assert_cmpuint(marker_get_offset(left), ==, 10);
   g_assert_cmpuint(marker_get_offset(right), ==, 30);
@@ -66,11 +66,25 @@ static void test_remove_marker_keeps_tree_balanced(void) {
   marker_manager_free(manager);
 }
 
+static void test_get_marker_reuses_existing(void) {
+  MarkerManager *manager = marker_manager_new(NULL);
+  Marker *first = marker_manager_get_marker(manager, 10);
+  Marker *second = marker_manager_get_marker(manager, 10);
+
+  g_assert_true(first == second);
+  marker_manager_unref_marker(manager, first);
+  g_assert_cmpuint(marker_get_offset(second), ==, 10);
+  marker_manager_unref_marker(manager, second);
+
+  marker_manager_free(manager);
+}
+
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/marker_manager/add_and_offsets", test_add_and_offsets);
   g_test_add_func("/marker_manager/insert_shifts", test_insert_shifts_following_markers);
   g_test_add_func("/marker_manager/delete_invalidates", test_delete_invalidates_and_shifts);
-  g_test_add_func("/marker_manager/remove_marker", test_remove_marker_keeps_tree_balanced);
+  g_test_add_func("/marker_manager/unref_marker", test_unref_marker_keeps_tree_balanced);
+  g_test_add_func("/marker_manager/reuse_existing", test_get_marker_reuses_existing);
   return g_test_run();
 }


### PR DESCRIPTION
## Summary
- rename marker APIs to get/unref and add reference counting to shared markers
- reuse existing markers when requesting the same offset instead of creating duplicates
- update marker manager tests to cover marker reuse and reference-aware cleanup

## Testing
- make
- make run *(fails: missing `xvfb-run` in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c364b8108328a6396d4bf12c2221)