### PR TITLE
Fix editor test floating reference crash

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -544,3 +544,12 @@ and let GTK insert another `)`. The fix ignores the boolean return value and
 instead checks whether the iterator actually advanced, allowing skips even
 when the cursor ends up at the buffer end.
 
+## Editor test crashed on floating widget reference
+
+Running the editor unit tests under Xvfb aborted with the warning "A floating
+object was finalized." The tests create an `Editor` widget without adding it
+to a container, so the widget kept its initial floating reference and
+`g_object_unref` finalized it while still floating. The tests now sink the
+floating reference immediately after construction, allowing the final unref to
+dispose the widget cleanly during teardown.
+

--- a/tests/editor_test.c
+++ b/tests/editor_test.c
@@ -13,6 +13,7 @@ static void test_undo_pristine(void)
   Document *document = project_add_document(project, g_string_new("(a b)"), NULL, DOCUMENT_LIVE);
 
   GtkWidget *widget = editor_new_for_document(project, document);
+  g_object_ref_sink(widget);
   Editor *editor = GLIDE_EDITOR(widget);
   GtkSourceBuffer *buffer = editor_get_buffer(editor);
 
@@ -33,6 +34,7 @@ static void test_toplevel_range_eof_without_newline(void)
       DOCUMENT_LIVE);
 
   GtkWidget *widget = editor_new_for_document(project, document);
+  g_object_ref_sink(widget);
   Editor *editor = GLIDE_EDITOR(widget);
 
   gsize start;


### PR DESCRIPTION
## Summary
- adopt the editor widget’s floating reference in the unit tests to prevent GTK from aborting
- record the crash scenario and resolution in BUGS.md

## Testing
- make run
- xvfb-run -a ./editor_test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dfef37b48328baaa887a1e19907f)