### PR TITLE
Introduce token manager for document tokens

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,7 @@ SOURCES += \
   editor_tooltip_window.c \
   evaluate.c \
   marker_manager.c \
+  token_manager.c \
   file_add.c \
   file_delete.c \
   file_new.c \

--- a/src/token_manager.c
+++ b/src/token_manager.c
@@ -1,0 +1,49 @@
+#include "token_manager.h"
+
+struct _TokenManager {
+  MarkerManager *marker_manager;
+  GArray *tokens; /* owned, LispToken */
+};
+
+TokenManager *token_manager_new(MarkerManager *marker_manager) {
+  g_return_val_if_fail(marker_manager != NULL, NULL);
+  TokenManager *manager = g_new0(TokenManager, 1);
+  manager->marker_manager = marker_manager;
+  manager->tokens = NULL;
+  return manager;
+}
+
+void token_manager_free(TokenManager *manager) {
+  if (!manager)
+    return;
+  token_manager_clear(manager);
+  g_free(manager);
+}
+
+void token_manager_clear(TokenManager *manager) {
+  g_return_if_fail(manager != NULL);
+  if (!manager->tokens)
+    return;
+  for (guint i = 0; i < manager->tokens->len; i++) {
+    LispToken *token = &g_array_index(manager->tokens, LispToken, i);
+    if (token->start_marker)
+      marker_manager_unref_marker(manager->marker_manager, token->start_marker);
+    if (token->end_marker)
+      marker_manager_unref_marker(manager->marker_manager, token->end_marker);
+    g_free(token->text);
+  }
+  g_array_free(manager->tokens, TRUE);
+  manager->tokens = NULL;
+}
+
+void token_manager_set_tokens(TokenManager *manager, GArray *tokens) {
+  g_return_if_fail(manager != NULL);
+  token_manager_clear(manager);
+  manager->tokens = tokens;
+}
+
+const GArray *token_manager_get_tokens(TokenManager *manager) {
+  g_return_val_if_fail(manager != NULL, NULL);
+  return manager->tokens;
+}
+

--- a/src/token_manager.h
+++ b/src/token_manager.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <glib.h>
+#include "lisp_lexer.h"
+#include "marker_manager.h"
+
+typedef struct _TokenManager TokenManager;
+
+TokenManager *token_manager_new(MarkerManager *marker_manager);
+void          token_manager_free(TokenManager *manager);
+void          token_manager_clear(TokenManager *manager);
+void          token_manager_set_tokens(TokenManager *manager, GArray *tokens);
+const GArray *token_manager_get_tokens(TokenManager *manager);
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,30 +25,32 @@ process_test: process_test.c process.c $(COMMON)
 repl_process_test: repl_process_test.c process.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c lisp_lexer.c lisp_parser.c node.c package.c document.c marker_manager.c project_stubs.c $(COMMON)
+repl_session_test: repl_session_test.c repl_session.c repl_process.c process.c status_service.c \
+  lisp_lexer.c lisp_parser.c node.c package.c document.c token_manager.c marker_manager.c project_stubs.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c document.c marker_manager.c project_stubs.c $(COMMON)
+lisp_parser_test: lisp_parser_test.c lisp_lexer.c lisp_parser.c node.c package.c document.c \
+  token_manager.c marker_manager.c project_stubs.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-project_test: project_test.c project_index.c project.c project_repl.c asdf.c document.c marker_manager.c analyse.c \
-  analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c \
-  process.c status_service.c $(COMMON)
+project_test: project_test.c project_index.c project.c project_repl.c asdf.c document.c token_manager.c marker_manager.c \
+  analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c \
+  repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 project_repl_test: project_repl_test.c repl_test_helpers.c project_index.c project.c project_repl.c asdf.c document.c \
-  marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c \
-  repl_session.c repl_process.c process.c status_service.c $(COMMON)
+  token_manager.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c \
+  lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-asdf_test: asdf_test.c asdf.c lisp_lexer.c lisp_parser.c node.c package.c project_index.c project.c project_repl.c document.c \
-  marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c repl_session.c repl_process.c process.c \
-  status_service.c $(COMMON)
+asdf_test: asdf_test.c asdf.c lisp_lexer.c lisp_parser.c node.c package.c project_index.c project.c project_repl.c \
+  document.c token_manager.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c repl_session.c \
+  repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c \
-  project_index.c project.c project_repl.c asdf.c document.c marker_manager.c repl_session.c repl_process.c process.c \
-  status_service.c $(COMMON)
+analyser_test: analyser_test.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c \
+  lisp_parser.c project_index.c project.c project_repl.c asdf.c document.c token_manager.c marker_manager.c repl_session.c \
+  repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 package_test: package_test.c package.c node.c ../src/marker_manager.c $(COMMON)
@@ -57,14 +59,14 @@ package_test: package_test.c package.c node.c ../src/marker_manager.c $(COMMON)
 status_service_test: status_service_test.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-editor_selection_manager_test: editor_selection_manager_test.c editor_selection_manager.c project_index.c project.c project_repl.c \
-  asdf.c document.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c node.c package.c lisp_lexer.c \
-  lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+editor_selection_manager_test: editor_selection_manager_test.c editor_selection_manager.c project_index.c project.c \
+  project_repl.c asdf.c document.c token_manager.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c function.c \
+  node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 editor_test: editor_test.c editor.c document_sync.c editor_selection_manager.c editor_tooltip_controller.c editor_tooltip_window.c \
-  project_index.c project.c project_repl.c asdf.c document.c marker_manager.c analyse.c analyse_defpackage.c analyse_defun.c \
-  function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
+  project_index.c project.c project_repl.c asdf.c document.c token_manager.c marker_manager.c analyse.c analyse_defpackage.c \
+  analyse_defun.c function.c node.c package.c lisp_lexer.c lisp_parser.c repl_session.c repl_process.c process.c status_service.c $(COMMON)
 :$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 marker_manager_test: marker_manager_test.c marker_manager.c $(COMMON)


### PR DESCRIPTION
## Summary
- add a TokenManager to own Lisp token arrays and handle marker cleanup
- update Document to delegate token lifecycle operations to the manager
- include the new module in build targets for the application and tests

## Testing
- make (from src)
- make run (from tests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f9cab6948328b535d34963c2f177)