### PR TITLE
Reuse AST nodes outside token changes

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -27,7 +27,8 @@ struct _Document {
 static void document_clear_ast(Document *document);
 static void document_set_ast(Document *document, Node *ast);
 static void document_reparse_range(Document *document, gsize start, gsize end);
-static void document_update_tokens(Document *document, gsize change_start, gsize change_end);
+static void document_update_tokens(Document *document, gsize change_start, gsize change_end,
+                                   gsize *token_change_start, gsize *token_change_end);
 
 Document *document_new(Project *project, DocumentState state) {
   if (project)
@@ -146,13 +147,14 @@ void document_reparse(Document *document) {
     g_return_if_fail(glide_is_ui_thread());
 
   document_clear_errors(document);
-  document_clear_ast(document);
   token_manager_clear(document->token_manager);
   const GString *text = document_get_content(document);
   if (text) {
-    document_update_tokens(document, 0, text->len);
+    gsize token_change_start = 0;
+    gsize token_change_end = text->len;
+    document_update_tokens(document, 0, text->len, &token_change_start, &token_change_end);
     GArray *tokens = token_manager_peek_tokens(document->token_manager);
-    Node *ast = lisp_parser_parse(tokens, document);
+    Node *ast = lisp_parser_parse(tokens, document, NULL, token_change_start, token_change_end);
     document_set_ast(document, ast);
   }
 
@@ -166,18 +168,26 @@ static void document_reparse_range(Document *document, gsize start, gsize end) {
     g_return_if_fail(glide_is_ui_thread());
 
   document_clear_errors(document);
-  document_clear_ast(document);
-  document_update_tokens(document, start, end);
+  Node *previous_ast = document->ast;
+  gsize token_change_start = start;
+  gsize token_change_end = end;
+  document_update_tokens(document, start, end, &token_change_start, &token_change_end);
 
   GArray *tokens = token_manager_peek_tokens(document->token_manager);
-  Node *ast = lisp_parser_parse(tokens, document);
+  Node *ast = lisp_parser_parse(tokens,
+                                document,
+                                (token_change_start == 0 && token_change_end ==
+                                 document->content->len) ? NULL : previous_ast,
+                                token_change_start,
+                                token_change_end);
   document_set_ast(document, ast);
 
   if (document->project)
     project_document_changed(document->project, document);
 }
 
-static void document_update_tokens(Document *document, gsize change_start, gsize change_end) {
+static void document_update_tokens(Document *document, gsize change_start, gsize change_end,
+                                   gsize *token_change_start, gsize *token_change_end) {
   g_return_if_fail(document != NULL);
 
   const GString *text = document_get_content(document);
@@ -189,7 +199,7 @@ static void document_update_tokens(Document *document, gsize change_start, gsize
   g_return_if_fail(change_start <= change_end);
 
   token_manager_update_tokens(document->token_manager, document, change_start, change_end,
-                              text_length);
+                              text_length, token_change_start, token_change_end);
 }
 
 const gchar *document_get_path(Document *document) {

--- a/src/lisp_parser.c
+++ b/src/lisp_parser.c
@@ -1,27 +1,157 @@
 #include <glib.h>
 #include "lisp_parser.h"
 
-static Node *parse_expression(Document *document, GArray *tokens, guint *position);
+typedef struct {
+  GHashTable *nodes_by_start_offset; /* gsize -> Node* */
+  GHashTable *tokens_present; /* LispToken* -> gpointer */
+  gsize change_start;
+  gsize change_end;
+} ReuseContext;
+
+static Node *parse_expression(Document *document, GArray *tokens, guint *position,
+                              ReuseContext *reuse_context);
 static Node *parse_symbol(Document *document, GArray *tokens, guint *position);
 
-Node *lisp_parser_parse(GArray *tokens, Document *document) {
+static void reuse_context_collect_node(Node *node, ReuseContext *reuse_context) {
+  if (!node || !reuse_context)
+    return;
+
+  if (node->start_token && node->end_token) {
+    if (!reuse_context->tokens_present ||
+        !g_hash_table_contains(reuse_context->tokens_present, node->start_token) ||
+        !g_hash_table_contains(reuse_context->tokens_present, node->end_token))
+      goto recurse_children;
+
+    gsize start_offset = node_get_start_offset(node);
+    gsize end_offset = node_get_end_offset(node);
+    gboolean outside_change = (end_offset <= reuse_context->change_start) ||
+                              (start_offset >= reuse_context->change_end);
+    if (outside_change) {
+      Node *existing = g_hash_table_lookup(reuse_context->nodes_by_start_offset,
+                                           GUINT_TO_POINTER(start_offset));
+      if (!existing || node_get_end_offset(existing) < end_offset)
+        g_hash_table_insert(reuse_context->nodes_by_start_offset,
+                            GUINT_TO_POINTER(start_offset), node);
+    }
+  }
+
+recurse_children:
+  if (node->children) {
+    for (guint i = 0; i < node->children->len; i++) {
+      Node *child = g_array_index(node->children, Node*, i);
+      reuse_context_collect_node(child, reuse_context);
+    }
+  }
+}
+
+static void reuse_context_init(ReuseContext *reuse_context, Node *previous_ast,
+                               GArray *tokens, gsize change_start, gsize change_end) {
+  reuse_context->nodes_by_start_offset = NULL;
+  reuse_context->tokens_present = NULL;
+  reuse_context->change_start = change_start;
+  reuse_context->change_end = change_end;
+  if (!previous_ast)
+    return;
+
+  reuse_context->nodes_by_start_offset = g_hash_table_new(g_direct_hash, g_direct_equal);
+  if (tokens) {
+    reuse_context->tokens_present = g_hash_table_new(g_direct_hash, g_direct_equal);
+    for (guint i = 0; i < tokens->len; i++) {
+      LispToken *token = &g_array_index(tokens, LispToken, i);
+      g_hash_table_add(reuse_context->tokens_present, token);
+    }
+  }
+  reuse_context_collect_node(previous_ast, reuse_context);
+}
+
+static void reuse_context_clear(ReuseContext *reuse_context) {
+  if (!reuse_context)
+    return;
+  if (reuse_context->tokens_present)
+    g_hash_table_destroy(reuse_context->tokens_present);
+  if (reuse_context->nodes_by_start_offset)
+    g_hash_table_destroy(reuse_context->nodes_by_start_offset);
+  reuse_context->nodes_by_start_offset = NULL;
+  reuse_context->tokens_present = NULL;
+}
+
+static void detach_reused_subtree(Node *node) {
+  if (!node || !node->parent || !node->parent->children)
+    return;
+
+  GArray *siblings = node->parent->children;
+  for (guint i = 0; i < siblings->len; i++) {
+    Node *sibling = g_array_index(siblings, Node*, i);
+    if (sibling == node) {
+      g_array_index(siblings, Node*, i) = NULL;
+      break;
+    }
+  }
+}
+
+static Node *try_reuse_node(GArray *tokens, guint *position, ReuseContext *reuse_context) {
+  if (!reuse_context || !reuse_context->nodes_by_start_offset || !tokens)
+    return NULL;
+
+  const LispToken *token = &g_array_index(tokens, LispToken, *position);
+  gsize token_offset = marker_get_offset(token->start_marker);
+  Node *candidate = g_hash_table_lookup(reuse_context->nodes_by_start_offset,
+                                        GUINT_TO_POINTER(token_offset));
+  if (!candidate)
+    return NULL;
+
+  if (!candidate->end_token)
+    return NULL;
+
+  if (candidate->start_token != token)
+    return NULL;
+
+  gsize candidate_start = node_get_start_offset(candidate);
+  gsize candidate_end = node_get_end_offset(candidate);
+  gboolean overlaps_change = !(candidate_end <= reuse_context->change_start ||
+                               candidate_start >= reuse_context->change_end);
+  if (overlaps_change)
+    return NULL;
+
+  guint end_index = *position;
+  while (end_index < tokens->len) {
+    const LispToken *current_token = &g_array_index(tokens, LispToken, end_index);
+    end_index++;
+    if (current_token == candidate->end_token)
+      break;
+  }
+
+  if (end_index <= *position || end_index > tokens->len)
+    return NULL;
+
+  detach_reused_subtree(candidate);
+  *position = end_index;
+  return candidate;
+}
+
+Node *lisp_parser_parse(GArray *tokens, Document *document, Node *previous_ast,
+                       gsize change_start, gsize change_end) {
   Node *ast = node_new(LISP_AST_NODE_TYPE_LIST, document);
   ast->children = g_array_new(FALSE, FALSE, sizeof(Node*));
 
   guint n_tokens = tokens ? tokens->len : 0;
   guint position = 0;
+  ReuseContext reuse_context;
+  reuse_context_init(&reuse_context, previous_ast, tokens, change_start, change_end);
   while (position < n_tokens) {
     const LispToken *token = &g_array_index(tokens, LispToken, position);
     if (token->type == LISP_TOKEN_TYPE_WHITESPACE || token->type == LISP_TOKEN_TYPE_COMMENT) {
       position++;
       continue;
     }
-    Node *expr = parse_expression(document, tokens, &position);
+    Node *expr = parse_expression(document, tokens, &position, &reuse_context);
     if (expr) {
       expr->parent = ast;
       g_array_append_val(ast->children, expr);
     }
   }
+
+  reuse_context_clear(&reuse_context);
 
   return ast;
 }
@@ -101,7 +231,8 @@ static Node *parse_symbol(Document *document, GArray *tokens, guint *position) {
   return sym;
 }
 
-static Node *parse_expression(Document *document, GArray *tokens, guint *position) {
+static Node *parse_expression(Document *document, GArray *tokens, guint *position,
+                              ReuseContext *reuse_context) {
   guint n_tokens = tokens ? tokens->len : 0;
   while (*position < n_tokens) {
     const LispToken *token = &g_array_index(tokens, LispToken, *position);
@@ -114,6 +245,10 @@ static Node *parse_expression(Document *document, GArray *tokens, guint *positio
     return NULL;
 
   const LispToken *token = &g_array_index(tokens, LispToken, *position);
+
+  Node *reused = try_reuse_node(tokens, position, reuse_context);
+  if (reused)
+    return reused;
 
   if (token->type == LISP_TOKEN_TYPE_LIST_START) {
     Node *list_node = node_new(LISP_AST_NODE_TYPE_LIST, document);
@@ -132,7 +267,7 @@ static Node *parse_expression(Document *document, GArray *tokens, guint *positio
         (*position)++;
         continue;
       }
-      Node *child_expr = parse_expression(document, tokens, position);
+      Node *child_expr = parse_expression(document, tokens, position, reuse_context);
       if (child_expr) {
         child_expr->parent = list_node;
         g_array_append_val(list_node->children, child_expr);
@@ -163,7 +298,7 @@ static Node *parse_expression(Document *document, GArray *tokens, guint *positio
     macro_node->start_token = token;
     macro_node->children = g_array_new(FALSE, FALSE, sizeof(Node*));
     (*position)++;
-    Node *child_expr = parse_expression(document, tokens, position);
+    Node *child_expr = parse_expression(document, tokens, position, reuse_context);
     if (child_expr) {
       child_expr->parent = macro_node;
       g_array_append_val(macro_node->children, child_expr);

--- a/src/lisp_parser.h
+++ b/src/lisp_parser.h
@@ -8,7 +8,8 @@ G_BEGIN_DECLS
 
 typedef struct _Document Document;
 
-Node       *lisp_parser_parse(GArray *tokens, Document *document);
+Node       *lisp_parser_parse(GArray *tokens, Document *document, Node *previous_ast,
+                              gsize change_start, gsize change_end);
 
 G_END_DECLS
 

--- a/src/token_manager.c
+++ b/src/token_manager.c
@@ -89,12 +89,18 @@ void token_manager_replace_range(TokenManager *manager, guint start_index, guint
 }
 
 void token_manager_update_tokens(TokenManager *manager, Document *document, gsize change_start,
-                                 gsize change_end, gsize text_length) {
+                                 gsize change_end, gsize text_length,
+                                 gsize *token_change_start, gsize *token_change_end) {
   g_return_if_fail(manager != NULL);
   g_return_if_fail(document != NULL);
 
-  if (token_manager_tokens_empty(manager, document, text_length))
+  if (token_manager_tokens_empty(manager, document, text_length)) {
+    if (token_change_start)
+      *token_change_start = 0;
+    if (token_change_end)
+      *token_change_end = text_length;
     return;
+  }
 
   GArray *tokens = token_manager_peek_tokens(manager);
 
@@ -125,6 +131,10 @@ void token_manager_update_tokens(TokenManager *manager, Document *document, gsiz
     relex_start = change_start;
 
   GArray *replacement_tokens = lisp_lexer_lex_range(document, relex_start, relex_end);
+  if (token_change_start)
+    *token_change_start = relex_start;
+  if (token_change_end)
+    *token_change_end = relex_end;
   token_manager_replace_range(manager, start_index, end_index, replacement_tokens);
 }
 

--- a/src/token_manager.h
+++ b/src/token_manager.h
@@ -16,5 +16,6 @@ void          token_manager_replace_range(TokenManager *manager, guint start_ind
                                           guint end_index, GArray *tokens);
 void          token_manager_update_tokens(TokenManager *manager, Document *document,
                                           gsize change_start, gsize change_end,
-                                          gsize text_length);
+                                          gsize text_length, gsize *token_change_start,
+                                          gsize *token_change_end);
 


### PR DESCRIPTION
## Summary
- track the token change range when re-lexing and pass it to the parser
- reuse unchanged AST subtrees during incremental parsing instead of rebuilding everything
- update document reparse flow to supply previous ASTs only when safe

## Testing
- make (in src)
- make run (in tests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efac477548328822d753e3483d513)