### PR TITLE
Make Marker opaque and store data in MarkerNode

### DIFF
--- a/src/marker_manager.h
+++ b/src/marker_manager.h
@@ -6,12 +6,6 @@ typedef struct _Document Document;
 typedef struct _MarkerManager MarkerManager;
 typedef struct _Marker Marker;
 
-struct _Marker {
-  gssize relative_offset; /* relative to parent, or absolute when root */
-  gboolean valid;
-  guint ref_count;
-};
-
 MarkerManager *marker_manager_new(Document *document);
 void           marker_manager_free(MarkerManager *manager);
 Marker        *marker_manager_get_marker(MarkerManager *manager, gsize offset);


### PR DESCRIPTION
## Summary
- move marker state into MarkerNode while keeping Marker opaque
- update marker access and tree operations to use node-held metadata

## Testing
- make
- make run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225435dee08328aa3368b345e792f8)