### PR TITLE
Remove unused document reference from MarkerManager

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -38,7 +38,7 @@ Document *document_new(Project *project, DocumentState state) {
   document->errors = g_array_new(FALSE, FALSE, sizeof(DocumentError));
   document->content = g_string_new("");
   document->ast = NULL;
-  document->marker_manager = marker_manager_new(document);
+  document->marker_manager = marker_manager_new();
   document->token_manager = token_manager_new(document->marker_manager);
   return document;
 }

--- a/src/marker_manager.c
+++ b/src/marker_manager.c
@@ -1,7 +1,4 @@
 #include "marker_manager.h"
-#include "document.h"
-#include "util.h"
-#include <glib-object.h>
 
 typedef struct _MarkerNode MarkerNode;
 
@@ -14,7 +11,6 @@ struct _MarkerNode {
 };
 
 struct _MarkerManager {
-  Document *document;
   MarkerNode *root;
 };
 
@@ -36,9 +32,8 @@ static int         marker_node_height(MarkerNode *node);
 static void        marker_node_update_height(MarkerNode *node);
 static int         marker_node_balance(MarkerNode *node);
 
-MarkerManager *marker_manager_new(Document *document) {
+MarkerManager *marker_manager_new(void) {
   MarkerManager *manager = g_new0(MarkerManager, 1);
-  manager->document = document;
   manager->root = NULL;
   return manager;
 }

--- a/src/marker_manager.h
+++ b/src/marker_manager.h
@@ -2,7 +2,6 @@
 
 #include <glib.h>
 
-typedef struct _Document Document;
 typedef struct _MarkerManager MarkerManager;
 typedef struct _Marker Marker;
 
@@ -12,7 +11,7 @@ struct _Marker {
   guint ref_count;
 };
 
-MarkerManager *marker_manager_new(Document *document);
+MarkerManager *marker_manager_new(void);
 void           marker_manager_free(MarkerManager *manager);
 Marker        *marker_manager_get_marker(MarkerManager *manager, gsize offset);
 void           marker_manager_unref_marker(MarkerManager *manager, Marker *marker);

--- a/tests/marker_manager_test.c
+++ b/tests/marker_manager_test.c
@@ -2,7 +2,7 @@
 #include <glib.h>
 
 static void test_add_and_offsets(void) {
-  MarkerManager *manager = marker_manager_new(NULL);
+  MarkerManager *manager = marker_manager_new();
   Marker *first = marker_manager_get_marker(manager, 10);
   Marker *second = marker_manager_get_marker(manager, 20);
   Marker *third = marker_manager_get_marker(manager, 5);
@@ -15,7 +15,7 @@ static void test_add_and_offsets(void) {
 }
 
 static void test_insert_shifts_following_markers(void) {
-  MarkerManager *manager = marker_manager_new(NULL);
+  MarkerManager *manager = marker_manager_new();
   Marker *before = marker_manager_get_marker(manager, 5);
   Marker *pivot = marker_manager_get_marker(manager, 15);
   Marker *after = marker_manager_get_marker(manager, 25);
@@ -30,7 +30,7 @@ static void test_insert_shifts_following_markers(void) {
 }
 
 static void test_delete_invalidates_and_shifts(void) {
-  MarkerManager *manager = marker_manager_new(NULL);
+  MarkerManager *manager = marker_manager_new();
   Marker *before = marker_manager_get_marker(manager, 5);
   Marker *inside_one = marker_manager_get_marker(manager, 12);
   Marker *inside_two = marker_manager_get_marker(manager, 18);
@@ -49,7 +49,7 @@ static void test_delete_invalidates_and_shifts(void) {
 }
 
 static void test_unref_marker_keeps_tree_balanced(void) {
-  MarkerManager *manager = marker_manager_new(NULL);
+  MarkerManager *manager = marker_manager_new();
   Marker *root = marker_manager_get_marker(manager, 20);
   Marker *left = marker_manager_get_marker(manager, 10);
   Marker *right = marker_manager_get_marker(manager, 30);
@@ -67,7 +67,7 @@ static void test_unref_marker_keeps_tree_balanced(void) {
 }
 
 static void test_get_marker_reuses_existing(void) {
-  MarkerManager *manager = marker_manager_new(NULL);
+  MarkerManager *manager = marker_manager_new();
   Marker *first = marker_manager_get_marker(manager, 10);
   Marker *second = marker_manager_get_marker(manager, 10);
 


### PR DESCRIPTION
## Summary
- remove the unused Document field from MarkerManager and simplify its constructor
- update document initialization and marker manager tests to use the new signature

## Testing
- make -C src
- make -C tests run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922538b553c8328bbc0daf16b6a06eb)