### PR TITLE
Decouple marker validity checks from document API

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -307,8 +307,3 @@ void document_unref_marker(Document *document, Marker *marker) {
   g_return_if_fail(document != NULL);
   marker_manager_unref_marker(document->marker_manager, marker);
 }
-
-gboolean document_is_marker_valid(Document *document, Marker *marker) {
-  g_return_val_if_fail(document != NULL, FALSE);
-  return marker_manager_is_valid(document->marker_manager, marker);
-}

--- a/src/document.h
+++ b/src/document.h
@@ -47,4 +47,3 @@ void         document_add_error(Document *document, DocumentError error);
 const GArray *document_get_errors(Document *document);
 Marker      *document_get_marker(Document *document, gsize offset);
 void         document_unref_marker(Document *document, Marker *marker);
-gboolean     document_is_marker_valid(Document *document, Marker *marker);

--- a/src/marker_manager.c
+++ b/src/marker_manager.c
@@ -115,8 +115,7 @@ gsize marker_get_offset(Marker *marker) {
   return marker_node_absolute_offset(node);
 }
 
-gboolean marker_manager_is_valid(MarkerManager *manager, Marker *marker) {
-  g_return_val_if_fail(manager != NULL, FALSE);
+gboolean marker_is_valid(Marker *marker) {
   g_return_val_if_fail(marker != NULL, FALSE);
   return marker->valid;
 }

--- a/src/marker_manager.h
+++ b/src/marker_manager.h
@@ -17,7 +17,7 @@ void           marker_manager_free(MarkerManager *manager);
 Marker        *marker_manager_get_marker(MarkerManager *manager, gsize offset);
 void           marker_manager_unref_marker(MarkerManager *manager, Marker *marker);
 gsize          marker_get_offset(Marker *marker);
-gboolean       marker_manager_is_valid(MarkerManager *manager, Marker *marker);
+gboolean       marker_is_valid(Marker *marker);
 void           marker_manager_handle_insert(MarkerManager *manager, gsize offset, gsize length);
 void           marker_manager_handle_delete(MarkerManager *manager, gsize start, gsize end);
 

--- a/tests/marker_manager_test.c
+++ b/tests/marker_manager_test.c
@@ -38,11 +38,11 @@ static void test_delete_invalidates_and_shifts(void) {
 
   marker_manager_handle_delete(manager, 10, 20);
 
-  g_assert_true(marker_manager_is_valid(manager, before));
+  g_assert_true(marker_is_valid(before));
   g_assert_cmpuint(marker_get_offset(before), ==, 5);
-  g_assert_false(marker_manager_is_valid(manager, inside_one));
-  g_assert_false(marker_manager_is_valid(manager, inside_two));
-  g_assert_true(marker_manager_is_valid(manager, after));
+  g_assert_false(marker_is_valid(inside_one));
+  g_assert_false(marker_is_valid(inside_two));
+  g_assert_true(marker_is_valid(after));
   g_assert_cmpuint(marker_get_offset(after), ==, 20);
 
   marker_manager_free(manager);


### PR DESCRIPTION
## Summary
- expose marker validity through a marker-level helper instead of the document API
- group marker-only helpers together in the marker manager header
- update marker manager tests to use the marker-level validity helper

## Testing
- make
- make run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d1a156788328ae25eb33e056b3c0)