### PR TITLE
Simplify lexer document handling

### DIFF
--- a/src/asdf.c
+++ b/src/asdf.c
@@ -2,6 +2,7 @@
 #include "lisp_lexer.h"
 #include "lisp_parser.h"
 #include "node.h"
+#include "document.h"
 #include <glib/gstdio.h>
 
 struct _Asdf {
@@ -150,8 +151,9 @@ uint asdf_get_dependency_count(Asdf *self) {
 
 static void parse_file_contents(Asdf *self, const gchar *contents) {
   GString *text = g_string_new(contents ? contents : "");
-  GArray *tokens = lisp_lexer_lex(text);
-  Node *ast = lisp_parser_parse(tokens, NULL);
+  Document *document = document_new(NULL, DOCUMENT_DORMANT);
+  document_set_content(document, g_string_new(text->str));
+  Node *ast = (Node*)document_get_ast(document);
   if (!ast)
     goto cleanup;
 
@@ -210,10 +212,8 @@ static void parse_file_contents(Asdf *self, const gchar *contents) {
   }
 
 cleanup:
-  if (ast)
-    node_free_deep(ast);
-  if (tokens)
-    g_array_free(tokens, TRUE);
+  if (document)
+    document_free(document);
   g_string_free(text, TRUE);
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -147,9 +147,8 @@ void document_reparse(Document *document) {
   document_clear_ast(document);
   document_clear_tokens(document);
 
-  const GString *content = document->content;
-  if (content) {
-    GArray *tokens = lisp_lexer_lex(content);
+  if (document->content) {
+    GArray *tokens = lisp_lexer_lex(document);
     document_set_tokens(document, tokens);
 
     Node *ast = lisp_parser_parse(tokens, document);
@@ -270,6 +269,14 @@ void document_add_error(Document *document, DocumentError error) {
 static void document_clear_tokens(Document *document) {
   g_return_if_fail(document != NULL);
   if (!document->tokens) return;
+  for (guint i = 0; i < document->tokens->len; i++) {
+    LispToken *token = &g_array_index(document->tokens, LispToken, i);
+    if (token->start_marker)
+      document_unref_marker(document, token->start_marker);
+    if (token->end_marker)
+      document_unref_marker(document, token->end_marker);
+    g_free(token->text);
+  }
   g_array_free(document->tokens, TRUE);
   document->tokens = NULL;
 }

--- a/src/lisp_lexer.h
+++ b/src/lisp_lexer.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <glib.h>
+#include "marker_manager.h"
 
 G_BEGIN_DECLS
+
+typedef struct _Document Document;
 
 typedef enum {
   LISP_TOKEN_TYPE_NUMBER,
@@ -23,10 +26,10 @@ typedef enum {
 typedef struct {
   LispTokenType type;
   gchar *text;
-  gsize start_offset;
-  gsize end_offset;
+  Marker *start_marker;
+  Marker *end_marker;
 } LispToken;
 
-GArray    *lisp_lexer_lex(const GString *text);
+GArray    *lisp_lexer_lex(Document *document);
 
 G_END_DECLS

--- a/src/lisp_parser_view.c
+++ b/src/lisp_parser_view.c
@@ -91,8 +91,8 @@ add_ast_node(LispParserView *self, const Node *node, GtkTreeIter *parent) {
   const GString *content = document_get_content(self->document);
 
   if (node->end_token && node->end_token != node->start_token) {
-    gsize start = node->start_token->start_offset;
-    gsize end = node->end_token->end_offset;
+    gsize start = node_get_start_offset(node);
+    gsize end = node_get_end_offset(node);
     if (!content || start >= end || end > content->len) {
       text = g_strdup("");
     } else {

--- a/src/node.c
+++ b/src/node.c
@@ -66,8 +66,8 @@ gboolean node_is_toplevel(const Node *node) {
 
 gsize node_get_start_offset(const Node *node) {
   g_return_val_if_fail(node, 0);
-  if (node->start_token)
-    return node->start_token->start_offset;
+  if (node->start_token && node->start_token->start_marker)
+    return marker_get_offset(node->start_token->start_marker);
   if (!node->children || node->children->len == 0)
     return 0;
   Node *child = g_array_index(node->children, Node*, 0);
@@ -76,14 +76,14 @@ gsize node_get_start_offset(const Node *node) {
 
 gsize node_get_end_offset(const Node *node) {
   g_return_val_if_fail(node, 0);
-  if (node->end_token)
-    return node->end_token->end_offset;
+  if (node->end_token && node->end_token->end_marker)
+    return marker_get_offset(node->end_token->end_marker);
   if (node->children && node->children->len > 0) {
     Node *child = g_array_index(node->children, Node*, node->children->len - 1);
     return node_get_end_offset(child);
   }
-  if (node->start_token)
-    return node->start_token->end_offset;
+  if (node->start_token && node->start_token->end_marker)
+    return marker_get_offset(node->start_token->end_marker);
   // A root node can be empty when the document is empty.
   return 0;
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,10 +25,10 @@ process_test: process_test.c process.c $(COMMON)
 repl_process_test: repl_process_test.c process.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c $(COMMON)
+repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c document.c marker_manager.c project_stubs.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c $(COMMON)
+lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c document.c marker_manager.c project_stubs.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 project_test: project_test.c project_index.c project.c project_repl.c asdf.c document.c marker_manager.c analyse.c \
@@ -51,7 +51,7 @@ analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c fu
   status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-package_test: package_test.c package.c node.c $(COMMON)
+package_test: package_test.c package.c node.c ../src/marker_manager.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 status_service_test: status_service_test.c status_service.c $(COMMON)

--- a/tests/project_stubs.c
+++ b/tests/project_stubs.c
@@ -1,0 +1,7 @@
+#include "project.h"
+
+void project_document_changed(Project * /*project*/, Document * /*document*/) {}
+
+const gchar *project_get_path(Project * /*project*/) {
+  return NULL;
+}


### PR DESCRIPTION
## Summary
- update the Lisp lexer API to take a Document directly and remove per-token document references
- ensure document cleanup releases token markers and text before freeing token arrays
- streamline document reparsing by invoking the lexer without redundant content plumbing

## Testing
- make -C src
- make -C tests run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921eb4fbc4083288b18f1f993ac71fd)